### PR TITLE
HOTFIX: One-liner adding CALIPER_HAVE_TAU to the config line

### DIFF
--- a/caliper-config.h.in
+++ b/caliper-config.h.in
@@ -9,6 +9,7 @@
 #cmakedefine CALIPER_HAVE_MITOS
 #cmakedefine CALIPER_HAVE_SAMPLER
 #cmakedefine CALIPER_HAVE_NVVP
+#cmakedefine CALIPER_HAVE_TAU
 #cmakedefine CALIPER_HAVE_VTUNE
 
 // Version information -- numerical and a version string


### PR DESCRIPTION
Hey, the service wasn't mentioned in caliper-config.h.in, which didn't yet cause problems, but might cause them in the future