### PR TITLE
[DNM] Validated Annotations

### DIFF
--- a/src/caliper/CMakeLists.txt
+++ b/src/caliper/CMakeLists.txt
@@ -17,6 +17,7 @@ set(CALIPER_SOURCES
     MetadataTree.cpp
     cali.cpp)
 
+add_subdirectory("RichAnnotations")
 
 add_library(caliper ${CALIPER_SOURCES} $<TARGET_OBJECTS:caliper-services> ${CALIPER_SERVICES_LIBS})
 target_link_libraries(caliper caliper-common)

--- a/src/caliper/RichAnnotations.h
+++ b/src/caliper/RichAnnotations.h
@@ -1,0 +1,2 @@
+#include "Annotation.h"
+#include "RichAnnotations/ValidatedAnnotation.h"

--- a/src/caliper/RichAnnotations/CMakeLists.txt
+++ b/src/caliper/RichAnnotations/CMakeLists.txt
@@ -1,2 +1,3 @@
+add_subdirectory(constraints)
 set(CALIPER_HEADERS ${CALIPER_HEADERS}
         ValidatedAnnotation.h)

--- a/src/caliper/RichAnnotations/CMakeLists.txt
+++ b/src/caliper/RichAnnotations/CMakeLists.txt
@@ -1,0 +1,2 @@
+set(CALIPER_HEADERS ${CALIPER_HEADERS}
+        ValidatedAnnotation.h)

--- a/src/caliper/RichAnnotations/ValidatedAnnotation.h
+++ b/src/caliper/RichAnnotations/ValidatedAnnotation.h
@@ -1,5 +1,6 @@
 #include "../Annotation.h"
 #include <iostream>
+#include <functional>
 #include <type_traits>
 namespace cali{
 
@@ -154,33 +155,27 @@ class ValidatedAnnotation<Validator, ValidatorList...> : public ValidatedAnnotat
 
 };
 
-template<typename T>
-struct MonotonicIncreasing{
+template<typename T, typename Comparator>
+struct Monotonic{
     public:
     void validateBegin(){}
     template<typename Q>
-    std::enable_if<std::is_same<T,Q>::value::type,void> validateBegin(Q& next){
-        if(last>next){
+    typename std::enable_if<std::is_same<T,Q>::value,void>::type validateBegin(Q& next){
+        if(Comparator()(next,last)){
             std::cout<<"ASPOLDE"<<std::endl;
         }
     }
     template<typename Q>
-    std::enable_if<!std::is_same<T,Q>::value::type,void> validateBegin(Q& next){
-        if(last>next){
+    typename std::enable_if<!std::is_same<T,Q>::value,void>::type validateBegin(Q& next){
+    }
+    template<typename Q>
+    typename std::enable_if<std::is_same<T,Q>::value,void>::type validateSet(Q& next){
+        if(Comparator()(next,last)){
             std::cout<<"ASPOLDE"<<std::endl;
         }
     }
     template<typename Q>
-    std::enable_if<std::is_same<T,Q>::value::type,void> validateSet(Q& next){
-        if(last>next){
-            std::cout<<"ASPOLDE"<<std::endl;
-        }
-    }
-    template<typename Q>
-    std::enable_if<!std::is_same<T,Q>::value::type,void> validateSet(Q& next){
-        if(last>next){
-            std::cout<<"ASPOLDE"<<std::endl;
-        }
+    typename std::enable_if<!std::is_same<T,Q>::value,void>::type validateSet(Q& next){
     }
 
     void validateEnd(){
@@ -188,4 +183,8 @@ struct MonotonicIncreasing{
     private:
     T last;
 };
+template<typename T>
+using MonotonicDecreasing = Monotonic<T,std::less_equal<T>>;
+template<typename T>
+using MonotonicIncreasing = Monotonic<T,std::greater_equal<T>>;
 } //end namespace cali

--- a/src/caliper/RichAnnotations/ValidatedAnnotation.h
+++ b/src/caliper/RichAnnotations/ValidatedAnnotation.h
@@ -80,68 +80,68 @@ private:
 template<class Validator, class... ValidatorList>
 class ValidatedAnnotation<Validator, ValidatorList...> : public ValidatedAnnotation<ValidatorList...>{
     public:
-    #define DEBUG_RETURN_TYPE ValidatedAnnotation<Validator, ValidatorList...>
     using innerValidator = ValidatedAnnotation<ValidatorList...>;
+    using wholeValidator = ValidatedAnnotation<Validator,ValidatorList...>;
 
     ValidatedAnnotation(const char* name, int opt=0) : ValidatedAnnotation<ValidatorList...>(name,opt){}
     ValidatedAnnotation(const DEBUG_RETURN_TYPE & other) : ValidatedAnnotation<ValidatorList...>(other){}
     //begin
-    DEBUG_RETURN_TYPE &operator = (const DEBUG_RETURN_TYPE & other){
+    wholeValidator &operator = (const DEBUG_RETURN_TYPE & other){
         my_val = other.getValidator();
         return *this;
     }
-    DEBUG_RETURN_TYPE& begin(){
+    wholeValidator& begin(){
         my_val.validateBegin();
         innerValidator::begin();
         return *this;
     }
-    DEBUG_RETURN_TYPE& begin(int data){
+    wholeValidator& begin(int data){
         my_val.validateBegin(data);
         innerValidator::begin(data);
         return *this;
     }
-    DEBUG_RETURN_TYPE& begin(double data){
+    wholeValidator& begin(double data){
         my_val.validateBegin(data);
         innerValidator::begin(data);
         return *this;
     }
-    DEBUG_RETURN_TYPE& begin(const char* data){
+    wholeValidator& begin(const char* data){
         my_val.validateBegin(data);
         innerValidator::begin(data);
         return *this;
     }
-    DEBUG_RETURN_TYPE& begin(cali_attr_type type, void* data, uint64_t size){
+    wholeValidator& begin(cali_attr_type type, void* data, uint64_t size){
         my_val.validateBegin(type,data,size);
         innerValidator::begin(type,data,size);
         return *this;
     }
-    DEBUG_RETURN_TYPE& begin(const Variant& data){
+    wholeValidator& begin(const Variant& data){
         my_val.validateBegin(data);
         innerValidator::begin(data);
         return *this;
     }
     //set
-    DEBUG_RETURN_TYPE& set(int data){
+    wholeValidator& set(int data){
         my_val.validateSet(data);
         innerValidator::set(data);
         return *this;
     }
-    DEBUG_RETURN_TYPE& set(double data){
+    wholeValidator& set(double data){
         my_val.validateSet(data);
         innerValidator::set(data);
         return *this;
     }
-    DEBUG_RETURN_TYPE& set(const char* data){
+    wholeValidator& set(const char* data){
         my_val.validateSet(data);
         innerValidator::set(data);
         return *this;
     }
-    DEBUG_RETURN_TYPE& set(cali_attr_type type, void* data, uint64_t size){
+    wholeValidator& set(cali_attr_type type, void* data, uint64_t size){
         my_val.validateSet(type,data,size);
         innerValidator::set(type,data,size);
         return *this;
     }
-    DEBUG_RETURN_TYPE& set(const Variant& data){
+    wholeValidator& set(const Variant& data){
         my_val.validateSet(data);
         innerValidator::set(data);
         return *this;

--- a/src/caliper/RichAnnotations/ValidatedAnnotation.h
+++ b/src/caliper/RichAnnotations/ValidatedAnnotation.h
@@ -1,5 +1,6 @@
 #include "../Annotation.h"
 #include <iostream>
+#include <type_traits>
 namespace cali{
 
 template<class... ValidatorList>
@@ -156,26 +157,32 @@ class ValidatedAnnotation<Validator, ValidatorList...> : public ValidatedAnnotat
 template<typename T>
 struct MonotonicIncreasing{
     public:
-    template<typename Q,std::enable_if<std::is_same<Q,T>::type>::int  >
-    void validateBegin(Q next){
+    void validateBegin(){}
+    template<typename Q>
+    std::enable_if<std::is_same<T,Q>::value::type,void> validateBegin(Q& next){
         if(last>next){
             std::cout<<"ASPOLDE"<<std::endl;
         }
-
     }
-    template<typename Q,std::enable_if<!std::is_same<Q,T>::type>::int  >
-    void validateBegin(Q next){
-    }
-    template<typename Q,std::enable_if<std::is_same<Q,T>::type>::int  >
-    void validateSet(Q next){
+    template<typename Q>
+    std::enable_if<!std::is_same<T,Q>::value::type,void> validateBegin(Q& next){
         if(last>next){
             std::cout<<"ASPOLDE"<<std::endl;
         }
+    }
+    template<typename Q>
+    std::enable_if<std::is_same<T,Q>::value::type,void> validateSet(Q& next){
+        if(last>next){
+            std::cout<<"ASPOLDE"<<std::endl;
+        }
+    }
+    template<typename Q>
+    std::enable_if<!std::is_same<T,Q>::value::type,void> validateSet(Q& next){
+        if(last>next){
+            std::cout<<"ASPOLDE"<<std::endl;
+        }
+    }
 
-    }
-    template<typename Q,std::enable_if<!std::is_same<Q,T>::type>::int  >
-    void validateSet(Q next){
-    }
     void validateEnd(){
     }
     private:

--- a/src/caliper/RichAnnotations/ValidatedAnnotation.h
+++ b/src/caliper/RichAnnotations/ValidatedAnnotation.h
@@ -84,9 +84,9 @@ class ValidatedAnnotation<Validator, ValidatorList...> : public ValidatedAnnotat
     using wholeValidator = ValidatedAnnotation<Validator,ValidatorList...>;
 
     ValidatedAnnotation(const char* name, int opt=0) : ValidatedAnnotation<ValidatorList...>(name,opt){}
-    ValidatedAnnotation(const DEBUG_RETURN_TYPE & other) : ValidatedAnnotation<ValidatorList...>(other){}
+    ValidatedAnnotation(const wholeValidator & other) : ValidatedAnnotation<ValidatorList...>(other){}
     //begin
-    wholeValidator &operator = (const DEBUG_RETURN_TYPE & other){
+    wholeValidator &operator = (const wholeValidator & other){
         my_val = other.getValidator();
         return *this;
     }

--- a/src/caliper/RichAnnotations/ValidatedAnnotation.h
+++ b/src/caliper/RichAnnotations/ValidatedAnnotation.h
@@ -1,0 +1,146 @@
+#include "../Annotation.h"
+namespace cali{
+
+template<class... ValidatorList>
+class ValidatedAnnotation{
+public:
+    //using thisType = decltype(*this);
+    using thisType = const ValidatedAnnotation<>&;
+    //ValidatedAnnotation() : inner_annot("ERROR"){}
+    ValidatedAnnotation(const char* name, int opt=0) : inner_annot(name,opt){
+        inner_annot = Annotation(name,opt);
+    }
+    ValidatedAnnotation(const thisType& other) : inner_annot(other.getAnnot()) {
+        inner_annot = other.getAnnot();
+    }
+    Annotation getAnnot() const{
+        return inner_annot;
+    }
+    thisType& operator = (thisType & other){
+        inner_annot = other.getAnnot();
+        return *this;
+    }
+    thisType& begin(){
+        inner_annot.begin();
+        return *this;
+    }
+    thisType& begin(int data){
+        inner_annot.begin(data);
+        return *this;
+    }
+    thisType& begin(double data){
+        inner_annot.begin(data);
+        return *this;
+    }
+    thisType& begin(const char* data){
+        inner_annot.begin(data);
+        return *this;
+    }
+    thisType& begin(cali_attr_type type, void* data, uint64_t size){
+        inner_annot.begin(type,data,size);
+        return *this;
+    }
+    thisType& begin(const Variant& data){
+        inner_annot.begin(data);
+        return *this;
+    }
+    //set
+    thisType& set(int data){
+        inner_annot.set(data);
+        return *this;
+    }
+    thisType& set(double data){
+        inner_annot.set(data);
+        return *this;
+    }
+    thisType& set(const char* data){
+        inner_annot.set(data);
+        return *this;
+    }
+    thisType& set(cali_attr_type type, void* data, uint64_t size){
+        inner_annot.set(type,data,size);
+        return *this;
+    }
+    thisType& set(const Variant& data){
+        inner_annot.set(data);
+        return *this;
+    }
+    void end(){
+        inner_annot.end();
+    }
+private:
+    Annotation inner_annot;
+};
+
+template<class Validator, class... ValidatorList>
+class ValidatedAnnotation<Validator, ValidatorList...> : public ValidatedAnnotation<ValidatorList...>{
+    public:
+    #define DEBUG_RETURN_TYPE ValidatedAnnotation<Validator, ValidatorList...>
+    using innerValidator = ValidatedAnnotation<ValidatorList...>;
+
+    ValidatedAnnotation(const char* name, int opt=0) : ValidatedAnnotation<ValidatorList...>(name,opt){
+       // ValidatedAnnotation<ValidatorList...>(name,opt);
+    }
+    ValidatedAnnotation(const DEBUG_RETURN_TYPE & other) : ValidatedAnnotation<ValidatorList...>(other){}
+    //begin
+    DEBUG_RETURN_TYPE &operator = (const DEBUG_RETURN_TYPE & other){
+        my_val = other.getValidator();
+        return *this;
+    }
+    DEBUG_RETURN_TYPE& begin(){
+        innerValidator::begin();
+        return *this;
+    }
+    DEBUG_RETURN_TYPE& begin(int data){
+        innerValidator::begin(data);
+        return *this;
+    }
+    DEBUG_RETURN_TYPE& begin(double data){
+        innerValidator::begin(data);
+        return *this;
+    }
+    DEBUG_RETURN_TYPE& begin(const char* data){
+        innerValidator::begin(data);
+        return *this;
+    }
+    DEBUG_RETURN_TYPE& begin(cali_attr_type type, void* data, uint64_t size){
+        innerValidator::begin(type,data,size);
+        return *this;
+    }
+    DEBUG_RETURN_TYPE& begin(const Variant& data){
+        innerValidator::begin(data);
+        return *this;
+    }
+    //set
+    DEBUG_RETURN_TYPE& set(int data){
+        innerValidator::set(data);
+        return *this;
+    }
+    DEBUG_RETURN_TYPE& set(double data){
+        innerValidator::set(data);
+        return *this;
+    }
+    DEBUG_RETURN_TYPE& set(const char* data){
+        innerValidator::set(data);
+        return *this;
+    }
+    DEBUG_RETURN_TYPE& set(cali_attr_type type, void* data, uint64_t size){
+        innerValidator::set(type,data,size);
+        return *this;
+    }
+    DEBUG_RETURN_TYPE& set(const Variant& data){
+        innerValidator::set(data);
+        return *this;
+    }
+    void end(){
+        innerValidator::end();
+    }
+    Validator my_val;
+    Validator getValidator(){
+        return my_val;
+    }
+
+};
+
+struct dummy{};
+} //end namespace cali

--- a/src/caliper/RichAnnotations/ValidatedAnnotation.h
+++ b/src/caliper/RichAnnotations/ValidatedAnnotation.h
@@ -2,6 +2,8 @@
 #include <iostream>
 #include <functional>
 #include <type_traits>
+#include "constraints/monotonic.h"
+#include "constraints/bounded.h"
 namespace cali{
 
 template<class... ValidatorList>
@@ -155,36 +157,4 @@ class ValidatedAnnotation<Validator, ValidatorList...> : public ValidatedAnnotat
 
 };
 
-template<typename T, typename Comparator>
-struct Monotonic{
-    public:
-    void validateBegin(){}
-    template<typename Q>
-    typename std::enable_if<std::is_same<T,Q>::value,void>::type validateBegin(Q& next){
-        if(Comparator()(next,last)){
-            std::cout<<"ASPOLDE"<<std::endl;
-        }
-    }
-    template<typename Q>
-    typename std::enable_if<!std::is_same<T,Q>::value,void>::type validateBegin(Q& next){
-    }
-    template<typename Q>
-    typename std::enable_if<std::is_same<T,Q>::value,void>::type validateSet(Q& next){
-        if(Comparator()(next,last)){
-            std::cout<<"ASPOLDE"<<std::endl;
-        }
-    }
-    template<typename Q>
-    typename std::enable_if<!std::is_same<T,Q>::value,void>::type validateSet(Q& next){
-    }
-
-    void validateEnd(){
-    }
-    private:
-    T last;
-};
-template<typename T>
-using MonotonicDecreasing = Monotonic<T,std::less_equal<T>>;
-template<typename T>
-using MonotonicIncreasing = Monotonic<T,std::greater_equal<T>>;
 } //end namespace cali

--- a/src/caliper/RichAnnotations/ValidatedAnnotation.h
+++ b/src/caliper/RichAnnotations/ValidatedAnnotation.h
@@ -1,4 +1,5 @@
 #include "../Annotation.h"
+#include <iostream>
 namespace cali{
 
 template<class... ValidatorList>
@@ -78,9 +79,7 @@ class ValidatedAnnotation<Validator, ValidatorList...> : public ValidatedAnnotat
     #define DEBUG_RETURN_TYPE ValidatedAnnotation<Validator, ValidatorList...>
     using innerValidator = ValidatedAnnotation<ValidatorList...>;
 
-    ValidatedAnnotation(const char* name, int opt=0) : ValidatedAnnotation<ValidatorList...>(name,opt){
-       // ValidatedAnnotation<ValidatorList...>(name,opt);
-    }
+    ValidatedAnnotation(const char* name, int opt=0) : ValidatedAnnotation<ValidatorList...>(name,opt){}
     ValidatedAnnotation(const DEBUG_RETURN_TYPE & other) : ValidatedAnnotation<ValidatorList...>(other){}
     //begin
     DEBUG_RETURN_TYPE &operator = (const DEBUG_RETURN_TYPE & other){
@@ -88,51 +87,63 @@ class ValidatedAnnotation<Validator, ValidatorList...> : public ValidatedAnnotat
         return *this;
     }
     DEBUG_RETURN_TYPE& begin(){
+        my_val.validateBegin();
         innerValidator::begin();
         return *this;
     }
     DEBUG_RETURN_TYPE& begin(int data){
+        my_val.validateBegin(data);
         innerValidator::begin(data);
         return *this;
     }
     DEBUG_RETURN_TYPE& begin(double data){
+        my_val.validateBegin(data);
         innerValidator::begin(data);
         return *this;
     }
     DEBUG_RETURN_TYPE& begin(const char* data){
+        my_val.validateBegin(data);
         innerValidator::begin(data);
         return *this;
     }
     DEBUG_RETURN_TYPE& begin(cali_attr_type type, void* data, uint64_t size){
+        my_val.validateBegin(type,data,size);
         innerValidator::begin(type,data,size);
         return *this;
     }
     DEBUG_RETURN_TYPE& begin(const Variant& data){
+        my_val.validateBegin(data);
         innerValidator::begin(data);
         return *this;
     }
     //set
     DEBUG_RETURN_TYPE& set(int data){
+        my_val.validateSet(data);
         innerValidator::set(data);
         return *this;
     }
     DEBUG_RETURN_TYPE& set(double data){
+        my_val.validateSet(data);
         innerValidator::set(data);
         return *this;
     }
     DEBUG_RETURN_TYPE& set(const char* data){
+        my_val.validateSet(data);
         innerValidator::set(data);
         return *this;
     }
     DEBUG_RETURN_TYPE& set(cali_attr_type type, void* data, uint64_t size){
+        my_val.validateSet(type,data,size);
         innerValidator::set(type,data,size);
         return *this;
     }
     DEBUG_RETURN_TYPE& set(const Variant& data){
+        my_val.validateSet(data);
         innerValidator::set(data);
         return *this;
     }
     void end(){
+        my_val.validateEnd();
         innerValidator::end();
     }
     Validator my_val;
@@ -142,5 +153,32 @@ class ValidatedAnnotation<Validator, ValidatorList...> : public ValidatedAnnotat
 
 };
 
-struct dummy{};
+template<typename T>
+struct MonotonicIncreasing{
+    public:
+    template<typename Q,std::enable_if<std::is_same<Q,T>::type>::int  >
+    void validateBegin(Q next){
+        if(last>next){
+            std::cout<<"ASPOLDE"<<std::endl;
+        }
+
+    }
+    template<typename Q,std::enable_if<!std::is_same<Q,T>::type>::int  >
+    void validateBegin(Q next){
+    }
+    template<typename Q,std::enable_if<std::is_same<Q,T>::type>::int  >
+    void validateSet(Q next){
+        if(last>next){
+            std::cout<<"ASPOLDE"<<std::endl;
+        }
+
+    }
+    template<typename Q,std::enable_if<!std::is_same<Q,T>::type>::int  >
+    void validateSet(Q next){
+    }
+    void validateEnd(){
+    }
+    private:
+    T last;
+};
 } //end namespace cali

--- a/src/caliper/RichAnnotations/constraints/CMakeLists.txt
+++ b/src/caliper/RichAnnotations/constraints/CMakeLists.txt
@@ -1,0 +1,1 @@
+set(CALIPER_HEADERS ${CALIPER_HEADERS} monotonic.h bounded.h)

--- a/src/caliper/RichAnnotations/constraints/bounded.h
+++ b/src/caliper/RichAnnotations/constraints/bounded.h
@@ -31,6 +31,8 @@ class Bounded
 
 template<typename T, T bound>
 using BoundedAbove = Bounded<T,std::less_equal<T>,bound>;
+template<typename T, T bound>
+using BoundedBelow = Bounded<T,std::greater_equal<T>,bound>;
 
 } //end namespace cali
 #endif

--- a/src/caliper/RichAnnotations/constraints/bounded.h
+++ b/src/caliper/RichAnnotations/constraints/bounded.h
@@ -12,6 +12,8 @@ class Bounded
             std::cout<<"ASPOLDE 2"<<std::endl;
         }
     }
+    void validateBegin(cali_attr_type type, void* data, uint64_t size){
+    }
     template<typename Q>
     typename std::enable_if<!std::is_same<T,Q>::value,void>::type validateBegin(Q& next){
     }
@@ -25,6 +27,8 @@ class Bounded
     typename std::enable_if<!std::is_same<T,Q>::value,void>::type validateSet(Q& next){
     }
 
+    void validateSet(cali_attr_type type, void* data, uint64_t size){
+    }
     void validateEnd(){
     }
 };

--- a/src/caliper/RichAnnotations/constraints/bounded.h
+++ b/src/caliper/RichAnnotations/constraints/bounded.h
@@ -1,0 +1,36 @@
+#ifndef CALI_BOUNDED_H
+#define CALI_BOUNDED_H
+namespace cali {
+template<typename T, typename Comparator, T bound>
+class Bounded
+{
+    public:
+    void validateBegin(){}
+    template<typename Q>
+    typename std::enable_if<std::is_same<T,Q>::value,void>::type validateBegin(Q& next){
+        if(Comparator()(bound,next)){
+            std::cout<<"ASPOLDE 2"<<std::endl;
+        }
+    }
+    template<typename Q>
+    typename std::enable_if<!std::is_same<T,Q>::value,void>::type validateBegin(Q& next){
+    }
+    template<typename Q>
+    typename std::enable_if<std::is_same<T,Q>::value,void>::type validateSet(Q& next){
+        if(Comparator()(bound,next)){
+            std::cout<<"ASPOLDE 2"<<std::endl;
+        }
+    }
+    template<typename Q>
+    typename std::enable_if<!std::is_same<T,Q>::value,void>::type validateSet(Q& next){
+    }
+
+    void validateEnd(){
+    }
+};
+
+template<typename T, T bound>
+using BoundedAbove = Bounded<T,std::less_equal<T>,bound>;
+
+} //end namespace cali
+#endif

--- a/src/caliper/RichAnnotations/constraints/monotonic.h
+++ b/src/caliper/RichAnnotations/constraints/monotonic.h
@@ -1,5 +1,6 @@
 #ifndef CALI_MONOTONIC_H
 #define CALI_MONOTONIC_H
+#include <functional>
 namespace cali {
 template<typename T, typename Comparator>
 struct Monotonic{
@@ -37,8 +38,8 @@ struct Monotonic{
 };
 
 template<typename T>
-using MonotonicDecreasing = Monotonic<T,std::less_equal<T>>;
+using MonotonicDecreasing = Monotonic<T,std::greater_equal<T>>;
 template<typename T>
-using MonotonicIncreasing = Monotonic<T,std::greater_equal<T>>;
+using MonotonicIncreasing = Monotonic<T,std::less_equal<T>>;
 } //end namespace cali
 #endif

--- a/src/caliper/RichAnnotations/constraints/monotonic.h
+++ b/src/caliper/RichAnnotations/constraints/monotonic.h
@@ -12,6 +12,7 @@ struct Monotonic{
         if(Comparator()(next,last)){
             std::cout<<"ASPOLDE"<<std::endl;
         }
+        last = next;
     }
     template<typename Q>
     typename std::enable_if<!std::is_same<T,Q>::value,void>::type validateBegin(Q& next){
@@ -21,6 +22,7 @@ struct Monotonic{
         if(Comparator()(next,last)){
             std::cout<<"ASPOLDE"<<std::endl;
         }
+        last = next;
     }
     void validateSet(cali_attr_type type, void* data, uint64_t size){
     }

--- a/src/caliper/RichAnnotations/constraints/monotonic.h
+++ b/src/caliper/RichAnnotations/constraints/monotonic.h
@@ -1,0 +1,38 @@
+#ifndef CALI_MONOTONIC_H
+#define CALI_MONOTONIC_H
+namespace cali {
+template<typename T, typename Comparator>
+struct Monotonic{
+    public:
+    void validateBegin(){}
+    template<typename Q>
+    typename std::enable_if<std::is_same<T,Q>::value,void>::type validateBegin(Q& next){
+        if(Comparator()(next,last)){
+            std::cout<<"ASPOLDE"<<std::endl;
+        }
+    }
+    template<typename Q>
+    typename std::enable_if<!std::is_same<T,Q>::value,void>::type validateBegin(Q& next){
+    }
+    template<typename Q>
+    typename std::enable_if<std::is_same<T,Q>::value,void>::type validateSet(Q& next){
+        if(Comparator()(next,last)){
+            std::cout<<"ASPOLDE"<<std::endl;
+        }
+    }
+    template<typename Q>
+    typename std::enable_if<!std::is_same<T,Q>::value,void>::type validateSet(Q& next){
+    }
+
+    void validateEnd(){
+    }
+    private:
+    T last;
+};
+
+template<typename T>
+using MonotonicDecreasing = Monotonic<T,std::less_equal<T>>;
+template<typename T>
+using MonotonicIncreasing = Monotonic<T,std::greater_equal<T>>;
+} //end namespace cali
+#endif

--- a/src/caliper/RichAnnotations/constraints/monotonic.h
+++ b/src/caliper/RichAnnotations/constraints/monotonic.h
@@ -5,6 +5,8 @@ template<typename T, typename Comparator>
 struct Monotonic{
     public:
     void validateBegin(){}
+    void validateBegin(cali_attr_type type, void* data, uint64_t size){
+    }
     template<typename Q>
     typename std::enable_if<std::is_same<T,Q>::value,void>::type validateBegin(Q& next){
         if(Comparator()(next,last)){
@@ -19,6 +21,8 @@ struct Monotonic{
         if(Comparator()(next,last)){
             std::cout<<"ASPOLDE"<<std::endl;
         }
+    }
+    void validateSet(cali_attr_type type, void* data, uint64_t size){
     }
     template<typename Q>
     typename std::enable_if<!std::is_same<T,Q>::value,void>::type validateSet(Q& next){

--- a/src/services/git/GitInfo.cpp
+++ b/src/services/git/GitInfo.cpp
@@ -115,10 +115,21 @@ void read_gitdir(Caliper* c){
     string date = makeCaliSafe(shell_exec("git --git-dir="+gitDirectory+"/.git log -1 --pretty=%ad"));
     string message = makeCaliSafe(shell_exec("git --git-dir="+gitDirectory+"/.git log -1 --pretty=%s"));
     c->begin(annot_git_dir,cali::Variant(CALI_TYPE_STRING,gitDirectory.c_str(),gitDirectory.length()));
-    c->set(annot_git_hash,cali::Variant(CALI_TYPE_STRING,hash.c_str(),hash.length()));
-    c->set(annot_git_message,cali::Variant(CALI_TYPE_STRING,message.c_str(),message.length()));
-    c->set(annot_git_name,cali::Variant(CALI_TYPE_STRING,author_name.c_str(),author_name.length()));
-    c->set(annot_git_date,cali::Variant(CALI_TYPE_STRING,date.c_str(),date.length()));
+    c->begin(annot_git_hash,cali::Variant(CALI_TYPE_STRING,hash.c_str(),hash.length()));
+    c->begin(annot_git_message,cali::Variant(CALI_TYPE_STRING,message.c_str(),message.length()));
+    c->begin(annot_git_name,cali::Variant(CALI_TYPE_STRING,author_name.c_str(),author_name.length()));
+    c->begin(annot_git_date,cali::Variant(CALI_TYPE_STRING,date.c_str(),date.length()));
+    c->end(annot_git_date);
+    c->end(annot_git_name);
+    c->end(annot_git_message);
+    c->end(annot_git_hash);
+    c->end(annot_git_dir);
+    //c->begin(annot_git_dir,cali::Variant(CALI_TYPE_STRING,gitDirectory.c_str(),gitDirectory.length()));
+    //c->set(annot_git_hash,cali::Variant(CALI_TYPE_STRING,hash.c_str(),hash.length()));
+    //c->set(annot_git_message,cali::Variant(CALI_TYPE_STRING,message.c_str(),message.length()));
+    //c->set(annot_git_name,cali::Variant(CALI_TYPE_STRING,author_name.c_str(),author_name.length()));
+    //c->set(annot_git_date,cali::Variant(CALI_TYPE_STRING,date.c_str(),date.length()));
+    //c->end(annot_git_dir);
 }
 
 void git_service_register(Caliper* c)

--- a/src/services/recorder/Recorder.cpp
+++ b/src/services/recorder/Recorder.cpp
@@ -168,8 +168,10 @@ class Recorder
     }
 
     static void write_record_cb(const RecordDescriptor& rec, const int* count, const Variant** data) {
-        if (!s_instance)
+        if (!s_instance){
+            std::cout<<"CANNOT WRITE: NOT YET INITIALIZED"<<std::endl;
             return;
+        }
 
         std::lock_guard<std::mutex> g(s_instance->m_lock);
         

--- a/src/services/textlog/TextLog.cpp
+++ b/src/services/textlog/TextLog.cpp
@@ -140,6 +140,10 @@ class TextLogService
             std::lock_guard<std::mutex> lock(trigger_attr_mutex);
             trigger_attr_map.insert(std::make_pair(attr.id(), attr));
         }
+        if(trigger_attr_names.size()==0){
+            std::lock_guard<std::mutex> lock(trigger_attr_mutex);
+            trigger_attr_map.insert(std::make_pair(attr.id(), attr));
+        }
     }
 
     void process_snapshot_cb(Caliper* c, const EntryList* trigger_info, const EntryList* snapshot) {

--- a/test/cali-basic.cpp
+++ b/test/cali-basic.cpp
@@ -33,12 +33,14 @@
 // A minimal Caliper instrumentation demo 
 
 #include <Annotation.h>
-
+#include <RichAnnotations.h>
 int main(int argc, char* argv[])
 {
+    using cali::dummy;
     // Mark begin of "initialization" phase
-    cali::Annotation
-        init_ann = cali::Annotation("initialization").begin();
+    cali::ValidatedAnnotation<cali::MonotonicIncreasing<int>>
+        init_ann = cali::ValidatedAnnotation<dummy>("initialization").begin();
+    
     // perform initialization tasks
     int count = 4;
     // Mark end of "initialization" phase

--- a/test/cali-basic.cpp
+++ b/test/cali-basic.cpp
@@ -36,10 +36,10 @@
 #include <RichAnnotations.h>
 int main(int argc, char* argv[])
 {
-    using cali::dummy;
+    using AnnotationType = cali::ValidatedAnnotation<cali::MonotonicIncreasing<int>>;
     // Mark begin of "initialization" phase
     cali::ValidatedAnnotation<cali::MonotonicIncreasing<int>>
-        init_ann = cali::ValidatedAnnotation<dummy>("initialization").begin();
+        init_ann = cali::ValidatedAnnotation<cali::MonotonicIncreasing<int>>("initialization").begin();
     
     // perform initialization tasks
     int count = 4;
@@ -55,7 +55,7 @@ int main(int argc, char* argv[])
         double t = 0.0, delta_t = 1e-6;
 
         // Create "iteration" attribute to export the iteration count
-        cali::Annotation iteration_ann("iteration");
+        AnnotationType iteration_ann("iteration");
         
         for (int i = 0; i < count; ++i) {
             // Export current iteration count under "iteration"

--- a/test/cali-basic.cpp
+++ b/test/cali-basic.cpp
@@ -38,8 +38,8 @@ int main(int argc, char* argv[])
 {
     using AnnotationType = cali::ValidatedAnnotation<cali::MonotonicIncreasing<int>>;
     // Mark begin of "initialization" phase
-    cali::ValidatedAnnotation<cali::MonotonicIncreasing<int>>
-        init_ann = cali::ValidatedAnnotation<cali::MonotonicIncreasing<int>>("initialization").begin();
+    cali::Annotation
+        init_ann = cali::Annotation("initialization").begin();
     
     // perform initialization tasks
     int count = 4;

--- a/test/cali-basic.cpp
+++ b/test/cali-basic.cpp
@@ -36,7 +36,7 @@
 #include <RichAnnotations.h>
 int main(int argc, char* argv[])
 {
-    using AnnotationType = cali::ValidatedAnnotation<cali::MonotonicIncreasing<int>>;
+    using AnnotationType = cali::ValidatedAnnotation<cali::MonotonicIncreasing<int>, cali::BoundedAbove<int,2>>;
     // Mark begin of "initialization" phase
     cali::Annotation
         init_ann = cali::Annotation("initialization").begin();


### PR DESCRIPTION
So these are the constrained validations I've been discussing with the group. I can't really push on them too hard, wanted to put them up so people could look at them. Anyway, these are validations which allow you to make assertions about your annotations, currently that they are bounded above or below some value, or that they're monotonically increasing or decreasing. They need a lot of work
- [ ] In the two implemented constraints (bounded and monotonic), we need logic to handle Variants casting to the template types of those constraints (that is, validateSet(Variant) needs to behave properly). Simple, just needs to get hacked on.
- [ ] Deciding on behaviors for when an item of the wrong type is passed to a set (that is, somebody says they have an int bounded below 8 and passes us 7.0, or 9.0)
- [ ] Providing response mechanisms to these errors. In the current implementation, an error triggers the program to write "ASPLODE." If these could trigger a callback which services could respond to, that might be nifty. Fair warning, I will be writing the service that sends you an email when your program gets in a bad state, and "crediting" @daboehme as the author (kidding (at least I think I'm kidding))
- [ ] Documentation. We need to document both that these are available, and how to implement your own

Anyway, a usage example is in test/cali-basic.cpp, these could be really slick. Food for thought.
