### PR TITLE
Added flag to cali-query to emit JSON compatible output

### DIFF
--- a/src/reader/CMakeLists.txt
+++ b/src/reader/CMakeLists.txt
@@ -8,7 +8,8 @@ set(CALIPER_READER_HEADERS
     RecordProcessor.h
     RecordSelector.h
     SimpleReader.h
-    Table.h)
+    Table.h
+    Json.h)
 
 set(CALIPER_READER_SOURCES
     Aggregator.cpp
@@ -17,7 +18,8 @@ set(CALIPER_READER_SOURCES
     CaliperMetadataDB.cpp
     RecordSelector.cpp
     SimpleReader.cpp
-    Table.cpp)
+    Table.cpp
+    Json.cpp)
 
 add_library(caliper-reader ${CALIPER_READER_SOURCES})
 

--- a/src/reader/Json.cpp
+++ b/src/reader/Json.cpp
@@ -78,7 +78,7 @@ struct Json::JsonImpl
 
         for (const std::string& s : fields)
             if (s.size() > 0)
-                m_cols.emplace_back(s, s.size(), Attribute::invalid);
+                m_cols.emplace_back(s, Attribute::invalid);
     }
 
     void update_column_attribute(CaliperMetadataDB& db, cali_id_t attr_id) {

--- a/src/reader/Json.cpp
+++ b/src/reader/Json.cpp
@@ -102,7 +102,7 @@ struct Json::JsonImpl
             name.compare(0, 6, "event.") == 0)
             return;
                 
-        m_cols.emplace_back(name, name.size(), attr);
+        m_cols.emplace_back(name, attr);
     }
     
     void update_columns(CaliperMetadataDB& db, const EntryList& list) {

--- a/src/reader/Json.cpp
+++ b/src/reader/Json.cpp
@@ -52,12 +52,11 @@ struct Json::JsonImpl
 {
     struct Column {
         std::string name;
-        std::size_t max_width;
 
         Attribute   attr;
 
-        Column(const std::string& n, std::size_t w, const Attribute& a)
-            : name(n), max_width(w), attr(a)
+        Column(const std::string& n, const Attribute& a)
+            : name(n), attr(a)
             { }
     };
 
@@ -148,7 +147,6 @@ struct Json::JsonImpl
             if (!val.empty()) {
                 active = true;
                 row[c] = val;
-                m_cols[c].max_width = std::max(val.size(), m_cols[c].max_width);
             }
         }
 

--- a/src/reader/Json.cpp
+++ b/src/reader/Json.cpp
@@ -1,0 +1,203 @@
+// Copyright (c) 2016, Lawrence Livermore National Security, LLC.  
+// Produced at the Lawrence Livermore National Laboratory.
+//
+// This file is part of Caliper.
+// Written by David Boehme, boehme3@llnl.gov.
+// LLNL-CODE-678900
+// All rights reserved.
+//
+// For details, see https://github.com/scalability-llnl/Caliper.
+// Please also see the LICENSE file for our additional BSD notice.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+//  * Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the disclaimer below.
+//  * Redistributions in binary form must reproduce the above copyright notice, this list of
+//    conditions and the disclaimer (as noted below) in the documentation and/or other materials
+//    provided with the distribution.
+//  * Neither the name of the LLNS/LLNL nor the names of its contributors may be used to endorse
+//    or promote products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+// OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// LAWRENCE LIVERMORE NATIONAL SECURITY, LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/// @file Json.cpp
+/// Print web-readable table
+
+#include "Json.h"
+
+#include "CaliperMetadataDB.h"
+
+#include "Attribute.h"
+#include "ContextRecord.h"
+#include "Node.h"
+
+#include "util/split.hpp"
+
+#include <algorithm>
+#include <iterator>
+
+using namespace cali;
+
+struct Json::JsonImpl
+{
+    struct Column {
+        std::string name;
+        std::size_t max_width;
+
+        Attribute   attr;
+
+        Column(const std::string& n, std::size_t w, const Attribute& a)
+            : name(n), max_width(w), attr(a)
+            { }
+    };
+
+    std::vector<Column>                     m_cols;
+    std::vector< std::vector<std::string> > m_rows;
+
+    bool                                    m_auto_column;
+    
+    void parse(const std::string& field_string) {
+        if (field_string.empty()) {
+            m_auto_column = true;
+            return;
+        } else
+            m_auto_column = false;
+        
+        std::vector<std::string> fields;
+
+        util::split(field_string, ':', std::back_inserter(fields));
+
+        for (const std::string& s : fields)
+            if (s.size() > 0)
+                m_cols.emplace_back(s, s.size(), Attribute::invalid);
+    }
+
+    void update_column_attribute(CaliperMetadataDB& db, cali_id_t attr_id) {
+        auto it = std::find_if(m_cols.begin(), m_cols.end(),
+                               [attr_id](const Column& c) {
+                                   return c.attr.id() == attr_id;
+                               });
+
+        if (it != m_cols.end())
+            return;
+        
+        Attribute attr   = db.attribute(attr_id);
+
+        if (attr == Attribute::invalid)
+            return;
+        
+        std::string name = attr.name();
+
+        // Skip internal "cali." and ".event" attributes
+        if (name.compare(0, 5, "cali." ) == 0 ||
+            name.compare(0, 6, "event.") == 0)
+            return;
+                
+        m_cols.emplace_back(name, name.size(), attr);
+    }
+    
+    void update_columns(CaliperMetadataDB& db, const EntryList& list) {
+        // Auto-generate columns from attributes in the snapshots. Used if no
+        // field list was given. Skips some internal attributes.
+
+        for (Entry e : list) {
+            if (e.node()) {
+                for (const Node* node = e.node(); node && node->attribute() != CALI_INV_ID; node = node->parent())
+                    update_column_attribute(db, node->attribute());
+            } else
+                update_column_attribute(db, e.attribute());
+        }
+    }
+    
+    void add(CaliperMetadataDB& db, const EntryList& list) {
+        if (m_auto_column)
+            update_columns(db, list);
+        
+        std::vector<std::string> row(m_cols.size());
+        bool active = false;
+        
+        for (std::vector<Column>::size_type c = 0; c < m_cols.size(); ++c) {
+            if (m_cols[c].attr == Attribute::invalid)
+                m_cols[c].attr = db.attribute(m_cols[c].name);
+            if (m_cols[c].attr == Attribute::invalid)
+                continue;
+
+            std::string val;
+
+            for (Entry e : list) {
+                if (e.node()) {
+                    for (const Node* node = e.node(); node; node = node->parent())
+                        if (node->attribute() == m_cols[c].attr.id())
+                            val = node->data().to_string().append(val.empty() ? "" : "/").append(val);
+                } else {
+                    if (e.attribute() == m_cols[c].attr.id())
+                        val = e.value().to_string();
+                }
+            }
+
+            if (!val.empty()) {
+                active = true;
+                row[c] = val;
+                m_cols[c].max_width = std::max(val.size(), m_cols[c].max_width);
+            }
+        }
+
+        if (active)
+            m_rows.push_back(std::move(row));
+    }
+
+    void flush(std::ostream& os) {
+            
+        // print header
+        os << "{ \"attributes\" : [" ;
+        for (const Column& col : m_cols)
+            os << "\"" << col.name <<"\",";
+
+        os << "\b ], "<< std::endl<<" \"rows\" : [ ";
+
+        // print rows
+
+        for (auto row : m_rows) {
+            os << " [ " ;
+            for (std::vector<Column>::size_type c = 0; c < row.size(); ++c) {
+                    os << "\"" << row[c] << "\",";
+            }
+            os<< "\b ]," ;
+        }        
+        os << "\b]}" << std::endl;
+    }
+};
+
+
+Json::Json(const std::string& fields)
+    : mP { new JsonImpl }
+{
+    mP->parse(fields);
+}
+
+Json::~Json()
+{
+    mP.reset();
+}
+
+void 
+Json::operator()(CaliperMetadataDB& db, const EntryList& list)
+{
+    mP->add(db, list);
+}
+
+void
+Json::flush(CaliperMetadataDB&, std::ostream& os)
+{
+    mP->flush(os);
+}

--- a/src/reader/Json.h
+++ b/src/reader/Json.h
@@ -1,0 +1,68 @@
+// Copyright (c) 2015, Lawrence Livermore National Security, LLC.  
+// Produced at the Lawrence Livermore National Laboratory.
+//
+// This file is part of Caliper.
+// Written by David Boehme, boehme3@llnl.gov.
+// LLNL-CODE-678900
+// All rights reserved.
+//
+// For details, see https://github.com/scalability-llnl/Caliper.
+// Please also see the LICENSE file for our additional BSD notice.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+//  * Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the disclaimer below.
+//  * Redistributions in binary form must reproduce the above copyright notice, this list of
+//    conditions and the disclaimer (as noted below) in the documentation and/or other materials
+//    provided with the distribution.
+//  * Neither the name of the LLNS/LLNL nor the names of its contributors may be used to endorse
+//    or promote products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+// OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// LAWRENCE LIVERMORE NATIONAL SECURITY, LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+///@file Json.h
+/// Json output formatter declarations
+
+#ifndef CALI_JSON_H
+#define CALI_JSON_H
+
+#include "RecordMap.h"
+#include "RecordProcessor.h"
+
+#include <iostream>
+#include <memory>
+
+namespace cali
+{
+
+class CaliperMetadataDB;
+
+class Json 
+{
+    struct JsonImpl;
+    std::shared_ptr<JsonImpl> mP;
+
+public:
+
+    Json(const std::string& fields);
+
+    ~Json();
+
+    void operator()(CaliperMetadataDB&, const EntryList&);
+
+    void flush(CaliperMetadataDB&, std::ostream& os);
+};
+
+} // namespace cali
+
+#endif

--- a/src/tools/cali-query/cali-query.cpp
+++ b/src/tools/cali-query/cali-query.cpp
@@ -45,6 +45,7 @@
 #include <RecordProcessor.h>
 #include <RecordSelector.h>
 #include <Table.h>
+#include <Json.h>
 
 #include <ContextRecord.h>
 #include <Node.h>
@@ -103,6 +104,10 @@ namespace
         }, 
         { "table", "table", 't', false,
           "Print given attributes in human-readable table form",
+          "ATTRIBUTES"
+        },
+        { "json", "json", 'j', false,
+          "Print given attributes in web-friendly json format",
           "ATTRIBUTES"
         },
         { "output", "output", 'o', true,  "Set the output file name", "FILE"  },
@@ -324,6 +329,7 @@ int main(int argc, const char* argv[])
     //
 
     Table             tbl_writer(args.get("attributes"));
+    Json              jsn_writer(args.get("attributes"));
 
     NodeProcessFn     node_proc   = [](CaliperMetadataDB&,const Node*) { return; };
     SnapshotProcessFn snap_writer = [](CaliperMetadataDB&,const EntryList&){ return; };
@@ -343,7 +349,11 @@ int main(int argc, const char* argv[])
         snap_writer = Format(fs.is_open() ? fs : cout, formatstr, args.get("title"));
     } else if (args.is_set("table")) {        
         snap_writer = tbl_writer;
-    } else {
+    } 
+    else if(args.is_set("json")) {
+        snap_writer = jsn_writer;
+    }
+    else {
         WriteRecord writer = WriteRecord(fs.is_open() ? fs : cout);
 
         snap_writer = writer;
@@ -387,4 +397,6 @@ int main(int argc, const char* argv[])
 
     if (args.is_set("table"))
         tbl_writer.flush(metadb, fs.is_open() ? fs : cout);
+    if (args.is_set("json"))
+        jsn_writer.flush(metadb, fs.is_open() ? fs : cout);
 }


### PR DESCRIPTION
This PR is absolutely not just changing the formatting in Table.h. Come to think of it, we should make that a base class with "processHeader" and "processRow" functions.  I'll leave that to wiser (and more patient) minds, this should allow Caliper to interface with the web tools we're developing around the lab