### PR TITLE
Fixed issue with Clang builds by swapping order of project() and cmak…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,8 @@
 # Caliper
 #
 
-project (caliper)
 cmake_minimum_required(VERSION 3.0)
+project (caliper)
 
 # Version information
 set(CALIPER_MAJOR_VERSION 1)
@@ -39,7 +39,7 @@ endif()
 
 if(CALIPER_HAVE_TAU)
     find_library(tau_lib libTAU.so)
-    list(APPEND CALIPER_EXTERNAL_LIBS ${tau_lib}) 
+    list(APPEND CALIPER_EXTERNAL_LIBS ${tau_lib})
 endif()
 # the RPATH to be used when installing, but only if it's not a system directory
 list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
@@ -130,15 +130,15 @@ configure_file(
   ${PROJECT_BINARY_DIR}/caliper-config.cmake
   @ONLY)
 
-install(FILES ${PROJECT_BINARY_DIR}/caliper-config.cmake 
+install(FILES ${PROJECT_BINARY_DIR}/caliper-config.cmake
   DESTINATION share/cmake/caliper)
 install(EXPORT caliper
   DESTINATION share/cmake/caliper)
 
-install(FILES ${PROJECT_BINARY_DIR}/caliper-config.h 
+install(FILES ${PROJECT_BINARY_DIR}/caliper-config.h
   DESTINATION include/caliper)
 
-install(FILES ${PROJECT_BINARY_DIR}/caliper.pc 
+install(FILES ${PROJECT_BINARY_DIR}/caliper.pc
   DESTINATION share/pkgconfig)
 
 add_subdirectory(src)


### PR DESCRIPTION
To fix an issue with Clang, I switched the order of the project and cmake_minimum_required commands in the top level CMakeLists.txt. See the cmake bug report at https://cmake.org/Bug/bug_relationship_graph.php?bug_id=15943&graph=dependency.

The issue with Clang was that the C++ standard was not propagated to the command line.

Thanks,
Tim Kelley/LANL