### PR TITLE
FindLibcurl.cmake: add path suffix

### DIFF
--- a/cmake/FindLibcurl.cmake
+++ b/cmake/FindLibcurl.cmake
@@ -1,7 +1,7 @@
 #
 # - Find libcurl
 #
-# LIBCURL_INCLUDE_DIR - Path to libcurl.h
+# LIBCURL_INCLUDE_DIR - Path to curl.h
 # LIBCURL_LIBRARY     - List of libraries for using libcurl
 # LIBCURL_FOUND       - True if libcurl was found
 
@@ -9,8 +9,8 @@ if(LIBCURL_INCLUDE_DIR)
   set(LIBCURL_FIND_QUIETLY true)
 endif()
 
-find_path(LIBCURL_INCLUDE_DIR curl.h)
 find_library(LIBCURL_LIBRARY curl)
+find_path(LIBCURL_INCLUDE_DIR curl.h PATH_SUFFIXES curl)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Libcurl DEFAULT_MSG LIBCURL_LIBRARY LIBCURL_INCLUDE_DIR)


### PR DESCRIPTION
Most linux distros put curl.h in a subdir curl, e.g.
http://packages.ubuntu.com/search?searchon=contents&keywords=curl.h&mode=exactfilename&suite=yakkety&arch=any