### PR TITLE
wrap.py: is not python3 compliant

### DIFF
--- a/src/services/CMakeLists.txt
+++ b/src/services/CMakeLists.txt
@@ -84,7 +84,7 @@ configure_file(
    ${CMAKE_CURRENT_BINARY_DIR}/gen_services_inc.py
 )
 
-find_package(PythonInterp REQUIRED)
+find_package(PythonInterp 2 REQUIRED)
 
 add_custom_target(services.inc.cpp
   COMMAND ${PYTHON_EXECUTABLE} gen_services_inc.py


### PR DESCRIPTION
The issue shows up at build time if `/usr/bin/python` is `python3`.