### PR TITLE
Allow Caliper to be included as a subdirectory in a CMake build

### DIFF
--- a/src/services/CMakeLists.txt
+++ b/src/services/CMakeLists.txt
@@ -1,8 +1,10 @@
 # A macro to include service module source files in the caliper runtime lib
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
+set(CALIPER_SERVICES_SRC_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
 macro(add_service_sources)
-  file(RELATIVE_PATH _relpath "${CMAKE_SOURCE_DIR}/src/services" "${CMAKE_CURRENT_SOURCE_DIR}")
+  file(RELATIVE_PATH _relpath "${CALIPER_SERVICES_SRC_ROOT_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}")
   foreach(_src ${ARGN})
     if (_relpath)
       list(APPEND CALIPER_SERVICES_SOURCES "${_relpath}/${_src}")


### PR DESCRIPTION
Tiny fix:

Right now we assume in exactly one place that the root of Caliper is CMAKE_SRC_DIR. This is not necessarily true, there are build systems which include third party libraries as git submodules that become CMake subdirectories in the eventual build. Caliper broke in one such code's build due to the deleted line I [highlight](https://github.com/LLNL/Caliper/pull/38/files#diff-ed082c60e62182b0788deea7c7ca1195L5). Let me know if this fix doesn't work or you want a different solution, I'm a little ignorant of the design decisions in that part of CMake.