### PR TITLE
Annotation Policies

### DIFF
--- a/include/caliper/AnnotationStub.h
+++ b/include/caliper/AnnotationStub.h
@@ -1,0 +1,159 @@
+// Copyright (c) 2015, Lawrence Livermore National Security, LLC.  
+// Produced at the Lawrence Livermore National Laboratory.
+//
+// This file is part of Caliper.
+// Written by David Boehme, boehme3@llnl.gov.
+// LLNL-CODE-678900
+// All rights reserved.
+//
+// For details, see https://github.com/scalability-llnl/Caliper.
+// Please also see the LICENSE file for our additional BSD notice.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+//  * Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the disclaimer below.
+//  * Redistributions in binary form must reproduce the above copyright notice, this list of
+//    conditions and the disclaimer (as noted below) in the documentation and/or other materials
+//    provided with the distribution.
+//  * Neither the name of the LLNS/LLNL nor the names of its contributors may be used to endorse
+//    or promote products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+// OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// LAWRENCE LIVERMORE NATIONAL SECURITY, LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/// \file AnnotationStub.h
+/// Caliper C++ annotation stub interface
+
+//
+// --- NOTE: This interface must be C++98 only!
+//
+
+#ifndef CALI_ANNOTATION_STUB_H
+#define CALI_ANNOTATION_STUB_H
+
+#include "common/cali_types.h"
+
+namespace cali
+{
+    
+class Variant;
+
+/// \brief Instrumentation interface to add and manipulate context attributes
+///
+/// The Annotation class is the primary source-code instrumentation interface
+/// for %Caliper. %Annotation objects provide access to named %Caliper context 
+/// attributes. If the referenced attribute does not exist yet, it will be 
+/// created automatically.
+///
+/// Example:
+/// \code
+/// cali::Annotation phase_ann("myprogram.phase");
+///
+/// phase_ann.begin("Initialization");
+///   // ...
+/// phase_ann.end();
+/// \endcode
+/// This example creates an annotation object for the \c myprogram.phase 
+/// attribute, and uses the \c begin()/end() methods to mark a section 
+/// of code where that attribute is set to "Initialization".
+///
+/// \note Access to the underlying named context attribute through
+/// %Annotation objects is not exclusive: multiple %Annotation objects
+/// can reference and update the same context attribute.
+
+class AnnotationStub 
+{
+
+
+public:
+
+    /// \brief Creates an annotation object to manipulate 
+    ///   the context attribute with the given \a name. 
+    /// 
+    /// \param name The attribute name
+    /// \param opt  %Attribute flags. Bitwise OR combination 
+    ///   of \ref cali_attr_properties values.
+    AnnotationStub(const char* name, int opt = 0);
+
+    AnnotationStub(const AnnotationStub&);
+
+    ~AnnotationStub();
+
+    AnnotationStub& operator = (const AnnotationStub&);
+
+    class Guard {
+        Guard(const Guard&);
+        Guard& operator = (const Guard&);
+
+    public:
+
+        Guard(AnnotationStub& a);
+
+        ~Guard();
+    };
+
+    // Keep AutoScope name for backward compatibility
+    typedef Guard AutoScope;
+
+    /// \name begin() overloads
+    /// \{
+
+    AnnotationStub& begin();
+
+    /// \brief Begin <em>name</em>=<em>data</em> region for the associated 
+    ///    context attribute.
+    ///
+    /// Marks begin of the <em>name</em>=<em>data</em> region, where
+    /// \a name is the attribute name given in
+    /// cali::AnnotationStub::AnnotationStub(). The new value will be nested
+    /// under already open regions for the \a name context attribute.
+    AnnotationStub& begin(int data);
+    /// \copydoc cali::AnnotationStub::begin(int)
+    AnnotationStub& begin(double data);
+    /// \copydoc cali::AnnotationStub::begin(int)
+    AnnotationStub& begin(const char* data);
+    AnnotationStub& begin(cali_attr_type type, void* data, uint64_t size);
+    /// \copydoc cali::AnnotationStub::begin(int)
+    AnnotationStub& begin(const Variant& data);
+
+    /// \}
+    /// \name set() overloads
+    /// \{
+
+    /// \brief Set <em>name</em>=<em>data</em> for the associated 
+    ///    context attribute.
+    ///
+    /// Exports <em>name</em>=<em>data</em>, where \a name is the
+    /// attribute name given in cali::AnnotationStub::AnnotationStub(). The
+    /// top-most prior open value for the \a name context attribute,
+    /// if any, will be overwritten.
+    AnnotationStub& set(int data);
+    /// \copydoc cali::AnnotationStub::set(int)
+    AnnotationStub& set(double data);
+    /// \copydoc cali::AnnotationStub::set(int)
+    AnnotationStub& set(const char* data);
+    AnnotationStub& set(cali_attr_type type, void* data, uint64_t size);
+    /// \copydoc cali::AnnotationStub::set(int)
+    AnnotationStub& set(const Variant& data);
+
+    /// \}
+
+    /// \brief Close top-most open region for the associated 
+    ///   context attribute.
+    void end();
+};
+
+/// \} // AnnotationAPI group
+    
+} // namespace cali
+
+#endif

--- a/include/caliper/Policy.h
+++ b/include/caliper/Policy.h
@@ -138,14 +138,14 @@ namespace cali{
     return Inclusive<cali::policy::tags::function, cali::policy::tags::loop>::policy<Tags...>();
   } 
 
-	//template<typename... Tags>
-	//using DefaultAnnotationTypeForTags = typename AnnotationSelector<
-	//                          policy::default_policy<Tags...>()
-	//                       >::AnnotationType;    
+	template<typename... Tags>
+	using DefaultAnnotationTypeForTags = typename AnnotationSelector<
+	                          policy::default_policy<Tags...>()
+	                       >::AnnotationType;    
 
-  //using DefaultFunctionAnnotation = DefaultAnnotationTypeForTags<cali::policy::tags::function>;
-  //using DefaultLoopAnnotation     = DefaultAnnotationTypeForTags<cali::policy::tags::loop>;
-  //using DefaultPackageAnnotation  = DefaultAnnotationTypeForTags<cali::policy::tags::package>;
+  using DefaultFunctionAnnotation = DefaultAnnotationTypeForTags<cali::policy::tags::function>;
+  using DefaultLoopAnnotation     = DefaultAnnotationTypeForTags<cali::policy::tags::loop>;
+  using DefaultPackageAnnotation  = DefaultAnnotationTypeForTags<cali::policy::tags::package>;
 
 } // end namespace policy  
 

--- a/include/caliper/Policy.h
+++ b/include/caliper/Policy.h
@@ -1,0 +1,154 @@
+// Copyright (c) 2015, Lawrence Livermore National Security, LLC.  
+// Produced at the Lawrence Livermore National Laboratory.
+//
+// This file is part of Caliper.
+// Written by David Boehme, boehme3@llnl.gov.
+// LLNL-CODE-678900
+// All rights reserved.
+//
+// For details, see https://github.com/scalability-llnl/Caliper.
+// Please also see the LICENSE file for our additional BSD notice.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+//  * Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the disclaimer below.
+//  * Redistributions in binary form must reproduce the above copyright notice, this list of
+//    conditions and the disclaimer (as noted below) in the documentation and/or other materials
+//    provided with the distribution.
+//  * Neither the name of the LLNS/LLNL nor the names of its contributors may be used to endorse
+//    or promote products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+// OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// LAWRENCE LIVERMORE NATIONAL SECURITY, LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/// \file Policy.h
+/// Caliper C++ Policy-based Annotations
+
+/**
+  * TODO: Namespace detail
+  */
+
+#ifndef CALI_POLICY_H
+#define CALI_POLICY_H
+
+#include "Annotation.h"
+#include "AnnotationStub.h"
+#include "cali_definitions.h"
+
+#include "common/Variant.h"
+
+#include <cstring>
+#include <iostream>
+#include <tuple>
+#include <type_traits>
+
+namespace cali{
+
+	namespace policy {
+	  namespace tags{
+	    struct function{};
+	    struct package{};
+			struct description{};
+	    struct loop{};
+	  } // end namespace tags
+	
+	struct Nil{};
+
+	template<typename... Types>
+	struct TypeList{};
+	template<>
+	struct TypeList<>{
+     using Cons = Nil;
+	   static constexpr const int size = 0;
+	};
+	
+	template<typename ConsType,typename... Types>
+	struct TypeList<ConsType,Types...>
+	{
+	    using Cons = ConsType;
+	    using More = TypeList<Types...>;
+	    static constexpr const int size = sizeof...(Types)+1;
+	};
+	
+	template<typename Term,typename tl>
+	constexpr const typename std::enable_if<tl::size==0,bool>::type in_helper(){
+	  return false;
+	}
+	    
+	template<typename Term,typename tl>
+	constexpr const typename std::enable_if<tl::size!=0,bool>::type in_helper(){
+    return std::is_same<typename tl::Cons,Term>::value || policy::in_helper<Term,typename tl::More>();
+	}
+	
+	template<typename Term,typename... Tags>
+	constexpr const bool in(){
+	  return in_helper<Term,TypeList<Tags...>>();
+	}
+	
+	template<typename... Tags>
+	constexpr const bool DefaultPolicy(){
+	   return policy::in<policy::tags::function,Tags...>();
+	}
+	
+	
+	template<typename Head, typename... Included>
+	struct Inclusive{
+     static constexpr int tail_size = sizeof...(Included);
+
+	   template<typename Shadow=Head,int ss=tail_size,typename... Tags>
+	   static constexpr const typename std::enable_if<ss!=0,bool>::type policy_help(){
+	      return policy::in<Shadow,Tags...>() || (Inclusive<Included...>::template policy<Tags...>());
+	   }
+	   template<typename Shadow=Head,int ss=tail_size, typename... Tags>
+	   static constexpr const typename std::enable_if<ss==0,bool>::type policy_help(){
+	      return policy::in<Shadow,Tags...>();
+	   }
+	   template<typename... Tags>
+	   static constexpr const bool policy(){
+	      return policy_help<Head, tail_size, Tags...>();
+	   }
+
+	
+	};
+	
+	template<bool enable>
+	struct AnnotationSelector{};
+	
+	template<>
+	struct AnnotationSelector<false>{
+	   using AnnotationType = cali::AnnotationStub;
+	};
+	
+	template<>
+	struct AnnotationSelector<true>{
+	   using AnnotationType = cali::Annotation;
+	};
+	
+  template<typename... Tags>
+  static constexpr bool default_policy(){
+    return Inclusive<cali::policy::tags::function, cali::policy::tags::loop>::policy<Tags...>();
+  } 
+
+	//template<typename... Tags>
+	//using DefaultAnnotationTypeForTags = typename AnnotationSelector<
+	//                          policy::default_policy<Tags...>()
+	//                       >::AnnotationType;    
+
+  //using DefaultFunctionAnnotation = DefaultAnnotationTypeForTags<cali::policy::tags::function>;
+  //using DefaultLoopAnnotation     = DefaultAnnotationTypeForTags<cali::policy::tags::loop>;
+  //using DefaultPackageAnnotation  = DefaultAnnotationTypeForTags<cali::policy::tags::package>;
+
+} // end namespace policy  
+
+} // end namespace cali
+
+#endif //CALI_POLICY_H

--- a/src/caliper/AnnotationStub.cpp
+++ b/src/caliper/AnnotationStub.cpp
@@ -1,0 +1,134 @@
+// Copyright (c) 2015, Lawrence Livermore National Security, LLC.  
+// Produced at the Lawrence Livermore National Laboratory.
+//
+// This file is part of Caliper.
+// Written by David Boehme, boehme3@llnl.gov.
+// LLNL-CODE-678900
+// All rights reserved.
+//
+// For details, see https://github.com/scalability-llnl/Caliper.
+// Please also see the LICENSE file for our additional BSD notice.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+//  * Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the disclaimer below.
+//  * Redistributions in binary form must reproduce the above copyright notice, this list of
+//    conditions and the disclaimer (as noted below) in the documentation and/or other materials
+//    provided with the distribution.
+//  * Neither the name of the LLNS/LLNL nor the names of its contributors may be used to endorse
+//    or promote products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+// OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// LAWRENCE LIVERMORE NATIONAL SECURITY, LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// Annotation interface
+
+#include "caliper/AnnotationStub.h"
+
+#include "caliper/Caliper.h"
+
+#include "caliper/common/Log.h"
+#include "caliper/common/Variant.h"
+
+#include <atomic>
+#include <cstring>
+#include <string>
+
+using namespace std;
+using namespace cali;
+
+// --- Guard subclass
+
+AnnotationStub::Guard::Guard(AnnotationStub& a)
+{ }
+
+AnnotationStub::Guard::~Guard()
+{ }
+
+// --- Constructors / destructor
+
+AnnotationStub::AnnotationStub(const char* name, int opt)
+{ }
+
+AnnotationStub::~AnnotationStub()
+{ }
+
+AnnotationStub::AnnotationStub(const AnnotationStub& a)
+{ }
+
+AnnotationStub& AnnotationStub::operator = (const AnnotationStub& a)
+{
+    return *this;
+}
+
+
+// --- begin() overloads
+
+AnnotationStub& AnnotationStub::begin()
+{
+    return *this;
+}
+
+AnnotationStub& AnnotationStub::begin(int data)
+{
+  return *this;
+}
+
+AnnotationStub& AnnotationStub::begin(double data)
+{
+  return *this;
+}
+
+AnnotationStub& AnnotationStub::begin(const char* data)
+{
+  return *this;
+}
+
+AnnotationStub& AnnotationStub::begin(cali_attr_type type, void* data, uint64_t size)
+{
+  return *this;
+}
+
+AnnotationStub& AnnotationStub::begin(const Variant& data)
+{
+    return *this;
+}
+
+// --- set() overloads
+
+AnnotationStub& AnnotationStub::set(int data)
+{
+  return *this;
+}
+
+AnnotationStub& AnnotationStub::set(double data)
+{
+  return *this;
+}
+
+AnnotationStub& AnnotationStub::set(const char* data)
+{
+  return *this;
+}
+
+AnnotationStub& AnnotationStub::set(cali_attr_type type, void* data, uint64_t size)
+{
+  return *this;
+}
+
+AnnotationStub& AnnotationStub::set(const Variant& data)
+{
+    return *this;
+}
+
+void AnnotationStub::end()
+{ }

--- a/src/caliper/CMakeLists.txt
+++ b/src/caliper/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(CALIPER_SOURCES
     Annotation.cpp
     AnnotationBinding.cpp
+    AnnotationStub.cpp
     Caliper.cpp
     ContextBuffer.cpp
     SnapshotRecord.cpp


### PR DESCRIPTION
This PR consists of three things

1) A stub Annotation class which matches the interface of Annotation and otherwise does nothing
2) The ability to specify Annotation policies and have tagged Annotations map either to a stub or the real thing based on said policies
3) Some default policies and tags for use in this system

Also a test. Those three come in ascending order of how confident I am in them, I'm almost positive we need more tags, and a better default policy, but I'm reasonably confident in the mechanisms these things are built on, I've tested it with gcc and Clang (Intel and PGI ongoing).

Mainly meant to spur discussion on (3), but feel free to let me know if I'm out of my mind, bearing in mind that the average user will only see `FunctionAnnotation`-like constructs, mid-level users might tag things, and only experts will be writing policy.