### PR TITLE
Correct SOS service pack/publish behavior

### DIFF
--- a/src/services/sos/Sos.cpp
+++ b/src/services/sos/Sos.cpp
@@ -40,7 +40,7 @@ const ConfigSet::Entry   configdata[] = {
 };
 
 // Takes an unpacked Caliper snapshot and publishes it in SOS
-void pack_snapshot(SOS_pub* sos_pub, int snapshot_id, const std::map< Attribute, std::vector<Variant> >& unpacked_snapshot) {
+void pack_snapshot(SOS_pub* sos_pub, bool yn_publish, int snapshot_id, const std::map< Attribute, std::vector<Variant> >& unpacked_snapshot) {
     for (auto &p : unpacked_snapshot) {
         switch (p.first.type()) {
         case CALI_TYPE_STRING:
@@ -71,8 +71,11 @@ void pack_snapshot(SOS_pub* sos_pub, int snapshot_id, const std::map< Attribute,
             ;
         }
     }
-
-    SOS_publish(sos_pub);
+    if (yn_publish == true) {
+        SOS_publish(sos_pub);
+    }
+    
+    return;
 }
 
 class SosService
@@ -90,7 +93,7 @@ class SosService
         Log(2).stream() << "sos: Publishing Caliper data" << std::endl;
 
         c->flush(nullptr, [this,c](const SnapshotRecord* snapshot){
-                pack_snapshot(sos_publication_handle, ++snapshot_id, snapshot->unpack(*c));
+                pack_snapshot(sos_publication_handle, true, ++snapshot_id, snapshot->unpack(*c));
                 return true;
             });
         c->clear(); //Avoids re-publishing snapshots.
@@ -102,7 +105,7 @@ class SosService
     }
 
     void process_snapshot(Caliper* c, const SnapshotRecord* trigger_info, const SnapshotRecord* snapshot) {
-        pack_snapshot(sos_publication_handle, ++snapshot_id, snapshot->unpack(*c));
+        pack_snapshot(sos_publication_handle, false, ++snapshot_id, snapshot->unpack(*c));
     }
 
     void post_end(Caliper* c, const Attribute& attr) {

--- a/src/services/sos/Sos.cpp
+++ b/src/services/sos/Sos.cpp
@@ -93,9 +93,10 @@ class SosService
         Log(2).stream() << "sos: Publishing Caliper data" << std::endl;
 
         c->flush(nullptr, [this,c](const SnapshotRecord* snapshot){
-                pack_snapshot(sos_publication_handle, true, ++snapshot_id, snapshot->unpack(*c));
+                pack_snapshot(sos_publication_handle, false, ++snapshot_id, snapshot->unpack(*c));
                 return true;
             });
+        SOS_publish(sos_publication_handle);
         c->clear(); //Avoids re-publishing snapshots.
     }
 


### PR DESCRIPTION
The SOS service is calling SOS_publish(...) and transmitting data to the daemon (apparently) as independent actions for each element of each snapshot. The desired behaviour is for calls to SOS_pack_related(...) to enqueue these values in the (SOS_pub*) sos_pub handle, and only once at the triggering event connect and transmit all enqueued values.