### PR TITLE
Added -lcaliper-tools-util to CMakeLists pkg-config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,7 +293,7 @@ install(FILES ${PROJECT_BINARY_DIR}/include/caliper/caliper-config.h
 # Create pkg-confic .pc file
 set(PKG_CONFIG_INCLUDEDIR "\${prefix}/include")
 set(PKG_CONFIG_LIBDIR "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
-set(PKG_CONFIG_LIBS "-L\${libdir} -lcaliper")
+set(PKG_CONFIG_LIBS "-L\${libdir} -lcaliper -lcaliper-tools-util")
 set(PKG_CONFIG_CFLAGS "-I\${includedir}")
 
 configure_file(


### PR DESCRIPTION
I added -lcaliper-tools-util so someone can more easily link to Caliper via something like

g++ $(pkg-config --cflags --libs-only-L caliper) file.cpp  $(pkg-config --libs-only-l caliper)

I'm just now discovering `pkg-config` so I'm not sure if this is the best way to handle this issue.