### PR TITLE
Store thread-local trace and aggregation buffers on blackboard

### DIFF
--- a/include/caliper/Caliper.h
+++ b/include/caliper/Caliper.h
@@ -167,6 +167,8 @@ class Caliper : public CaliperMetadataAccessInterface
         : m_is_signal(sig)
         { }
 
+    void release_thread();
+
 public:
 
     //

--- a/include/caliper/common/Attribute.h
+++ b/include/caliper/common/Attribute.h
@@ -38,17 +38,16 @@
 #ifndef CALI_ATTRIBUTE_H
 #define CALI_ATTRIBUTE_H
 
-#include "cali_types.h"
+#include "caliper/common/cali_types.h"
 
-#include "Variant.h"
+#include "caliper/common/Node.h"
+#include "caliper/common/Variant.h"
 
 #include <iostream>
 #include <string>
 
 namespace cali
 {
-
-class Node;
     
 struct MetaAttributeIDs {
     cali_id_t name_attr_id;
@@ -75,7 +74,7 @@ public:
         : m_node(0)
         { }
 
-    cali_id_t      id() const;
+    cali_id_t      id() const { return m_node ? m_node->id() : CALI_INV_ID; }
 
     std::string    name() const;
     const char*    name_c_str() const;

--- a/include/caliper/common/Entry.h
+++ b/include/caliper/common/Entry.h
@@ -54,7 +54,7 @@ public:
     /// For immediate entries, returns the stored attribute id.
     /// For reference entries, returns the referenced node's 
     /// attribute id.
-    cali_id_t attribute() const;
+    cali_id_t attribute() const { return m_node ? m_node->attribute() : m_attr_id; }
 
     /// \brief Count instances of attribute \a attr_id in this entry
     int       count(cali_id_t attr_id = CALI_INV_ID) const;
@@ -63,7 +63,7 @@ public:
     }
 
     /// \brief Return top-level data value of this entry
-    Variant   value() const;
+    Variant   value() const { return m_node ? m_node->data() : m_value; }
 
     /// \brief Extract data value for attribute \a attr_id from this entry
     Variant   value(cali_id_t attr_id) const;

--- a/include/caliper/common/Variant.h
+++ b/include/caliper/common/Variant.h
@@ -60,8 +60,9 @@ class Variant
     cali_variant_t m_v;
     
 public:
+    
     CONSTEXPR_UNLESS_PGI Variant()
-        : m_v { CALI_TYPE_INV, { .v_uint = 0 } } { }
+        : m_v { CALI_TYPE_INV, { .v_uint = 0 } }  { }
     
     Variant(const cali_variant_t& v)
         : m_v(v) { }
@@ -91,10 +92,12 @@ public:
 
     cali_variant_t c_variant() const { return m_v; }
     
-    cali_attr_type type() const { return cali_variant_get_type(m_v);  }
-    const void*    data() const { return cali_variant_get_data(&m_v); }
-    size_t         size() const { return cali_variant_get_size(m_v);  }
+    cali_attr_type type() const    { return cali_variant_get_type(m_v);  }
+    const void* const data() const { return cali_variant_get_data(&m_v); }
+    size_t         size() const    { return cali_variant_get_size(m_v);  }
 
+    void* const    get_ptr() const { return cali_variant_get_ptr(m_v);   }
+    
     cali_id_t      to_id(bool* okptr = nullptr) const;
     int            to_int(bool* okptr = nullptr) const {
         return cali_variant_to_int(m_v, okptr);

--- a/include/caliper/common/cali_types.h
+++ b/include/caliper/common/cali_types.h
@@ -63,10 +63,11 @@ typedef enum {
   CALI_TYPE_ADDR   = 5, /**< 64-bit address             */
   CALI_TYPE_DOUBLE = 6, /**< Double-precision floating point type */
   CALI_TYPE_BOOL   = 7, /**< C or C++ boolean           */
-  CALI_TYPE_TYPE   = 8  /**< Instance of cali_attr_type */
+  CALI_TYPE_TYPE   = 8, /**< Instance of cali_attr_type */
+  CALI_TYPE_PTR    = 9  /**< Raw pointer. Internal use only. */
 } cali_attr_type;
 
-#define CALI_MAXTYPE CALI_TYPE_TYPE
+#define CALI_MAXTYPE CALI_TYPE_PTR
 
 /**
  * \brief 

--- a/include/caliper/common/cali_variant.h
+++ b/include/caliper/common/cali_variant.h
@@ -1,5 +1,5 @@
 /* *********************************************************************************************
- * Copyright (c) 2017, Lawrence Livermore National Security, LLC.  
+ * Copyright (c) 2017, Lawrence Livermore National Security, LLC.
  * Produced at the Lawrence Livermore National Laboratory.
  *
  * This file is part of Caliper.
@@ -47,16 +47,16 @@ extern "C" {
 #include <stdbool.h>
 #include <stddef.h>
 
-/** The variant struct manages values of different types in Caliper.    
+/** The variant struct manages values of different types in Caliper.
  *  Types with fixed size (i.e., numeric types) are stored in the variant directly.
- *  Variable-length types (strings and blobs) are stored as unmanaged pointers. 
- */    
+ *  Variable-length types (strings and blobs) are stored as unmanaged pointers.
+ */
 typedef struct {
     /** Least significant bytes encode the type.
      *  Remaining bytes encode the size of variable-length types (strings and blobs (usr)).
      */
     uint64_t type_and_size;
-    
+
     /** Value in various type representations
      */
     union {
@@ -65,7 +65,8 @@ typedef struct {
         int            v_int;
         uint64_t       v_uint;
         cali_attr_type v_type;
-        const void*    unmanaged_ptr;
+        void*          unmanaged_ptr;
+        const void*    unmanaged_const_ptr;
     }        value;
 } cali_variant_t;
 
@@ -79,7 +80,7 @@ cali_make_empty_variant()
     v.value.v_uint = 0;
     return v;
 }
-    
+
 /** \brief Test if variant is empty
  */
 inline bool
@@ -87,8 +88,8 @@ cali_variant_is_empty(cali_variant_t v)
 {
     return 0 == v.type_and_size;
 }
-  
-/** \brief Return type of a variant  
+
+/** \brief Return type of a variant
  */
 cali_attr_type
 cali_variant_get_type(cali_variant_t v);
@@ -100,10 +101,10 @@ cali_variant_get_size(cali_variant_t v);
 
 /** \brief Get a pointer to the variant's data
  */
-const void*
+const void* const
 cali_variant_get_data(const cali_variant_t* v);
 
-/** \brief Construct variant from type, pointer, and size 
+/** \brief Construct variant from type, pointer, and size
  */
 cali_variant_t
 cali_make_variant(cali_attr_type type, const void* ptr, size_t size);
@@ -118,14 +119,14 @@ cali_make_variant_from_bool(bool value)
     v.value.v_bool = value;
     return v;
 }
-    
+
 inline cali_variant_t
 cali_make_variant_from_int(int value)
 {
     cali_variant_t v;
     v.type_and_size = CALI_TYPE_INT;
     v.value.v_uint = 0;
-    v.value.v_int = value;    
+    v.value.v_int = value;
     return v;
 }
 
@@ -157,6 +158,24 @@ cali_make_variant_from_type(cali_attr_type value)
     return v;
 }
 
+inline cali_variant_t
+cali_make_variant_from_ptr(void* ptr)
+{
+    cali_variant_t v;
+    v.type_and_size = CALI_TYPE_PTR;
+    v.value.unmanaged_ptr = ptr;
+    return v;
+}
+
+/** \brief Return the pointer stored in the variant. Only works for
+ *    CALI_TYPE_PTR.
+ */
+inline void* const
+cali_variant_get_ptr(cali_variant_t v)
+{
+    return v.type_and_size == CALI_TYPE_PTR ? v.value.unmanaged_ptr : NULL;
+}
+
 /** \brief Return the variant's value as integer
  */
 int
@@ -173,8 +192,8 @@ cali_variant_to_type(cali_variant_t v, bool* okptr);
 
 bool
 cali_variant_to_bool(cali_variant_t v, bool* okptr);
-    
-/** \brief Compare variant values. 
+
+/** \brief Compare variant values.
  */
 int
 cali_variant_compare(cali_variant_t lhs, cali_variant_t rhs);
@@ -185,13 +204,13 @@ cali_variant_eq(cali_variant_t lhs, cali_variant_t rhs);
 /** \brief Pack variant into byte buffer
  */
 size_t
-cali_variant_pack(cali_variant_t v, unsigned char* buf);    
+cali_variant_pack(cali_variant_t v, unsigned char* buf);
 
 /** \brief Unpack variant from byte buffer
  */
 cali_variant_t
 cali_variant_unpack(const unsigned char* buf, size_t* inc, bool* okptr);
-    
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/src/caliper/Blackboard.h
+++ b/src/caliper/Blackboard.h
@@ -113,6 +113,16 @@ public:
         return hashtable[I].id == attr.id() ? hashtable[I].data.reference : nullptr;
     }
 
+    inline Variant
+    get_immediate(const cali::Attribute& attr) const {
+        std::lock_guard<util::spinlock>
+            g(lock);
+
+        size_t I = find_existing_entry(attr.id());
+        
+        return hashtable[I].id == attr.id() ? hashtable[I].data.immediate : nullptr;
+    }
+
     void    set(const cali::Attribute& attr, const cali::Variant& val);
     void    set(const cali::Attribute& attr, cali::Node* node);
 

--- a/src/caliper/Caliper.cpp
+++ b/src/caliper/Caliper.cpp
@@ -266,6 +266,11 @@ struct Caliper::ThreadData
         }
 
     ~ThreadData() {
+        {
+            Caliper c;
+            c.release_thread();
+        }
+        
         if (is_initial_thread)
             Caliper::release();
             
@@ -1447,6 +1452,15 @@ void
 Caliper::deactivate_channel(Channel* chn)
 {
     chn->mP->active = false;
+}
+
+/// \brief Release current thread
+void
+Caliper::release_thread()
+{
+    for (auto &chn : sG->channels)
+        if (chn)
+            chn->mP->events.release_thread_evt(this, chn.get());
 }
 
 //

--- a/src/caliper/MetadataTree.cpp
+++ b/src/caliper/MetadataTree.cpp
@@ -92,7 +92,8 @@ struct MetadataTree::MetadataTreeImpl
                     {  8, 8,  { CALI_TYPE_STRING, "cali.attribute.name",  19 }, 3 },
                     {  9, 8,  { CALI_TYPE_STRING, "cali.attribute.type",  19 }, 7 },
                     { 10, 8,  { CALI_TYPE_STRING, "cali.attribute.prop",  19 }, 1 },
-                    { CALI_INV_ID, CALI_INV_ID, { }, CALI_INV_ID },
+                    { 11, 9,  { CALI_TYPE_PTR    }, CALI_INV_ID },
+                    { CALI_INV_ID, CALI_INV_ID, { }, CALI_INV_ID }
                 };
 
                 for (const NodeInfo* info = bootstrap_nodes; info->id != CALI_INV_ID; ++info) {
@@ -109,7 +110,7 @@ struct MetadataTree::MetadataTreeImpl
                 }
 
                 node_blocks[0].chunk = chunk;
-                node_blocks[0].index = 11;
+                node_blocks[0].index = 12;
             }
 
         ~GlobalData() {

--- a/src/common/Attribute.cpp
+++ b/src/common/Attribute.cpp
@@ -57,12 +57,6 @@ Attribute::make_attribute(const Node* node)
     return Attribute::invalid;
 }
 
-cali_id_t
-Attribute::id() const
-{ 
-    return m_node ? m_node->id() : CALI_INV_ID;
-}
-
 std::string
 Attribute::name() const 
 {

--- a/src/common/Entry.cpp
+++ b/src/common/Entry.cpp
@@ -39,12 +39,6 @@
 
 using namespace cali;
 
-cali_id_t
-Entry::attribute() const
-{
-    return m_node ? m_node->attribute() : m_attr_id;
-}
-
 int 
 Entry::count(cali_id_t attr_id) const 
 {
@@ -60,12 +54,6 @@ Entry::count(cali_id_t attr_id) const
     }
 
     return res;
-}
-
-Variant 
-Entry::value() const
-{
-    return m_node ? m_node->data() : m_value;
 }
 
 Variant 

--- a/src/common/Variant.cpp
+++ b/src/common/Variant.cpp
@@ -111,10 +111,14 @@ Variant::to_string() const
         ret = to_bool() ? "true" : "false";
         break;
     case CALI_TYPE_TYPE:
-    {
         ret = cali_type2string(to_attr_type());
-    }
         break;
+    case CALI_TYPE_PTR:
+    {
+        std::ostringstream os;
+        os << std::hex << reinterpret_cast<uint64_t>(data());
+        ret = os.str();
+    }
     }
 
     return ret;
@@ -129,6 +133,7 @@ Variant::from_string(cali_attr_type type, const char* str, bool* okptr)
     switch (type) {
     case CALI_TYPE_INV:
     case CALI_TYPE_USR:
+    case CALI_TYPE_PTR:
         // Can't convert USR or INV types at this point
         break;
     case CALI_TYPE_STRING:

--- a/src/common/cali_types.c
+++ b/src/common/cali_types.c
@@ -20,6 +20,7 @@ static const struct typemap_t {
   { "double", CALI_TYPE_DOUBLE },
   { "bool",   CALI_TYPE_BOOL   },
   { "type",   CALI_TYPE_TYPE   },
+  { "ptr",    CALI_TYPE_PTR    },
   { NULL,     CALI_TYPE_INV    }
 };
 

--- a/src/common/cali_variant.c
+++ b/src/common/cali_variant.c
@@ -1,5 +1,5 @@
 /* *********************************************************************************************
- * Copyright (c) 2017, Lawrence Livermore National Security, LLC.  
+ * Copyright (c) 2017, Lawrence Livermore National Security, LLC.
  * Produced at the Lawrence Livermore National Laboratory.
  *
  * This file is part of Caliper.
@@ -81,23 +81,25 @@ cali_variant_get_size(cali_variant_t v)
         return sizeof(bool);
     case CALI_TYPE_TYPE:
         return sizeof(cali_attr_type);
+    case CALI_TYPE_PTR:
+        return sizeof(void*);
     }
 
     return 0;
 }
 
-const void*
+const void* const
 cali_variant_get_data(const cali_variant_t* v)
 {
     uint64_t          t = _EXTRACT_TYPE(v->type_and_size);
     cali_attr_type type = (t <= CALI_MAXTYPE ? (cali_attr_type) t : CALI_TYPE_INV);
-    
+
     switch (type) {
     case CALI_TYPE_INV:
         return 0;
     case CALI_TYPE_USR:
     case CALI_TYPE_STRING:
-        return v->value.unmanaged_ptr;
+        return v->value.unmanaged_const_ptr;
     case CALI_TYPE_INT:
         return &v->value.v_int;
     case CALI_TYPE_ADDR:
@@ -109,11 +111,12 @@ cali_variant_get_data(const cali_variant_t* v)
         return &v->value.v_bool;
     case CALI_TYPE_TYPE:
         return &v->value.v_type;
+    case CALI_TYPE_PTR:
+        return v->value.unmanaged_ptr;
     }
 
     return NULL;
 }
-
 
 cali_variant_t
 cali_make_variant(cali_attr_type type, const void* ptr, size_t size)
@@ -121,14 +124,14 @@ cali_make_variant(cali_attr_type type, const void* ptr, size_t size)
     cali_variant_t v = { 0, { .v_uint = 0 } };
 
     v.type_and_size = (type & CALI_VARIANT_TYPE_MASK);
-    
+
     switch (type) {
     case CALI_TYPE_INV:
         break;
     case CALI_TYPE_USR:
     case CALI_TYPE_STRING:
         v.type_and_size  = (size << 8) | (type & CALI_VARIANT_TYPE_MASK);
-        v.value.unmanaged_ptr = ptr;
+        v.value.unmanaged_const_ptr = ptr;
         break;
     case CALI_TYPE_INT:
         v.value.v_int    = *((const int*) ptr);
@@ -146,11 +149,14 @@ cali_make_variant(cali_attr_type type, const void* ptr, size_t size)
     case CALI_TYPE_TYPE:
         v.value.v_type   = *((const cali_attr_type*) ptr);
         break;
+    case CALI_TYPE_PTR:
+        v.value.unmanaged_const_ptr = ptr;
+        break;
     }
 
     return v;
 }
-                  
+
 extern inline cali_variant_t
 cali_make_variant_from_bool(bool value);
 
@@ -166,17 +172,22 @@ cali_make_variant_from_double(double value);
 extern inline cali_variant_t
 cali_make_variant_from_type(cali_attr_type value);
 
+extern inline cali_variant_t
+cali_make_variant_from_ptr(void* ptr);
+
+extern inline void* const
+cali_variant_get_ptr(cali_variant_t v);
 
 /** \brief Return the variant's value as integer
  *
  *  This function returns the variant's value as integer.
  *  Numeric types (bool, int, uint, double, type) will be converted to int,
  *  and value pointed to by \a okptr is set to `true`.
- *  For other types (blobs and strings) the function returns zero, and the 
+ *  For other types (blobs and strings) the function returns zero, and the
  *  value pointed to by \a okptr is set to `false`.
- *  
+ *
  *  \param v     The input variant
- *  \param okptr If non-NULL, indicate success or failure int the referenced variable.   
+ *  \param okptr If non-NULL, indicate success or failure int the referenced variable.
  *  \return The integer value. Zero if the conversion was unsuccesful.
  */
 int
@@ -192,6 +203,7 @@ cali_variant_to_int(cali_variant_t v, bool* okptr)
     case CALI_TYPE_INV:
     case CALI_TYPE_USR:
     case CALI_TYPE_STRING:
+    case CALI_TYPE_PTR:
         ok  = false;
         break;
     case CALI_TYPE_INT:
@@ -223,11 +235,11 @@ cali_variant_to_int(cali_variant_t v, bool* okptr)
  *  This function returns the variant's value as integer.
  *  Numeric types (bool, int, uint, double, type) will be converted to `uint64_t`,
  *  and value pointed to by \a okptr is set to `true`.
- *  For other types (blobs and strings) the function returns zero, and the 
+ *  For other types (blobs and strings) the function returns zero, and the
  *  value pointed to by \a okptr is set to `false`.
- *  
+ *
  *  \param v     The input variant
- *  \param okptr If non-NULL, indicate success or failure int the referenced variable.   
+ *  \param okptr If non-NULL, indicate success or failure int the referenced variable.
  *  \return The integer value. Zero if the conversion was unsuccesful.
  */
 uint64_t
@@ -243,6 +255,7 @@ cali_variant_to_uint(cali_variant_t v, bool* okptr)
     case CALI_TYPE_INV:
     case CALI_TYPE_USR:
     case CALI_TYPE_STRING:
+    case CALI_TYPE_PTR:
         ok  = false;
         break;
     case CALI_TYPE_INT:
@@ -274,11 +287,11 @@ cali_variant_to_uint(cali_variant_t v, bool* okptr)
  *  This function returns the variant's value as double.
  *  Numeric types (bool, int, uint, double, type) will be converted to double,
  *  and value pointed to by \a okptr is set to `true`.
- *  For other types (blobs and strings) the function returns zero, and the 
+ *  For other types (blobs and strings) the function returns zero, and the
  *  value pointed to by \a okptr is set to `false`.
- *  
+ *
  *  \param v     The input variant
- *  \param okptr If non-NULL, indicate success or failure int the referenced variable.   
+ *  \param okptr If non-NULL, indicate success or failure int the referenced variable.
  *  \return The double value. Zero if the conversion was unsuccesful.
  */
 double
@@ -294,6 +307,7 @@ cali_variant_to_double(cali_variant_t v, bool* okptr)
     case CALI_TYPE_INV:
     case CALI_TYPE_USR:
     case CALI_TYPE_STRING:
+    case CALI_TYPE_PTR:
         ok  = false;
         break;
     case CALI_TYPE_INT:
@@ -325,11 +339,11 @@ cali_variant_to_double(cali_variant_t v, bool* okptr)
  *  This function returns the variant's value as type.
  *  For boolean and integer types (int, uint, addr, bool), the returned
  *  value is `false` if the value is equal to 0, and `true` otherwise.
- *  For other types the function returns `false`, and the 
+ *  For other types the function returns `false`, and the
  *  value pointed to by \a okptr is set to `false`.
- *  
+ *
  *  \param v     The input variant
- *  \param okptr If non-NULL, indicate success or failure int the referenced variable.   
+ *  \param okptr If non-NULL, indicate success or failure int the referenced variable.
  *  \return The boolean value; `false` if the conversion was unsuccesful.
  */
 bool
@@ -366,11 +380,11 @@ cali_variant_to_bool(cali_variant_t v, bool* okptr)
  *
  *  This function returns the variant's value as type.
  *  This is only successful for TYPE variants.
- *  For other types the function returns CALI_TYPE_INV, and the 
+ *  For other types the function returns CALI_TYPE_INV, and the
  *  value pointed to by \a okptr is set to `false`.
- *  
+ *
  *  \param v     The input variant
- *  \param okptr If non-NULL, indicate success or failure int the referenced variable.   
+ *  \param okptr If non-NULL, indicate success or failure int the referenced variable.
  *  \return The type value. CALI_TYPE_INV if the conversion was unsuccesful.
  */
 cali_attr_type
@@ -418,7 +432,7 @@ cali_variant_compare(cali_variant_t lhs, cali_variant_t rhs)
             {
                 int lhssize = (int) _EXTRACT_SIZE(lhs.type_and_size);
                 int rhssize = (int) _EXTRACT_SIZE(rhs.type_and_size);
-                int cmp     = memcmp(lhs.value.unmanaged_ptr, rhs.value.unmanaged_ptr,
+                int cmp     = memcmp(lhs.value.unmanaged_const_ptr, rhs.value.unmanaged_const_ptr,
                                      imin(lhssize, rhssize));
 
                 return (cmp ? cmp : (lhssize - rhssize));
@@ -426,8 +440,8 @@ cali_variant_compare(cali_variant_t lhs, cali_variant_t rhs)
         case CALI_TYPE_STRING:
             {
                 int lhssize = (int) _EXTRACT_SIZE(lhs.type_and_size);
-                int rhssize = (int) _EXTRACT_SIZE(rhs.type_and_size);                
-                int cmp     = strncmp(lhs.value.unmanaged_ptr, rhs.value.unmanaged_ptr,
+                int rhssize = (int) _EXTRACT_SIZE(rhs.type_and_size);
+                int cmp     = strncmp(lhs.value.unmanaged_const_ptr, rhs.value.unmanaged_const_ptr,
                                       imin(lhssize, rhssize));
 
                 return (cmp ? cmp : (lhssize - rhssize));
@@ -451,6 +465,8 @@ cali_variant_compare(cali_variant_t lhs, cali_variant_t rhs)
             }
         case CALI_TYPE_TYPE:
             return ((int) lhs.value.v_type) - ((int) rhs.value.v_type);
+        case CALI_TYPE_PTR:
+            return (int) (lhs.value.unmanaged_ptr  - rhs.value.unmanaged_ptr);
         }
     }
 
@@ -461,16 +477,16 @@ bool
 cali_variant_eq(cali_variant_t lhs, cali_variant_t rhs)
 {
     if (lhs.type_and_size != rhs.type_and_size)
-        return false;    
+        return false;
 
     switch ( _EXTRACT_TYPE(lhs.type_and_size) ) {
     case CALI_TYPE_USR:
     case CALI_TYPE_STRING:
         {
-            if (lhs.value.unmanaged_ptr == rhs.value.unmanaged_ptr)
+            if (lhs.value.unmanaged_const_ptr == rhs.value.unmanaged_const_ptr)
                 return true;
             else
-                return 0 == memcmp(lhs.value.unmanaged_ptr, rhs.value.unmanaged_ptr, 
+                return 0 == memcmp(lhs.value.unmanaged_const_ptr, rhs.value.unmanaged_const_ptr,
                                    _EXTRACT_SIZE(lhs.type_and_size));
         }
         break;
@@ -499,7 +515,7 @@ cali_variant_unpack(const unsigned char* buf, size_t* inc, bool *okptr)
     size_t p = 0;
 
     uint64_t ts = vldec_u64(buf, &p);
-    
+
     if (_EXTRACT_TYPE(ts) > CALI_MAXTYPE) {
         if (okptr)
             *okptr = false;
@@ -509,12 +525,11 @@ cali_variant_unpack(const unsigned char* buf, size_t* inc, bool *okptr)
 
     v.type_and_size = ts;
     v.value.v_uint  = vldec_u64(buf+p, &p);
-    
+
     if (inc)
         *inc  += p;
     if (okptr)
-        *okptr = true; 
+        *okptr = true;
 
     return v;
 }
-

--- a/src/common/test/test_variant.cpp
+++ b/src/common/test/test_variant.cpp
@@ -11,6 +11,7 @@ using namespace cali;
 TEST(Variant_Test, FromString) {
     const char* teststr = "My wonderful test string";
     uint64_t uval = 0xef10;
+    void* ptr = nullptr;
     
     const struct testcase_t {
         cali_attr_type type;
@@ -40,6 +41,8 @@ TEST(Variant_Test, FromString) {
         { CALI_TYPE_TYPE,   "int",   true,  Variant(CALI_TYPE_INT) },
         { CALI_TYPE_TYPE,   "bla",   false, Variant()      },
 
+        { CALI_TYPE_PTR,    "0",     false, Variant()      },
+
         { CALI_TYPE_INV, 0, false, Variant() }
     };
 
@@ -62,6 +65,7 @@ TEST(Variant_Test, PackUnpack) {
     const void*    val_5_inv  = NULL;
     cali_attr_type val_6_type = CALI_TYPE_ADDR;
     bool           val_7_bool = true;
+    void*          val_8_ptr  = this;
 
     cali::Variant  v_1_int_in(val_1_int);
     cali::Variant  v_2_uint_in(CALI_TYPE_UINT, &val_2_uint, sizeof(uint64_t));
@@ -70,11 +74,12 @@ TEST(Variant_Test, PackUnpack) {
     cali::Variant  v_5_inv_in;
     cali::Variant  v_6_type_in(val_6_type);
     cali::Variant  v_7_bool_in(val_7_bool);
+    cali::Variant  v_8_ptr_in(cali_make_variant_from_ptr(val_8_ptr));
 
-    unsigned char buf[160]; // must be >= 7*22 = 154 bytes
+    unsigned char buf[180]; // must be >= 8*22 = 154 bytes
     size_t pos = 0;
 
-    memset(buf, 0, 160);
+    memset(buf, 0, 180);
 
     pos += v_1_int_in.pack(buf+pos);
     pos += v_2_uint_in.pack(buf+pos);
@@ -83,8 +88,9 @@ TEST(Variant_Test, PackUnpack) {
     pos += v_5_inv_in.pack(buf+pos);
     pos += v_6_type_in.pack(buf+pos);
     pos += v_7_bool_in.pack(buf+pos);
+    pos += v_8_ptr_in.pack(buf+pos);
 
-    EXPECT_LE(pos, 154);
+    EXPECT_LE(pos, 176);
 
     bool ok = false;
     pos = 0;
@@ -103,25 +109,40 @@ TEST(Variant_Test, PackUnpack) {
     EXPECT_TRUE(ok && "v_6 unpack (type)");
     Variant v_7_bool_out = Variant::unpack(buf+pos, &pos, &ok);
     EXPECT_TRUE(ok && "v_7 unpack (bool)");
+    Variant v_8_ptr_out  = Variant::unpack(buf+pos, &pos, &ok);
+    EXPECT_TRUE(ok && "v_8 unpack (ptr)");
 
     EXPECT_EQ(v_1_int_out.type(), CALI_TYPE_INT);
     EXPECT_EQ(v_1_int_out.to_int(), val_1_int);
+    EXPECT_EQ(v_1_int_in, v_1_int_out);
 
     EXPECT_EQ(v_2_uint_out.type(), CALI_TYPE_UINT);
     EXPECT_EQ(v_2_uint_out.to_uint(), val_2_uint);
+    EXPECT_EQ(v_2_uint_in, v_2_uint_out);
 
     EXPECT_EQ(v_3_str_out.type(), CALI_TYPE_STRING);
+    EXPECT_EQ(v_3_str_out.size(), strlen(val_3_str)+1);
+    EXPECT_EQ(v_3_str_out.data(), static_cast<const void*>(val_3_str));
     EXPECT_EQ(v_3_str_out.to_string(), std::string(val_3_str));
+    EXPECT_EQ(v_3_str_in, v_3_str_out);
 
     EXPECT_EQ(v_4_dbl_out.type(), CALI_TYPE_DOUBLE);
     EXPECT_EQ(v_4_dbl_out.to_double(), val_4_dbl);
+    EXPECT_EQ(v_4_dbl_in, v_4_dbl_out);
 
     EXPECT_EQ(v_5_inv_out.type(), CALI_TYPE_INV);
     EXPECT_TRUE(v_5_inv_out.empty());
+    EXPECT_EQ(v_5_inv_in, v_5_inv_out);
 
     EXPECT_EQ(v_6_type_out.type(), CALI_TYPE_TYPE);
     EXPECT_EQ(v_6_type_out.to_attr_type(), val_6_type);
+    EXPECT_EQ(v_6_type_in, v_6_type_out);
 
     EXPECT_EQ(v_7_bool_out.type(), CALI_TYPE_BOOL);
     EXPECT_EQ(v_7_bool_out.to_bool(), val_7_bool);
+    EXPECT_EQ(v_7_bool_in, v_7_bool_out);
+
+    EXPECT_EQ(v_8_ptr_out.type(), CALI_TYPE_PTR);
+    EXPECT_EQ(v_8_ptr_out.get_ptr(), val_8_ptr);
+    EXPECT_EQ(v_8_ptr_in, v_8_ptr_out);
 }

--- a/src/reader/CaliperMetadataDB.cpp
+++ b/src/reader/CaliperMetadataDB.cpp
@@ -113,12 +113,13 @@ struct CaliperMetadataDB::CaliperMetadataDBImpl
             {  8, 8,  { CALI_TYPE_STRING, "cali.attribute.name",  19 }, 3 },
             {  9, 8,  { CALI_TYPE_STRING, "cali.attribute.type",  19 }, 7 },
             { 10, 8,  { CALI_TYPE_STRING, "cali.attribute.prop",  19 }, 1 },
-            { CALI_INV_ID, CALI_INV_ID, { }, CALI_INV_ID },
+            { 11, 9,  { CALI_TYPE_PTR    }, CALI_INV_ID },
+            { CALI_INV_ID, CALI_INV_ID, { }, CALI_INV_ID }
         };
 
         // Create nodes
 
-        m_nodes.resize(11);
+        m_nodes.resize(12);
 
         for (const NodeInfo* info = bootstrap_nodes; info->id != CALI_INV_ID; ++info) {
             Node* node = new Node(info->id, info->attr_id, info->data);


### PR DESCRIPTION
Store thread-local trace and aggregation buffers on thread blackboard instead of having them in their own thread-local variables. This prevents issues with the undefined destruction order of thread-local static variables. Also simplifies the code.  