### PR TITLE
C++ Metadata Interface

### DIFF
--- a/include/caliper/Annotation.h
+++ b/include/caliper/Annotation.h
@@ -41,7 +41,7 @@
 #define CALI_ANNOTATION_H
 
 #include "common/cali_types.h"
-
+#include <map>
 namespace cali
 {
     
@@ -134,6 +134,16 @@ public:
     /// \param opt  %Attribute flags. Bitwise OR combination 
     ///   of \ref cali_attr_properties values.
     Annotation(const char* name, int opt = 0);
+    
+    using MetadataListType = std::map<const char*, Variant>;
+    /// \brief Creates an annotation object to manipulate 
+    ///   the context attribute with the given \a name. 
+    /// 
+    /// \param name The attribute name
+    /// \param opt  %Attribute flags. Bitwise OR combination 
+    ///   of \ref cali_attr_properties values.
+    /// \param metadata: a map of 
+    Annotation(const char* name, const MetadataListType& metadata, int opt=0);
 
     Annotation(const Annotation&);
 

--- a/include/caliper/Annotation.h
+++ b/include/caliper/Annotation.h
@@ -135,7 +135,7 @@ public:
     ///   of \ref cali_attr_properties values.
     Annotation(const char* name, int opt = 0);
     
-    using MetadataListType = std::map<const char*, Variant>;
+    typedef std::map<const char*, Variant> MetadataListType ;
     /// \brief Creates an annotation object to manipulate 
     ///   the context attribute with the given \a name. 
     /// 

--- a/include/caliper/Caliper.h
+++ b/include/caliper/Caliper.h
@@ -267,6 +267,8 @@ public:
 
     size_t    num_attributes() const;
 
+    bool      attribute_exists(const std::string& name) const;
+
     Attribute get_attribute(cali_id_t id) const;
     Attribute get_attribute(const std::string& name) const;
 

--- a/src/caliper/Annotation.cpp
+++ b/src/caliper/Annotation.cpp
@@ -187,10 +187,12 @@ struct Annotation::Impl {
     }
 
     void set(const Variant& data) {
+        cali_attr_type type = data.type();
+        establish_metadata(type);
         Caliper   c;
-        Attribute attr = get_attribute(c, data.type());
+        Attribute attr = get_attribute(c, type());
 
-        if ((attr.type() == data.type()) && attr.type() != CALI_TYPE_INV)
+        if ((attr.type() == type()) && attr.type() != CALI_TYPE_INV)
             c.set(attr, data);
     }
 

--- a/src/caliper/Annotation.cpp
+++ b/src/caliper/Annotation.cpp
@@ -190,9 +190,9 @@ struct Annotation::Impl {
         cali_attr_type type = data.type();
         establish_metadata(type);
         Caliper   c;
-        Attribute attr = get_attribute(c, type());
+        Attribute attr = get_attribute(c, type);
 
-        if ((attr.type() == type()) && attr.type() != CALI_TYPE_INV)
+        if ((attr.type() == type) && attr.type() != CALI_TYPE_INV)
             c.set(attr, data);
     }
 

--- a/src/caliper/Caliper.cpp
+++ b/src/caliper/Caliper.cpp
@@ -563,6 +563,28 @@ Caliper::create_attribute(const std::string& name, cali_attr_type type, int prop
 /// While it should be signal safe, we do not recommend using this function in a signal handler.
 ///
 /// \param name The attribute name
+/// \return true if the attribute exists, false otherwise
+
+bool
+Caliper::attribute_exists(const std::string& name) const
+{
+    std::lock_guard<::siglock>
+        g(sT->lock);
+
+    sG->attribute_lock.lock();
+
+    auto it = sG->attribute_nodes.find(name);
+
+    sG->attribute_lock.unlock();
+
+    return (it!= sG->attribute_nodes.end());
+}
+
+/// \brief Find an attribute by name
+///
+/// While it should be signal safe, we do not recommend using this function in a signal handler.
+///
+/// \param name The attribute name
 /// \return Attribute object, or Attribute::invalid if not found.
 
 Attribute


### PR DESCRIPTION
@daboehme , I'm a little unsure what's expensive in Caliper, I think my implementation is a good one, but want some backup to make sure I'm not screwing anything up.

On Annotation creation, we look up Annotations of the same name. If the Annotation doesn't already exist, we fill up the metadata items with what they need (keys and values).

On a begin or a set, we try to establish the metadata. First we check if any metadata keys exist, and if not we short circuit out. If keys exist, we create the attribute. Once done, we wipe out the metadata keys, which will lead future calls to establish_metadata to short circuit out.