### PR TITLE
Fix for the BG/Q Clang compilers. Also, PGI's handling of Rapidjson

### DIFF
--- a/src/services/spot/Spot.cpp
+++ b/src/services/spot/Spot.cpp
@@ -36,6 +36,7 @@
 
 #include "caliper/CaliperService.h"
 
+#include "caliper/caliper-config.h"
 #include "caliper/Caliper.h"
 #include "caliper/SnapshotRecord.h"
 
@@ -49,12 +50,17 @@
 #include "caliper/common/OutputStream.h"
 #include "caliper/common/RuntimeConfig.h"
 #include "caliper/common/util/split.hpp"
-
+#ifdef CALIPER_REDUCED_CONSTEXPR_USAGE
+#define OLD_GNUC __GNUC__
+#undef __GNUC__
+#endif
 #include "rapidjson/rapidjson.h"
 #include "rapidjson/document.h"
 #include "rapidjson/ostreamwrapper.h"
 #include "rapidjson/writer.h"
-
+#ifdef CALIPER_REDUCED_CONSTEXPR_USAGE
+#define __GNUC_ OLD_GNUC
+#endif
 #include <iostream>
 #include <sstream>
 #include <iterator>


### PR DESCRIPTION
Sorry about this one. Turns out that we had two bugs

1) BG/Q Clang not supporting std::vector<T>::emplace
2) PGI having trouble with rapidjson, our JSON handling library

Solving (1) was template metaprogramming: check if vector emplace exists (check that its return type equals its return type). If it does, use emplace, otherwise use insert. If you want to just use insert everywhere, feel free, I just wanted to use it everywhere we can.

Solving (2) was bad preprocessor hacking. If we're using PGI, before including PGI, I mess with our preprocessor definitions, then restore them after [(thanks to these folks for the idea.)](https://github.com/Tencent/rapidjson/issues/1115)

None of this is pretty, but it makes us more portable.