### PR TITLE
Remove constexpr spinlock constructor. Fixes #160

### DIFF
--- a/include/caliper/common/util/spinlock.hpp
+++ b/include/caliper/common/util/spinlock.hpp
@@ -10,12 +10,11 @@ namespace util
 {
     
 class spinlock {
-    std::atomic_flag m_lock;
+    std::atomic_flag m_lock = ATOMIC_FLAG_INIT;
 
 public:
 
-    constexpr spinlock()
-        : m_lock { 0 }
+    spinlock()
         { }
 
     void lock() {

--- a/src/caliper/Blackboard.h
+++ b/src/caliper/Blackboard.h
@@ -75,7 +75,7 @@ class Blackboard {
     
 public:
 
-    CONSTEXPR_UNLESS_PGI Blackboard()
+    Blackboard()
         : hashtable       {   },
           ref_toc         { 0 },
           ref_toctoc      { 0 },


### PR DESCRIPTION
Per the standard, std::atomic_flag constructor doesn't have to be constexpr, though the Apple compiler was the only one having a problem with this.