### PR TITLE
"Forwarding" Annotation calls to Variant

### DIFF
--- a/include/caliper/Annotation.h
+++ b/include/caliper/Annotation.h
@@ -224,19 +224,19 @@ public:
 #else
     template<typename Arg>
     Annotation& begin(const Arg& arg){
-        return begin(arg);
+        return begin(Variant(arg));
     }
     template<typename Arg>
     Annotation& set(const Arg& arg){
-        return set(arg);
+        return set(Variant(arg));
     }
     template<typename Arg>
     Annotation& begin(Arg& arg){
-        return begin(arg);
+        return begin(Variant(arg));
     }
     template<typename Arg>
     Annotation& set(Arg& arg){
-        return set(arg);
+        return set(Variant(arg));
     }
 #endif
 

--- a/include/caliper/Annotation.h
+++ b/include/caliper/Annotation.h
@@ -42,6 +42,11 @@
 
 #include "common/cali_types.h"
 #include <map>
+
+#if __cplusplus >= 201103L
+#define CALI_FORWARDING_ENABLED
+#endif
+
 namespace cali
 {
     
@@ -202,6 +207,39 @@ public:
     /// \copydoc cali::Annotation::begin(int)
     Annotation& begin(const Variant& data);
 
+#ifdef CALI_FORWARDING_ENABLED
+    template<typename Arg, typename... Args>
+    struct head{
+        using type = Arg;
+    };
+
+    template<typename... Args>
+    auto begin(Args&&... args) -> typename std::enable_if<!std::is_same<typename head<Args...>::type,cali::Variant>::value,Annotation&>::type {
+        return begin(Variant(std::forward<Args>(args)...));
+    }
+    template<typename... Args>
+    auto set(Args&&... args) -> typename std::enable_if<!std::is_same<typename head<Args...>::type,cali::Variant>::value,Annotation&>::type {
+        return set(Variant(std::forward<Args>(args)...));
+    }
+#else
+    template<typename Arg>
+    Annotation& begin(const Arg& arg){
+        return begin(arg);
+    }
+    template<typename Arg>
+    Annotation& set(const Arg& arg){
+        return set(arg);
+    }
+    template<typename Arg>
+    Annotation& begin(Arg& arg){
+        return begin(arg);
+    }
+    template<typename Arg>
+    Annotation& set(Arg& arg){
+        return set(arg);
+    }
+#endif
+
     /// \}
     /// \name set() overloads
     /// \{
@@ -232,5 +270,8 @@ public:
 /// \} // AnnotationAPI group
     
 } // namespace cali
+
+#undef CALI_FORWARDING_ENABLED
+
 
 #endif

--- a/test/ci_app_tests/ci_test_basic.cpp
+++ b/test/ci_app_tests/ci_test_basic.cpp
@@ -20,7 +20,7 @@ int main()
     copy_ann.begin("loop");
 
     cali::Annotation iter_ann("iteration", CALI_ATTR_ASVALUE);
-
+    iter_ann.begin(uint64_t(5));
     for (int i = 0; i < count; ++i) {
         cali::Annotation::Guard
             g_iter_ann(iter_ann.begin(i));


### PR DESCRIPTION
This will allow us to do whatever we want in Variant, and have Annotation be able to play nicely with it. Good call by @mrzv that in the single-arg case we can do this without variadics, getting most of the benefit without C++11

The "std::enable_if" prevents infinite recursion, which I think would happen otherwise.

If this is good, we can put together another PR with changes to Variant including std::size_t and such