### PR TITLE
Fix initialization order bug 

### DIFF
--- a/include/caliper/ConfigManager.h
+++ b/include/caliper/ConfigManager.h
@@ -74,7 +74,7 @@ public:
 
     /// \brief Add a list of pre-defined configurations. Internal use.
     static void
-    add_controllers(const ConfigInfo*);
+    add_controllers(const ConfigInfo**);
 
     ConfigManager();
 

--- a/src/caliper/ConfigManager.cpp
+++ b/src/caliper/ConfigManager.cpp
@@ -19,7 +19,7 @@ namespace cali
 {
 
 // defined in controllers/controllers.cpp
-extern ConfigManager::ConfigInfo builtin_controllers_table[];
+extern const ConfigManager::ConfigInfo* builtin_controllers_table[];
 
 }
 
@@ -40,7 +40,7 @@ merge_new_elements(std::map<K, V>& to, const std::map<K, V>& from) {
 }
 
 struct ConfigInfoList {
-    const ConfigManager::ConfigInfo* configs;
+    const ConfigManager::ConfigInfo** configs;
     ConfigInfoList* next;
 };
 
@@ -139,36 +139,25 @@ struct ConfigManager::ConfigManagerImpl
     // Return config info object with given name, or null if not found
     const ConfigInfo*
     find_config(const std::string& name) {
-        const ::ConfigInfoList* lst_p = ::s_config_list;
-        const ConfigInfo* cfg_p = nullptr;
-
-        while (lst_p) {
-            cfg_p = lst_p->configs;
-
-            while (cfg_p && cfg_p->name && name != std::string(cfg_p->name))
-                ++cfg_p;
-
-            if (cfg_p && cfg_p->name)
-                break;
-
-            lst_p = lst_p->next;
-        }
-
-        if (cfg_p && !cfg_p->name)
-            cfg_p = nullptr;
-
-        return cfg_p;
+        for (const ::ConfigInfoList *i = ::s_config_list; i; i = i->next)
+           for (const ConfigInfo **j = i->configs; *j; j++) {
+               const ConfigInfo *cfg_p = *j;
+               if (cfg_p->name && cfg_p->name == name)
+                  return cfg_p;
+           }
+        return nullptr;
     }
 
     // Return true if key is an option in any config
     bool
     is_option(const std::string& key) {
-        for (const ::ConfigInfoList* lst_p = ::s_config_list; lst_p; lst_p = lst_p->next)
-            for (const ConfigInfo* cfg_p = lst_p->configs; cfg_p && cfg_p->name; ++cfg_p)
-                for (const char** opt = cfg_p->args; opt && *opt; ++opt)
-                    if (key == *opt)
-                        return true;
-
+        for (const ::ConfigInfoList *i = ::s_config_list; i; i = i->next)
+           for (const ConfigInfo **j = i->configs; *j; j++) {
+              const ConfigInfo *cfg_p = *j;
+              for (const char **opt = cfg_p->args; opt && *opt; opt++)
+                 if (key == std::string(*opt))
+                    return true;
+           }
         return false;
     }
 
@@ -326,7 +315,7 @@ ConfigManager::flush()
 }
 
 void
-ConfigManager::add_controllers(const ConfigManager::ConfigInfo* ctrlrs)
+ConfigManager::add_controllers(const ConfigManager::ConfigInfo** ctrlrs)
 {
     ::ConfigInfoList* elem = new ConfigInfoList { ctrlrs, ::s_config_list };
     s_config_list = elem;
@@ -338,8 +327,8 @@ ConfigManager::available_configs()
     std::vector<std::string> ret;
 
     for (const ConfigInfoList* lp = s_config_list; lp; lp = lp->next)
-        for (const ConfigInfo* cp = lp->configs; cp && cp->name; ++cp)
-            ret.push_back(cp->name);
+        for (const ConfigInfo** cp = lp->configs; *cp && (*cp)->name; ++cp)
+            ret.push_back((*cp)->name);
 
     return ret;
 }
@@ -350,8 +339,8 @@ ConfigManager::get_config_docstrings()
     std::vector<std::string> ret;
 
     for (const ConfigInfoList* lp = s_config_list; lp; lp = lp->next)
-        for (const ConfigInfo* cp = lp->configs; cp && cp->name; ++cp)
-            ret.push_back(cp->description);
+        for (const ConfigInfo** cp = lp->configs; *cp && (*cp)->name; ++cp)
+            ret.push_back((*cp)->description);
 
     return ret;
 }

--- a/src/caliper/controllers/controllers.cpp
+++ b/src/caliper/controllers/controllers.cpp
@@ -7,12 +7,11 @@ extern ConfigManager::ConfigInfo event_trace_controller_info;
 extern ConfigManager::ConfigInfo nvprof_controller_info;
 extern ConfigManager::ConfigInfo runtime_report_controller_info;
 
-ConfigManager::ConfigInfo builtin_controllers_table[] = {
-    event_trace_controller_info,
-    nvprof_controller_info,
-    runtime_report_controller_info,
-
-    { nullptr, nullptr, nullptr }
+ConfigManager::ConfigInfo* builtin_controllers_table[] = {
+    &event_trace_controller_info,
+    &nvprof_controller_info,
+    &runtime_report_controller_info,
+    nullptr
 };
 
 }

--- a/src/mpi-rt/setup_mpi.cpp
+++ b/src/mpi-rt/setup_mpi.cpp
@@ -44,11 +44,10 @@ CaliperService cali_mpi_services[] = {
 extern ConfigManager::ConfigInfo spot_controller_info;
 extern ConfigManager::ConfigInfo spot_v1_controller_info;
 
-ConfigManager::ConfigInfo mpi_controllers[] = {
-    spot_controller_info,
-    spot_v1_controller_info,
-
-    { nullptr, nullptr, nullptr }
+const ConfigManager::ConfigInfo *mpi_controllers[] = {
+    &spot_controller_info,
+    &spot_v1_controller_info,
+    nullptr
 };
 
 bool is_initialized = false;

--- a/src/tools/cali-query/cali-query.cpp
+++ b/src/tools/cali-query/cali-query.cpp
@@ -221,9 +221,11 @@ public:
     }
 };
 
-const ConfigManager::ConfigInfo caliquery_cfglist[] = {
-    { "progress", "progress\n Print cali-query progress (when processing multiple files).", nullptr, ProgressController::create },
-    { nullptr, nullptr, nullptr, nullptr }
+ConfigManager::ConfigInfo ProgressInfo = { "progress", "progress\n Print cali-query progress (when processing multiple files).", nullptr, ProgressController::create };
+
+const ConfigManager::ConfigInfo* caliquery_cfglist[] = {
+   &ProgressInfo,
+   nullptr
 };
 
 void setup_caliper_config(const Args& args)


### PR DESCRIPTION
Caliper had an initialization order bug with the intel compiler.  The ConfigInfo objects were being copied into ConfigInfoLists at initialization time.  But the intel compiler wasn't treating them as POD, which meant they were being initialized by a constructor.  If the copy ConfigInfo to ConfigInfoList constructor ran before the ConfigInfo constructor, then incomplete objects would get copied.

This makes the ConfigInfoList track ConfigInfo by pointer, rather than by copy.
