### PR TITLE
Fixed -Wformat-trunction warning with GCC by checking return value 

### DIFF
--- a/src/services/io/CurIOus/src/file_registry.c
+++ b/src/services/io/CurIOus/src/file_registry.c
@@ -51,8 +51,11 @@ int curious_register_file_by_fd(int fd) {
   char buf[BUF_SIZE];
   
   // append fd to fd_path
-  snprintf(fd_path + len, DIGITS, "%d", fd);
-
+  int trunc_ret = snprintf(fd_path + len, DIGITS, "%d", fd);
+  if(trunc_ret < 0 || trunc_ret >= DIGITS)
+    fprintf(stderr, "Warning! err code: %i. fd (%i) may be truncated in fd_path (%s)\n",
+	    trunc_ret, fd, fd_path);
+  
   // see where the link stored at fd_path goes
   size_t bytes_written = readlink(fd_path, buf, BUF_SIZE);
   


### PR DESCRIPTION
## Warning

```console
../external/caliper/src/services/io/CurIOus/src/file_registry.c: In function 'curious_register_file_by_fd':
../external/caliper/src/services/io/CurIOus/src/file_registry.c:54:36: warning: '%d' directive output may be truncated writing between 1 and 10 bytes into a region of size 6 [-Wformat-truncation=]
   snprintf(fd_path + len, DIGITS, "%d", fd);
                                    ^~
../external/caliper/src/services/io/CurIOus/src/file_registry.c:54:35: note: directive argument in the range [0, 2147483647]
   snprintf(fd_path + len, DIGITS, "%d", fd);
                                   ^~~~
In file included from /usr/include/stdio.h:862,
                 from ../external/caliper/src/services/io/CurIOus/src/file_registry.c:4:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:64:10: note: '__builtin___snprintf_chk' output between 2 and 11 bytes into a destination of size 6
   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        __bos (__s), __fmt, __va_arg_pack ());
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

## Original 

```c
  // append fd to fd_path                                                                                                                                                                                                                     
  snprintf(fd_path + len, DIGITS, "%d", fd);
```

## Modification

```c
  // append fd to fd_path                                                                                                                                                                                                                     
  int trunc_ret = snprintf(fd_path + len, DIGITS, "%d", fd);
  if(trunc_ret < 0 || trunc_ret >= DIGITS)
    fprintf(stderr, "Warning! err code: %i. fd (%i) may be truncated in fd_path (%s)\n",
            trunc_ret, fd, fd_path);
```

Based on [snprintf](http://www.cplusplus.com/reference/cstdio/snprintf/) which states for 

```c
int snprintf ( char * s, size_t n, const char * format, ... );
```

w.r.t. the return value:

> The number of characters that would have been written if n had been sufficiently large, not counting the terminating null character.
> If an encoding error occurs, a negative number is returned.
> Notice that only when this returned value is non-negative and less than n, the string has been completely written.

