### PR TITLE
Timestamp service: Change precision of timestamps to nanoseconds

### DIFF
--- a/src/services/timestamp/Timestamp.cpp
+++ b/src/services/timestamp/Timestamp.cpp
@@ -179,7 +179,8 @@ class Timestamp
 
         if (record_timestamp && (scope & CALI_SCOPE_PROCESS))
             sbuf->append(timestamp_attr.id(),
-                         Variant(cali_make_variant_from_uint(chrono::system_clock::to_time_t(chrono::system_clock::now()))));
+                         Variant(cali_make_variant_from_uint(
+                                 chrono::duration_cast<chrono::nanoseconds>(chrono::system_clock::now().time_since_epoch()).count())));
     }
 
     void post_init_cb(Caliper* c, Channel* chn) {


### PR DESCRIPTION
As you may know (at least I was told you know) we are integrating Caliper into our monitoring framework [DCDB](http://dcdb.it). For this we would like the timestamp service to provide absolute timestamps with sub-second precision.
Ideally, the timestamps use nanosecond precision like in this PR, but anything more fine grained than seconds would do the trick.
Another option would be to make the precision configurable like for the snapshot duration.
Let me know what you think