### PR TITLE
Update built-in gotcha's open() wrapper. Fixes #249

### DIFF
--- a/ext/gotcha/src/libc_wrappers.c
+++ b/ext/gotcha/src/libc_wrappers.c
@@ -358,7 +358,12 @@ int gotcha_open(const char *pathname, int flags, ...)
    }
    va_end(args);
 
+#if defined(SYS_open)
    result = syscall(SYS_open, pathname, flags, mode);
+#else
+   result = syscall(SYS_openat, AT_FDCWD, pathname, flags, mode);
+#endif
+
    if (result >= 0)
       return (int) result;
    


### PR DESCRIPTION
Pull in change from upstream gotcha to fix #249. Thanks @mastino for reporting.