### PR TITLE
Mark region end mismatches as errors by default

### DIFF
--- a/include/caliper/common/cali_types.h
+++ b/include/caliper/common/cali_types.h
@@ -2,8 +2,8 @@
  * See top-level LICENSE file for details.
  */
 
-/** 
- * \file  cali_types.h 
+/**
+ * \file  cali_types.h
  * \brief Context annotation library typedefs
  */
 
@@ -40,12 +40,12 @@ typedef enum {
 #define CALI_MAXTYPE CALI_TYPE_PTR
 
 /**
- * \brief 
+ * \brief
  */
-const char* 
+const char*
 cali_type2string(cali_attr_type type);
 
-cali_attr_type 
+cali_attr_type
 cali_string2type(const char* str);
 
 /**
@@ -59,21 +59,26 @@ typedef enum {
   /** \brief Default value */
   CALI_ATTR_DEFAULT       =     0,
 
-  /** 
+  /**
    * \brief Store directly as key:value pair, not in the context tree.
    *
-   * Attributes with this property will be not be put into the context
+   * Entries with this property will be not be put into the context
    * tree, but stored directly as key:value pairs on the blackboard
    * and in snapshot records. ASVALUE attributes cannot be
    * nested. Only applicable to scalar data types.
    */
   CALI_ATTR_ASVALUE       =     1,
-  /** \brief Create a separate context tree root node for this attribute. */
+
+  /** \brief Create a separate context tree root node for this attribute.
+   *
+   * Useful for attributes that form overlapping hierarchies separate from
+   * the main region stack.
+   */
   CALI_ATTR_NOMERGE       =     2,
   /** \brief Process-scope attribute. Shared between all threads. */
   CALI_ATTR_SCOPE_PROCESS =    12, /* scope flags are mutually exclusive */
   /** \brief Thread-scope attribute. */
-  CALI_ATTR_SCOPE_THREAD  =    20, 
+  CALI_ATTR_SCOPE_THREAD  =    20,
   /** \brief Task-scope attribute. Currently unused. */
   CALI_ATTR_SCOPE_TASK    =    24,
 
@@ -84,7 +89,7 @@ typedef enum {
   CALI_ATTR_HIDDEN        =   128,
 
   /** \brief Begin/end calls are properly aligned with the call stack.
-   * 
+   *
    * Indicates that \a begin/end calls for this attribute are
    * correctly nested with the call stack and other NESTED attributes.
    * That is, an active region of a NESTED attribute does not
@@ -92,17 +97,25 @@ typedef enum {
    * regions.
    */
   CALI_ATTR_NESTED        =   256,
-  
+
   /** \brief A metadata attribute describing global information
    *    for a measurement run
    *
    * Global attributes represent metadata associated with an application
-   * run (e.g., application executable name and version, start date and 
+   * run (e.g., application executable name and version, start date and
    * time, and so on). They may be written in a separate metadata section
-   * in some output formats. For distributed programs (e.g. MPI), 
+   * in some output formats. For distributed programs (e.g. MPI),
    * global attributes should have the same value on each process.
    */
-  CALI_ATTR_GLOBAL        =   512
+  CALI_ATTR_GLOBAL        =   512,
+
+  /** \brief This attribute is not aligned with stacked begin/end regions.
+   *
+   * Entries with this property may still be merged into a single context
+   * tree branch, but one that is separate from the properly nested
+   * region branch. Stack nesting checks are skipped.
+   */
+  CALI_ATTR_UNALIGNED     =  1024
 } cali_attr_properties;
 
 #define CALI_ATTR_SCOPE_MASK 60
@@ -113,13 +126,13 @@ typedef enum {
  * \param  buf  Buffer to write string to
  * \param  len  Length of string buffer
  * \return      -1 if provided buffer is too short; length of written string otherwise
- */  
+ */
 int
 cali_prop2string(int prop, char* buf, size_t len);
 
 int
 cali_string2prop(const char*);
-  
+
 typedef enum {
   CALI_OP_SUM = 1,
   CALI_OP_MIN = 2,

--- a/src/caliper/Caliper.cpp
+++ b/src/caliper/Caliper.cpp
@@ -518,6 +518,12 @@ struct Caliper::GlobalData
         Log(1).stream() << "Initialized" << std::endl;
     }
 
+    // Get the attribute key, which determines the blackboard slot for each
+    // attribute. By default, we merge most attributes into two slots:
+    // region_key for region-type (begin/end) attributes, unaligned_key for
+    // set-type attributes. We skip stack nesting checks for unaligned
+    // attributes. Immediate (as_value) and nomerge attributes get
+    // their own slots.
     inline const Attribute&
     get_key(const Attribute& attr) const {
         int prop = attr.properties();

--- a/src/caliper/cali.cpp
+++ b/src/caliper/cali.cpp
@@ -508,7 +508,7 @@ cali_set_double_byname(const char* attr_name, double val)
 {
     Caliper   c;
     Attribute attr =
-        c.create_attribute(attr_name, CALI_TYPE_DOUBLE, CALI_ATTR_DEFAULT);
+        c.create_attribute(attr_name, CALI_TYPE_DOUBLE, CALI_ATTR_UNALIGNED);
 
     c.set(attr, Variant(val));
 }
@@ -518,7 +518,7 @@ cali_set_int_byname(const char* attr_name, int val)
 {
     Caliper   c;
     Attribute attr =
-        c.create_attribute(attr_name, CALI_TYPE_INT, CALI_ATTR_DEFAULT);
+        c.create_attribute(attr_name, CALI_TYPE_INT, CALI_ATTR_UNALIGNED);
 
     c.set(attr, Variant(val));
 }
@@ -528,7 +528,7 @@ cali_set_string_byname(const char* attr_name, const char* val)
 {
     Caliper   c;
     Attribute attr =
-        c.create_attribute(attr_name, CALI_TYPE_STRING, CALI_ATTR_DEFAULT);
+        c.create_attribute(attr_name, CALI_TYPE_STRING, CALI_ATTR_UNALIGNED);
 
     c.set(attr, Variant(CALI_TYPE_STRING, val, strlen(val)));
 }
@@ -550,7 +550,7 @@ cali_set_global_double_byname(const char* name, double val)
 {
     Caliper   c;
     Attribute attr =
-        c.create_attribute(name, CALI_TYPE_DOUBLE, CALI_ATTR_GLOBAL | CALI_ATTR_SKIP_EVENTS);
+        c.create_attribute(name, CALI_TYPE_DOUBLE, CALI_ATTR_GLOBAL | CALI_ATTR_UNALIGNED | CALI_ATTR_SKIP_EVENTS);
 
     // TODO: check for existing incompatible attribute key
 
@@ -562,7 +562,7 @@ cali_set_global_int_byname(const char* name, int val)
 {
     Caliper   c;
     Attribute attr =
-        c.create_attribute(name, CALI_TYPE_INT, CALI_ATTR_GLOBAL | CALI_ATTR_SKIP_EVENTS);
+        c.create_attribute(name, CALI_TYPE_INT, CALI_ATTR_GLOBAL | CALI_ATTR_UNALIGNED | CALI_ATTR_SKIP_EVENTS);
 
     // TODO: check for existing incompatible attribute key
 
@@ -574,7 +574,7 @@ cali_set_global_string_byname(const char* name, const char* val)
 {
     Caliper   c;
     Attribute attr =
-        c.create_attribute(name, CALI_TYPE_STRING, CALI_ATTR_GLOBAL | CALI_ATTR_SKIP_EVENTS);
+        c.create_attribute(name, CALI_TYPE_STRING, CALI_ATTR_GLOBAL | CALI_ATTR_UNALIGNED | CALI_ATTR_SKIP_EVENTS);
 
     // TODO: check for existing incompatible attribute key
 
@@ -586,7 +586,7 @@ cali_set_global_uint_byname(const char* name, uint64_t val)
 {
     Caliper   c;
     Attribute attr =
-        c.create_attribute(name, CALI_TYPE_UINT, CALI_ATTR_GLOBAL | CALI_ATTR_SKIP_EVENTS);
+        c.create_attribute(name, CALI_TYPE_UINT, CALI_ATTR_GLOBAL | CALI_ATTR_UNALIGNED | CALI_ATTR_SKIP_EVENTS);
 
     // TODO: check for existing incompatible attribute key
 

--- a/src/caliper/test/test_channel_api.cpp
+++ b/src/caliper/test/test_channel_api.cpp
@@ -85,8 +85,6 @@ TEST(ChannelAPITest, C_API) {
     EXPECT_EQ(cali_channel_is_active(chn_b_id), 0);
     EXPECT_EQ(cali_channel_is_active(chn_c_id), 0);
 
-    cali_begin_int_byname("chn.c_api.not_b", 4477);
-
     cali_id_t attr_a = cali_find_attribute("chn.c_api.all");
 
     ASSERT_NE(attr_a, CALI_INV_ID);

--- a/src/common/cali_types.c
+++ b/src/common/cali_types.c
@@ -57,6 +57,7 @@ static const struct propmap_t {
   { "hidden",        CALI_ATTR_HIDDEN,        CALI_ATTR_HIDDEN      },
   { "nested",        CALI_ATTR_NESTED,        CALI_ATTR_NESTED      },
   { "global",        CALI_ATTR_GLOBAL,        CALI_ATTR_GLOBAL      },
+  { "unaligned",     CALI_ATTR_UNALIGNED,     CALI_ATTR_UNALIGNED   },
   { 0, CALI_ATTR_DEFAULT, CALI_ATTR_DEFAULT }
 };
 

--- a/src/services/pthread/PthreadService.cpp
+++ b/src/services/pthread/PthreadService.cpp
@@ -61,7 +61,7 @@ cali_pthread_create_wrapper(pthread_t *thread, const pthread_attr_t *attr,
 {
     decltype(&pthread_create) orig_pthread_create =
         reinterpret_cast<decltype(&pthread_create)>(gotcha_get_wrappee(orig_pthread_create_handle));
-    
+
     return (*orig_pthread_create)(thread, attr, thread_wrapper, new wrapper_args({ fn, arg }));
 }
 
@@ -71,7 +71,7 @@ post_init_cb(Caliper* c, Channel* channel)
     channel->events().subscribe_attribute(c, channel, id_attr);
 
     if (!is_wrapped) {
-        struct gotcha_binding_t pthread_binding[] = { 
+        struct gotcha_binding_t pthread_binding[] = {
             { "pthread_create", (void*) cali_pthread_create_wrapper, &orig_pthread_create_handle }
         };
 
@@ -79,16 +79,16 @@ post_init_cb(Caliper* c, Channel* channel)
                     "caliper/pthread");
 
         is_wrapped = true;
-        
+
         uint64_t id = static_cast<uint64_t>(pthread_self());
-        
+
         c->set(master_attr, Variant(true));
         c->set(id_attr,     Variant(cali_make_variant_from_uint(id)));
     }
 }
 
 // Initialization routine.
-void 
+void
 pthreadservice_initialize(Caliper* c, Channel* chn)
 {
     Attribute subscription_attr = c->get_attribute("subscription_event");
@@ -96,11 +96,13 @@ pthreadservice_initialize(Caliper* c, Channel* chn)
 
     id_attr =
         c->create_attribute("pthread.id", CALI_TYPE_UINT,
-                            CALI_ATTR_SCOPE_THREAD,
+                            CALI_ATTR_SCOPE_THREAD |
+                            CALI_ATTR_UNALIGNED,
                             1, &subscription_attr, &v_true);
     master_attr =
         c->create_attribute("pthread.is_master", CALI_TYPE_BOOL,
                             CALI_ATTR_SCOPE_THREAD |
+                            CALI_ATTR_UNALIGNED    |
                             CALI_ATTR_SKIP_EVENTS);
 
     chn->events().post_init_evt.connect(

--- a/src/tools/cali-query/cali-query.cpp
+++ b/src/tools/cali-query/cali-query.cpp
@@ -356,7 +356,7 @@ int main(int argc, const char* argv[])
                   << num_threads << " thread" << (num_threads == 1 ? "." : "s.")
                   << std::endl;
 
-    Annotation("cali-query.num-threads", CALI_ATTR_SCOPE_PROCESS | CALI_ATTR_SKIP_EVENTS).set(static_cast<int>(num_threads));
+    cali_set_global_int_byname("cali-query.num-threads", num_threads);
 
     CALI_MARK_END("Initialization");
 
@@ -372,7 +372,7 @@ int main(int argc, const char* argv[])
 
     auto thread_fn = [&](unsigned t) {
         Annotation::Guard
-            g_t(Annotation("thread", CALI_ATTR_SCOPE_THREAD).set(static_cast<int>(t)));
+            g_t(Annotation("thread", CALI_ATTR_SCOPE_THREAD).begin(static_cast<int>(t)));
 
         for (unsigned i = index++; i < files.size(); i = index++) { // "index++" is atomic read-mod-write
             const char* filename = (files[i].empty() ? "stdin" : files[i].c_str());

--- a/test/ci_app_tests/ci_test_binding.cpp
+++ b/test/ci_app_tests/ci_test_binding.cpp
@@ -24,7 +24,7 @@ public:
 
     void initialize(Caliper* c, Channel*) {
         m_my_attr = 
-            c->create_attribute("testbinding",  CALI_TYPE_STRING, CALI_ATTR_DEFAULT);
+            c->create_attribute("testbinding",  CALI_TYPE_STRING, CALI_ATTR_NOMERGE);
         m_prop_attr =
             c->create_attribute("testproperty", CALI_TYPE_INT,    CALI_ATTR_DEFAULT);
     }

--- a/test/ci_app_tests/ci_test_c_ann.c
+++ b/test/ci_app_tests/ci_test_c_ann.c
@@ -10,8 +10,8 @@ int main()
   cali_set_global_int_byname("global.int", 1337);
   cali_set_global_string_byname("global.string", "my global string");
   cali_set_global_uint_byname("global.uint", 42);
-                                
-  cali_id_t iter_attr = 
+
+  cali_id_t iter_attr =
     cali_create_attribute("iteration", CALI_TYPE_INT, CALI_ATTR_ASVALUE);
 
   cali_begin_string_byname("phase", "loop");
@@ -20,7 +20,7 @@ int main()
     cali_begin_int(iter_attr, i);
     cali_end(iter_attr);
   }
-  
+
   cali_end_byname("phase");
 
   cali_begin_byname("ci_test_c_ann.meta-attr");
@@ -31,13 +31,13 @@ int main()
     cali_make_variant_from_int(47);
 
   cali_id_t test_attr =
-      cali_create_attribute_with_metadata("test-attr-with-metadata", CALI_TYPE_STRING, CALI_ATTR_DEFAULT,
+      cali_create_attribute_with_metadata("test-attr-with-metadata", CALI_TYPE_STRING, CALI_ATTR_NOMERGE,
                                           1, &meta_attr, &meta_val);
 
   cali_set_string(test_attr, "abracadabra");
-  
+
   cali_end_byname("ci_test_c_ann.meta-attr");
-  
+
   cali_begin_byname("ci_test_c_ann.setbyname");
 
   cali_set_int_byname("attr.int", 20);

--- a/test/ci_app_tests/ci_test_thread.cpp
+++ b/test/ci_app_tests/ci_test_thread.cpp
@@ -14,12 +14,13 @@ void* thread_proc(void* arg)
 
     int thread_id = *(static_cast<int*>(arg));
 
-    cali::Annotation("my_thread_id", CALI_ATTR_SCOPE_THREAD).set(thread_id);
+    cali::Annotation::Guard
+        g( cali::Annotation("my_thread_id", CALI_ATTR_SCOPE_THREAD).begin(thread_id) );
 
     return NULL;
 }
 
-int main() 
+int main()
 {
     CALI_CXX_MARK_FUNCTION;
 
@@ -34,7 +35,7 @@ int main()
         c.create_channel("exp_nopthread", exp_nopthread_cfg);
 
     cali::RuntimeConfig exp_pthread_cfg;
-    
+
     exp_pthread_cfg.set("CALI_SERVICES_ENABLE", "event,trace,pthread,recorder");
     exp_pthread_cfg.set("CALI_CHANNEL_SNAPSHOT_SCOPES", "process,thread,channel");
     exp_pthread_cfg.set("CALI_RECORDER_FILENAME", "stdout");
@@ -53,8 +54,8 @@ int main()
     int       thread_ids[4] = { 16, 25, 36, 49 };
     pthread_t thread[4];
 
-    cali::Annotation("local",  CALI_ATTR_SCOPE_THREAD).set(99);
-    cali::Annotation("global", CALI_ATTR_SCOPE_PROCESS).set(999);
+    cali::Annotation("local",  CALI_ATTR_SCOPE_THREAD  | CALI_ATTR_UNALIGNED).set(99);
+    cali::Annotation("global", CALI_ATTR_SCOPE_PROCESS | CALI_ATTR_UNALIGNED).set(999);
 
     for (int i = 0; i < 4; ++i)
         pthread_create(&thread[i], NULL, thread_proc, &thread_ids[i]);

--- a/test/ci_app_tests/ci_test_thread.cpp
+++ b/test/ci_app_tests/ci_test_thread.cpp
@@ -7,15 +7,14 @@
 
 #include <pthread.h>
 
+cali_id_t thread_attr_id = CALI_INV_ID;
 
 void* thread_proc(void* arg)
 {
     CALI_CXX_MARK_FUNCTION;
 
     int thread_id = *(static_cast<int*>(arg));
-
-    cali::Annotation::Guard
-        g( cali::Annotation("my_thread_id", CALI_ATTR_SCOPE_THREAD).begin(thread_id) );
+    cali_set_int(thread_attr_id, thread_id);
 
     return NULL;
 }
@@ -23,6 +22,9 @@ void* thread_proc(void* arg)
 int main()
 {
     CALI_CXX_MARK_FUNCTION;
+
+    thread_attr_id =
+        cali_create_attribute("my_thread_id", CALI_TYPE_INT, CALI_ATTR_SCOPE_THREAD | CALI_ATTR_UNALIGNED);
 
     cali::Caliper c;
     cali::RuntimeConfig exp_nopthread_cfg;

--- a/test/ci_app_tests/test_pthread.py
+++ b/test/ci_app_tests/test_pthread.py
@@ -25,7 +25,7 @@ class CaliperThreadTest(unittest.TestCase):
         self.assertTrue(calitest.has_snapshot_with_keys(
             snapshots, {'local', 'global', 'function'}))
         self.assertTrue(calitest.has_snapshot_with_keys(
-            snapshots, {'pthread.id', 'pthread.is_master', 'my_thread_id', 'global', 'event.end#function'}))
+            snapshots, {'pthread.id', 'pthread.is_master', 'my_thread_id', 'global', 'function'}))
         self.assertTrue(calitest.has_snapshot_with_attributes(
             snapshots, {'my_thread_id' : '49',
                         'pthread.is_master' : 'false',


### PR DESCRIPTION
Caliper supports overlapping annotation regions (i.e., ```begin(A),begin(B),end(A),end(B)```), but usually this is indicates an error in the annotation placements rather than being intentional. It is inefficient, and in the worst case consumes lots of resources and leads to crashes. We therefore now stop region tracking and print an error message when we detect this situation. For intentionally overlapping regions, users should create attributes with the `CALI_ATTR_UNALIGNED` or `CALI_ATTR_NOMERGE` flags.

This change breaks Caliper region tracking in codes that have overlapping region annotations (usually inadvertently), even though it worked before. There's a config setting to restore the old behavior, but the best cause of action is to fix the annotations.