### PR TITLE
Fixed unused variable warnings in ChannelController.h

### DIFF
--- a/include/caliper/ChannelController.h
+++ b/include/caliper/ChannelController.h
@@ -58,7 +58,7 @@ protected:
     ///
     ///   This can be used to setup additional functionality, e.g.
     /// registering %Caliper callbacks.
-    virtual void  on_create(Caliper* c, Channel* chn) { }
+    virtual void  on_create(Caliper* /*c*/, Channel* /*chn*/) { }
 
 public:
 


### PR DESCRIPTION
- These two variables will cause compilation errors in projects compiling against caliper with `-Wall -Werror`