### PR TITLE
Filter adiak import categories

### DIFF
--- a/src/caliper/controllers/HatchetRegionProfileController.cpp
+++ b/src/caliper/controllers/HatchetRegionProfileController.cpp
@@ -48,8 +48,11 @@ public:
             if (opts.is_set("use.mpi"))
                 use_mpi = have_mpi && opts.is_enabled("use.mpi");
 
-            if (have_adiak)
+            if (have_adiak) {
                 config()["CALI_SERVICES_ENABLE"].append(",adiak_import");
+                config()["CALI_ADIAK_IMPORT_CATEGORIES"] =
+                    opts.get("adiak.import_categories", "2,3").to_string();
+            }
 
             if (use_mpi) {
                 config()["CALI_SERVICES_ENABLE"   ].append(",mpi,mpireport");
@@ -60,7 +63,7 @@ public:
                     opts.query_let("local", "")
                     + " select "
                     + opts.query_select("local", "*,sum(sum#time.duration) as time")
-                    + " group by " 
+                    + " group by "
                     + opts.query_groupby("local", "prop:nested,mpi.rank")
                     + " format " + format;
             } else {
@@ -68,9 +71,9 @@ public:
                 config()["CALI_REPORT_FILENAME"   ] = output;
                 config()["CALI_REPORT_CONFIG"     ] =
                     opts.query_let("local", "")
-                    + " select " 
+                    + " select "
                     + opts.query_select("local", "*,sum(sum#time.duration) as time")
-                    + " group by " 
+                    + " group by "
                     + opts.query_groupby("local", "prop:nested")
                     + " format " + format;
             }
@@ -114,7 +117,7 @@ const char* controller_spec =
     "{"
     " \"name\"        : \"hatchet-region-profile\","
     " \"description\" : \"Record a region time profile for processing with hatchet\","
-    " \"categories\"  : [ \"metric\", \"output\", \"region\" ],"
+    " \"categories\"  : [ \"adiak\", \"metric\", \"output\", \"region\" ],"
     " \"services\"    : [ \"aggregate\", \"event\", \"timestamp\" ],"
     " \"config\"      : "
     "   { \"CALI_CHANNEL_FLUSH_ON_EXIT\"      : \"false\","

--- a/src/caliper/controllers/HatchetSampleProfileController.cpp
+++ b/src/caliper/controllers/HatchetSampleProfileController.cpp
@@ -53,8 +53,11 @@ public:
             if (opts.is_set("use.mpi"))
                 use_mpi = have_mpi && opts.is_enabled("use.mpi");
 
-            if (have_adiak)
+            if (have_adiak) {
                 config()["CALI_SERVICES_ENABLE"].append(",adiak_import");
+                config()["CALI_ADIAK_IMPORT_CATEGORIES"] =
+                    opts.get("adiak.import_categories", "2,3").to_string();
+            }
 
             if (use_mpi) {
                 groupby += ",mpi.rank";
@@ -133,7 +136,7 @@ const char* controller_spec =
     " \"name\"        : \"hatchet-sample-profile\","
     " \"description\" : \"Record a sampling profile for processing with hatchet\","
     " \"services\"    : [ \"sampler\", \"trace\" ],"
-    " \"categories\"  : [ \"output\" ],"
+    " \"categories\"  : [ \"adiak\", \"output\" ],"
     " \"config\"      : { \"CALI_CHANNEL_FLUSH_ON_EXIT\": \"false\" },"
     " \"options\": "
     " ["

--- a/src/caliper/controllers/controllers.cpp
+++ b/src/caliper/controllers/controllers.cpp
@@ -478,6 +478,13 @@ const char* builtin_option_specs =
     " \"description\" : \"Output location ('stdout', 'stderr', or filename)\","
     " \"type\"        : \"string\","
     " \"category\"    : \"output\""
+    "},"
+    "{"
+    " \"name\"        : \"adiak.import_categories\","
+    " \"services\"    : [ \"adiak_import\" ],"
+    " \"description\" : \"Adiak import categories. Comma-separated list of integers.\","
+    " \"type\"        : \"string\","
+    " \"category\"    : \"adiak\""
     "}"
     "]";
 

--- a/src/mpi/controllers/SpotController.cpp
+++ b/src/mpi/controllers/SpotController.cpp
@@ -235,6 +235,8 @@ public:
 #ifdef CALIPER_HAVE_ADIAK
             if (opts.get("output", "").to_string() != "adiak")
                 config()["CALI_SERVICES_ENABLE"].append(",adiak_import");
+            config()["CALI_ADIAK_IMPORT_CATEGORIES"] =
+                opts.get("adiak.import_categories", "2,3").to_string();
 #endif
             m_opts.update_channel_config(config());
         }
@@ -261,7 +263,7 @@ const char* controller_spec =
     "{"
     " \"name\"        : \"spot\","
     " \"description\" : \"Record a time profile for the Spot web visualization framework\","
-    " \"categories\"  : [ \"metric\", \"output\", \"region\" ],"
+    " \"categories\"  : [ \"adiak\", \"metric\", \"output\", \"region\" ],"
     " \"services\"    : [ \"aggregate\", \"event\", \"timestamp\" ],"
     " \"config\"      : "
     "   { \"CALI_CHANNEL_FLUSH_ON_EXIT\"      : \"false\","


### PR DESCRIPTION
Adds the CALI_ADIAK_IMPORT_CATEGORIES config flag that lets users select adiak categories to import in the adiak_import service. It is accessible via the adiak.import_categories option in the ConfigManager.