### PR TITLE
Set cmake-policy CMP0063 for VISIBILITY_INLINES_HIDDEN and CMAKE_<LAN…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,16 @@
 cmake_minimum_required(VERSION 3.1)
 project (caliper C CXX)
 
+if(NOT CMAKE_VERSION VERSION_LESS 3.3)
+    # ensure visibility gets honored for all targets
+    cmake_policy(SET CMP0063 NEW)
+endif()
+
+# set the default visibility settings
+set(CMAKE_VISIBILITY_INLINES_HIDDEN OFF)
+set(CMAKE_C_VISIBILITY_PRESET "default")
+set(CMAKE_CXX_VISIBILITY_PRESET "default")
+
 # Version information
 set(CALIPER_MAJOR_VERSION 2)
 set(CALIPER_MINOR_VERSION 5)


### PR DESCRIPTION
…G>_VISIBILITY_PRESET

- OLD behavior for this policy is to ignore the visibility properties static libraries, object libraries, and executables without exports
- NEW behavior is to honor the visibility properties for all target types
- introduced in cmake 3.3
- see: 'cmake --help-policy CMP0063' for more info
- Also set CMAKE_{C,CXX}_VISIBILITY_PRESET to ON

I am doing this:

```cmake
# set these as the defaults
if(timemory_MASTER_PROJECT)
    set(CMAKE_VISIBILITY_INLINES_HIDDEN OFF CACHE BOOL "Add compile flag to hide symbols of inline functions")
    set(CMAKE_C_VISIBILITY_PRESET "default" CACHE STRING "Default visibility")
    set(CMAKE_CXX_VISIBILITY_PRESET "default" CACHE STRING "Default visibility")
else()
    set(CMAKE_VISIBILITY_INLINES_HIDDEN OFF)
    set(CMAKE_C_VISIBILITY_PRESET "default")
    set(CMAKE_CXX_VISIBILITY_PRESET "default")
endif()
```
when I am the top-level project. I cache these variables in order to propagate the value down to sub-projects. 
This results in about 6 instance of this warning in CMake 3.18+:

```console
CMake Warning (dev) at external/caliper/src/common/CMakeLists.txt:20 (add_library):
  Policy CMP0063 is not set: Honor visibility properties for all target
  types.  Run "cmake --help-policy CMP0063" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

  Target "caliper-common" of type "OBJECT_LIBRARY" has the following
  visibility properties set for CXX:

    CXX_VISIBILITY_PRESET
    VISIBILITY_INLINES_HIDDEN

  For compatibility CMake is not honoring them for this target.
```

I really only need this set to `OLD` or `NEW`:

```cmake
if(NOT CMAKE_VERSION VERSION_LESS 3.3)
    # ensure visibility gets honored for all targets
    cmake_policy(SET CMP0063 NEW)
endif()
```
and I set it to `NEW` because I included this:

```cmake
# set the default visibility settings
set(CMAKE_VISIBILITY_INLINES_HIDDEN OFF)
set(CMAKE_C_VISIBILITY_PRESET "default")
set(CMAKE_CXX_VISIBILITY_PRESET "default")
```

since I figured it was a good thing to set since if someone caches `CMAKE_<LANG>_VISIBILITY_PRESET` as `"hidden"` and added you as a sub-project then if would hide anything you didn't explicitly mark with `__attribute__((visibility("default")))`. Also, the above scenario could also potentially fix that issue we debugged previously with the `timemory.component.CaliperConfig` class in Python not actually updating your singleton.
