### PR TITLE
Added Kokkos metadata callback

### DIFF
--- a/src/services/kokkos/KokkosProfilingSymbols.cpp
+++ b/src/services/kokkos/KokkosProfilingSymbols.cpp
@@ -66,3 +66,8 @@ extern "C" void kokkosp_begin_deep_copy(const SpaceHandle dst_handle, const char
 extern "C" void kokkosp_end_deep_copy() {
     kokkosp_callbacks.kokkosp_end_deep_copy_callback();
 }
+#ifndef CALIPER_HAVE_ADIAK
+extern "C" void kokkosp_declare_metadata(const char* key, const char* value) {
+  cali::Annotation(key,CALI_ATTR_GLOBAL).set(value);
+}
+#endif


### PR DESCRIPTION
This adds a callback to Caliper for Kokkos metadata. Note that we guard this with Adiak not being defined, if we have Adiak we'll declare metadata there (link to that PR: https://github.com/LLNL/Adiak/pull/6 ). We should wait on the Adiak PR to merge this, if we do decide to merge this