### PR TITLE
Fix cmake 3.19 and python 3.8 build

### DIFF
--- a/cmake/WrapConfig.cmake
+++ b/cmake/WrapConfig.cmake
@@ -27,15 +27,8 @@ if (NOT Wrap_CONFIG_LOADED)
     set(file_path    ${CMAKE_CURRENT_BINARY_DIR}/${file_name})
     set(wrapper_path ${CMAKE_CURRENT_SOURCE_DIR}/${wrapper_name})
 
-    # Play nice with FindPythonInterp -- use the interpreter if it was found,
-    # otherwise use the script directly.
-    if (PYTHON_EXECUTABLE)
-      set(command ${PYTHON_EXECUTABLE})
-      set(script_arg ${Wrap_EXECUTABLE})
-    else()
-      set(command ${Wrap_EXECUTABLE})
-      set(script_arg "")
-    endif()
+    set(command ${CALI_PYTHON_EXECUTABLE})
+    set(script_arg ${Wrap_EXECUTABLE})
 
     # Backward compatibility for old FindMPIs that did not have MPI_C_INCLUDE_PATH
     if (NOT MPI_C_INCLUDE_PATH)


### PR DESCRIPTION
Caliper cannot be build if you have CMake 3.12 (or later) and only python 3. If you use CMake 3.12, `PYTHON_EXECUTABLE` is not set (https://github.com/LLNL/Caliper/blob/master/CMakeLists.txt#L353-L355). This means that we go in the else branch [here](https://github.com/LLNL/Caliper/blob/master/cmake/WrapConfig.cmake#L32-L38):
```
   if (PYTHON_EXECUTABLE)
      set(command ${PYTHON_EXECUTABLE})
      set(script_arg ${Wrap_EXECUTABLE})
    else()
      set(command ${Wrap_EXECUTABLE})
      set(script_arg "")
    endif()
```
and we call the script directly. But the [script](https://github.com/LLNL/Caliper/blob/27af6ac221f9419e8fb0f95a35e6f706ad4d0cbd/src/mpi/services/mpiwrap/wrap.py) has 
```
#!/usr/bin/env python
```
and doesn't work python 3. It should be 
```
#!/usr/bin/env python3
```

Since python is always required, we can always use `${CALI_PYTHON_EXECUTABLE}` to call the script.