### PR TITLE
Quote loop names in loop-report and spot. Fixes #345

### DIFF
--- a/src/mpi/controllers/LoopReportController.cpp
+++ b/src/mpi/controllers/LoopReportController.cpp
@@ -173,7 +173,7 @@ class LoopReportController : public cali::ChannelController
                 { "let",      block   },
                 { "select",   select  },
                 { "group by", "Block" },
-                { "where",    std::string("loop=")+loopname }
+                { "where",    std::string("loop=\"")+loopname+"\"" }
             }, false);
 
         return local_aggregate(c, db, CalQLParser(query.c_str()).spec());

--- a/src/mpi/controllers/SpotController.cpp
+++ b/src/mpi/controllers/SpotController.cpp
@@ -186,7 +186,7 @@ public:
                 { "let",      block },
                 { "select",   select },
                 { "group by", "cali.channel,loop,block" },
-                { "where",    std::string("loop.start_iteration,loop=") + loopname }
+                { "where",    std::string("loop.start_iteration,loop=\"") + loopname + "\"" }
             }, false /* no aliases */);
 
         local_aggregate(query.c_str(), c, channel(), db, output_agg);

--- a/test/ci_app_tests/ci_test_macros.cpp
+++ b/test/ci_app_tests/ci_test_macros.cpp
@@ -61,7 +61,7 @@ int main(int argc, char* argv[])
             count = std::max(1, std::stoi(argv[3]));
     }
 
-    CALI_CXX_MARK_LOOP_BEGIN(mainloop, "mainloop");
+    CALI_CXX_MARK_LOOP_BEGIN(mainloop, "main loop");
 
     for (int i = 0; i < count; ++i) {
         CALI_CXX_MARK_LOOP_ITERATION(mainloop, i);

--- a/test/ci_app_tests/test_basictrace.py
+++ b/test/ci_app_tests/test_basictrace.py
@@ -230,8 +230,8 @@ class CaliperBasicTraceTest(unittest.TestCase):
         self.assertTrue(cat.has_snapshot_with_attributes(
             snapshots, {
                 'function'   : 'main',
-                'loop'       : 'mainloop',
-                'iteration#mainloop' : '3' }))
+                'loop'       : 'main loop',
+                'iteration#main loop' : '3' }))
         self.assertTrue(cat.has_snapshot_with_attributes(
             snapshots, {
                 'function'   : 'main/foo',
@@ -244,7 +244,7 @@ class CaliperBasicTraceTest(unittest.TestCase):
         self.assertTrue(cat.has_snapshot_with_attributes(
             snapshots, {
                 'function'   : 'main/foo',
-                'loop'       : 'mainloop/fooloop',
+                'loop'       : 'main loop/fooloop',
                 'iteration#fooloop' : '3' }))
 
     def test_property_override(self):

--- a/test/ci_app_tests/test_json.py
+++ b/test/ci_app_tests/test_json.py
@@ -63,7 +63,7 @@ class CaliperJSONTest(unittest.TestCase):
 
         target_cmd = [ './ci_test_macros' ]
         query_cmd  = [ '../../src/tools/cali-query/cali-query',
-                       '-q', 'SELECT count(),sum(time.inclusive.duration),loop,iteration#mainloop group by loop,iteration#mainloop format json-split' ]
+                       '-q', 'SELECT count(),sum(time.inclusive.duration),loop,iteration#main\ loop group by loop,iteration#main\ loop format json-split' ]
 
         caliper_config = {
             'CALI_CONFIG_PROFILE'    : 'serial-trace',
@@ -77,7 +77,7 @@ class CaliperJSONTest(unittest.TestCase):
 
         columns = obj['columns']
 
-        self.assertEqual( { 'path', 'iteration#mainloop', 'count', 'sum#time.inclusive.duration' }, set(columns) )
+        self.assertEqual( { 'path', 'iteration#main loop', 'count', 'sum#time.inclusive.duration' }, set(columns) )
 
         data = obj['data']
 
@@ -92,13 +92,13 @@ class CaliperJSONTest(unittest.TestCase):
 
         nodes = obj['nodes']
 
-        self.assertEqual(nodes[0]['label' ], 'mainloop')
+        self.assertEqual(nodes[0]['label' ], 'main loop')
         self.assertEqual(nodes[0]['column'], 'path')
         self.assertEqual(nodes[1]['label' ], 'fooloop')
         self.assertEqual(nodes[1]['column'], 'path')
         self.assertEqual(nodes[1]['parent'], 0)
 
-        iterindex = columns.index('iteration#mainloop')
+        iterindex = columns.index('iteration#main loop')
 
         # Note: this is a pretty fragile test
         self.assertEqual(data[9][iterindex], 3)

--- a/test/ci_app_tests/test_loopreport.py
+++ b/test/ci_app_tests/test_loopreport.py
@@ -17,8 +17,8 @@ class CaliperLoopReportTest(unittest.TestCase):
 
         log_targets = [
             'Loop summary:',
-            'Loop     Iterations Time (s)',
-            'mainloop         20'
+            'Loop      Iterations Time (s)',
+            'main loop         20'
         ]
 
         report_out,_ = cat.run_test(target_cmd, caliper_config)
@@ -40,7 +40,7 @@ class CaliperLoopReportTest(unittest.TestCase):
         }
 
         log_targets = [
-            'Iteration summary (mainloop):',
+            'Iteration summary (main loop):',
             'Block Iterations Time (s)',
             '    0         15',
             '   30         15',
@@ -95,7 +95,7 @@ class CaliperLoopReportTest(unittest.TestCase):
 
         log_targets = [
             'Iteration summary (fooloop):',
-            'mainloop/fooloop        400',
+            'main loop/fooloop        400',
             'Block Iterations Time (s)',
             '    0        100',
             '    5        100',

--- a/test/ci_app_tests/test_monitor.py
+++ b/test/ci_app_tests/test_monitor.py
@@ -14,7 +14,7 @@ class CaliperTestMonitor(unittest.TestCase):
         caliper_config = {
             'CALI_SERVICES_ENABLE'   : 'loop_monitor,trace,report',
             'CALI_LOOP_MONITOR_ITERATION_INTERVAL' : '5',
-            'CALI_REPORT_CONFIG'     : 'select * where iteration#mainloop format expand',
+            'CALI_REPORT_CONFIG'     : 'select * where iteration#main\ loop format expand',
             'CALI_REPORT_FILENAME'   : 'stdout',
             'CALI_LOG_VERBOSITY'     : '0'
         }
@@ -24,8 +24,8 @@ class CaliperTestMonitor(unittest.TestCase):
 
         self.assertTrue(len(snapshots) == 2)
         self.assertTrue(cat.has_snapshot_with_attributes(
-            snapshots, { 'iteration#mainloop' : '4',
-                         'loop.iterations'    : '5'
+            snapshots, { 'iteration#main loop' : '4',
+                         'loop.iterations'     : '5'
             }))
 
     def test_loopmonitor_time_interval(self):
@@ -67,16 +67,16 @@ class CaliperTestMonitor(unittest.TestCase):
 
         self.assertEqual(len(snapshots), 20)
         self.assertTrue(cat.has_snapshot_with_attributes(
-            snapshots, { 'iteration#mainloop' : '3',
-                         'iteration#fooloop'  : '4',
-                         'loop.iterations'    : '5',
-                         'loop'               : 'mainloop/fooloop'
+            snapshots, { 'iteration#main loop' : '3',
+                         'iteration#fooloop'   : '4',
+                         'loop.iterations'     : '5',
+                         'loop'                : 'main loop/fooloop'
             }))
         self.assertTrue(cat.has_snapshot_with_attributes(
-            snapshots, { 'iteration#mainloop' : '7',
-                         'iteration#fooloop'  : '9',
-                         'loop.iterations'    : '5',
-                         'loop'               : 'mainloop/fooloop'
+            snapshots, { 'iteration#main loop' : '7',
+                         'iteration#fooloop'   : '9',
+                         'loop.iterations'     : '5',
+                         'loop'                : 'main loop/fooloop'
             }))
 
     def test_regionmonitor_time_interval(self):
@@ -95,7 +95,7 @@ class CaliperTestMonitor(unittest.TestCase):
 
         self.assertTrue(len(snapshots) == 4)
         self.assertTrue(cat.has_snapshot_with_attributes(
-            snapshots, { 'loop'     : 'mainloop/fooloop',
+            snapshots, { 'loop'     : 'main loop/fooloop',
                          'function' : 'main/foo'
             }))
         self.assertFalse(cat.has_snapshot_with_attributes(

--- a/test/ci_app_tests/test_report.py
+++ b/test/ci_app_tests/test_report.py
@@ -52,7 +52,7 @@ class CaliperReportTest(unittest.TestCase):
 
         caliper_config = {
             'CALI_SERVICES_ENABLE'   : 'event,trace,report',
-            'CALI_REPORT_CONFIG'     : 'select *,count() group by prop:nested,iteration#mainloop format expand',
+            'CALI_REPORT_CONFIG'     : 'select *,count() group by prop:nested,iteration#main\ loop format expand',
             'CALI_LOG_VERBOSITY'     : '0'
         }
 
@@ -61,16 +61,16 @@ class CaliperReportTest(unittest.TestCase):
 
         self.assertTrue(cat.has_snapshot_with_attributes(
             snapshots, { 'function'   : 'main/foo',
-                         'loop'       : 'mainloop',
+                         'loop'       : 'main loop',
                          'annotation' : 'pre-loop',
                          'statement'  : 'foo.init',
-                         'iteration#mainloop' : '2',
+                         'iteration#main loop' : '2',
                          'count'      : '1'
             }))
         self.assertTrue(cat.has_snapshot_with_attributes(
             snapshots, { 'function'   : 'main/foo',
-                         'loop'       : 'mainloop/fooloop',
-                         'iteration#mainloop' : '3',
+                         'loop'       : 'main loop/fooloop',
+                         'iteration#main loop' : '3',
                          'count'      : '9'
             }))
 
@@ -88,8 +88,8 @@ class CaliperReportTest(unittest.TestCase):
 
         self.assertTrue(cat.has_snapshot_with_attributes(
             snapshots, { 'function'   : 'main/foo',
-                         'loop'       : 'mainloop/fooloop',
-                         'iteration#mainloop' : '3',
+                         'loop'       : 'main loop/fooloop',
+                         'iteration#main loop' : '3',
                          'iteration#fooloop'  : '1',
                          'count'      : '1'
             }))
@@ -99,7 +99,7 @@ class CaliperReportTest(unittest.TestCase):
 
         caliper_config = {
             'CALI_SERVICES_ENABLE'   : 'event,trace,report',
-            'CALI_REPORT_CONFIG'     : 'select *,count() as my\\ count\\ alias group by prop:nested,iteration#mainloop format expand',
+            'CALI_REPORT_CONFIG'     : 'select *,count() as my\\ count\\ alias group by prop:nested,iteration#main\ loop format expand',
             'CALI_LOG_VERBOSITY'     : '0'
         }
 
@@ -108,17 +108,17 @@ class CaliperReportTest(unittest.TestCase):
 
         self.assertTrue(cat.has_snapshot_with_attributes(
             snapshots, { 'function'   : 'main/foo',
-                         'loop'       : 'mainloop',
+                         'loop'       : 'main loop',
                          'annotation' : 'pre-loop',
                          'statement'  : 'foo.init',
-                         'iteration#mainloop' : '2',
-                         'my count alias'     : '1'
+                         'iteration#main loop' : '2',
+                         'my count alias'      : '1'
             }))
         self.assertTrue(cat.has_snapshot_with_attributes(
             snapshots, { 'function'   : 'main/foo',
-                         'loop'       : 'mainloop/fooloop',
-                         'iteration#mainloop' : '3',
-                         'my count alias'     : '9'
+                         'loop'       : 'main loop/fooloop',
+                         'iteration#main loop' : '3',
+                         'my count alias'      : '9'
             }))
 
     def test_report_tree_formatter(self):
@@ -133,7 +133,7 @@ class CaliperReportTest(unittest.TestCase):
         report_targets = [
             'Path             Count',
             'main                 1',
-            '  mainloop           5',
+            '  main loop          5',
             '    foo              4',
             '      fooloop       20',
             '      pre-loop       4',
@@ -161,9 +161,9 @@ class CaliperReportTest(unittest.TestCase):
         }
 
         report_targets = [
-            'loop             count',
-            'mainloop/fooloop     4',
-            'mainloop             1'
+            'loop              count',
+            'main loop/fooloop     4',
+            'main loop             1'
         ]
 
         report_output,_ = cat.run_test(target_cmd, caliper_config)

--- a/test/ci_app_tests/test_runtimereport.py
+++ b/test/ci_app_tests/test_runtimereport.py
@@ -18,7 +18,7 @@ class CaliperRuntimeReportTest(unittest.TestCase):
         log_targets = [
             'Path',
             'main',
-            '  mainloop',
+            '  main loop',
             '    foo',
             '      fooloop'
         ]
@@ -43,7 +43,7 @@ class CaliperRuntimeReportTest(unittest.TestCase):
         log_targets = [
             'Time (E) Time (I) Time % (E) Time % (I)',
             'main',
-            '  mainloop',
+            '  main loop',
             '    foo',
             '      fooloop'
         ]

--- a/test/ci_app_tests/test_textlog.py
+++ b/test/ci_app_tests/test_textlog.py
@@ -12,8 +12,8 @@ class CaliperTextlogTest(unittest.TestCase):
 
         caliper_config = {
             'CALI_SERVICES_ENABLE'      : 'event,textlog',
-            'CALI_TEXTLOG_TRIGGER'      : 'iteration#mainloop',
-            'CALI_TEXTLOG_FORMATSTRING' : '%function% iteration: %[2]iteration#mainloop',
+            'CALI_TEXTLOG_TRIGGER'      : 'iteration#main\ loop',
+            'CALI_TEXTLOG_FORMATSTRING' : '%function% iteration: %[2]iteration#main loop%',
             'CALI_LOG_VERBOSITY'        : '0',
         }
 
@@ -44,7 +44,7 @@ class CaliperTextlogTest(unittest.TestCase):
         }
 
         log_targets = [
-            'loop=mainloop/fooloop'
+            'loop=main loop/fooloop'
         ]
 
         report_out,_ = cat.run_test(target_cmd, caliper_config)


### PR DESCRIPTION
Correctly quote loop names in loop-report and spot controllers, so it does not break for loop names with spaces. Fixes #345. Thanks @Rombur for reporting this.