### PR TITLE
Allowed Caliper to control Kokkos fencing behavior

### DIFF
--- a/src/services/kokkos/CMakeLists.txt
+++ b/src/services/kokkos/CMakeLists.txt
@@ -1,3 +1,4 @@
+include_directories(include)
 set(CALIPER_KOKKOS_SOURCES
   KokkosProfilingSymbols.cpp
   KokkosLookup.cpp

--- a/src/services/kokkos/KokkosProfilingSymbols.hpp
+++ b/src/services/kokkos/KokkosProfilingSymbols.hpp
@@ -1,9 +1,9 @@
 #ifndef CALIPER_SERVICES_KOKKOS_PROFILING_SYMBOLS_HPP
 #define CALIPER_SERVICES_KOKKOS_PROFILING_SYMBOLS_HPP
 
-
+//comment
 #include "types.hpp"
-
+#include <impl/Kokkos_Profiling_Interface.hpp>
 
 #endif
 

--- a/src/services/kokkos/include/impl/Kokkos_Profiling_C_Interface.h
+++ b/src/services/kokkos/include/impl/Kokkos_Profiling_C_Interface.h
@@ -1,0 +1,296 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_PROFILING_C_INTERFACE_HPP
+#define KOKKOS_PROFILING_C_INTERFACE_HPP
+
+#ifdef __cplusplus
+#include <cstddef>
+#include <cstdint>
+#else
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+#endif
+
+#define KOKKOSP_INTERFACE_VERSION 20210225
+
+// Profiling
+
+struct Kokkos_Profiling_KokkosPDeviceInfo {
+  size_t deviceID;
+};
+
+struct Kokkos_Profiling_SpaceHandle {
+  char name[64];
+};
+
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_initFunction)(
+    const int, const uint64_t, const uint32_t,
+    struct Kokkos_Profiling_KokkosPDeviceInfo*);
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_finalizeFunction)();
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_parseArgsFunction)(int, char**);
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_printHelpFunction)(char*);
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_beginFunction)(const char*, const uint32_t,
+                                               uint64_t*);
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_endFunction)(uint64_t);
+
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_pushFunction)(const char*);
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_popFunction)();
+
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_allocateDataFunction)(
+    const struct Kokkos_Profiling_SpaceHandle, const char*, const void*,
+    const uint64_t);
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_deallocateDataFunction)(
+    const struct Kokkos_Profiling_SpaceHandle, const char*, const void*,
+    const uint64_t);
+
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_createProfileSectionFunction)(const char*,
+                                                              uint32_t*);
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_startProfileSectionFunction)(const uint32_t);
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_stopProfileSectionFunction)(const uint32_t);
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_destroyProfileSectionFunction)(const uint32_t);
+
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_profileEventFunction)(const char*);
+
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_beginDeepCopyFunction)(
+    struct Kokkos_Profiling_SpaceHandle, const char*, const void*,
+    struct Kokkos_Profiling_SpaceHandle, const char*, const void*, uint64_t);
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_endDeepCopyFunction)();
+typedef void (*Kokkos_Profiling_beginFenceFunction)(const char*, const uint32_t,
+                                                    uint64_t*);
+typedef void (*Kokkos_Profiling_endFenceFunction)(uint64_t);
+
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_dualViewSyncFunction)(const char*,
+                                                      const void* const, bool);
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_dualViewModifyFunction)(const char*,
+                                                        const void* const,
+                                                        bool);
+
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_declareMetadataFunction)(const char*,
+                                                         const char*);
+
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Tools_toolInvokedFenceFunction)(const uint32_t);
+
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Tools_functionPointer)();
+struct Kokkos_Tools_ToolProgrammingInterface {
+  Kokkos_Tools_toolInvokedFenceFunction fence;
+  // allow addition of more actions
+  Kokkos_Tools_functionPointer padding[31];
+};
+
+struct Kokkos_Tools_ToolSettings {
+  bool requires_global_fencing;
+  bool padding[255];
+};
+
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Tools_provideToolProgrammingInterfaceFunction)(
+    const uint32_t, struct Kokkos_Tools_ToolProgrammingInterface);
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Tools_requestToolSettingsFunction)(
+    const uint32_t, struct Kokkos_Tools_ToolSettings*);
+
+// Tuning
+
+#define KOKKOS_TOOLS_TUNING_STRING_LENGTH 64
+typedef char Kokkos_Tools_Tuning_String[KOKKOS_TOOLS_TUNING_STRING_LENGTH];
+union Kokkos_Tools_VariableValue_ValueUnion {
+  int64_t int_value;
+  double double_value;
+  Kokkos_Tools_Tuning_String string_value;
+};
+
+union Kokkos_Tools_VariableValue_ValueUnionSet {
+  int64_t* int_value;
+  double* double_value;
+  Kokkos_Tools_Tuning_String* string_value;
+};
+
+struct Kokkos_Tools_ValueSet {
+  size_t size;
+  union Kokkos_Tools_VariableValue_ValueUnionSet values;
+};
+
+enum Kokkos_Tools_OptimizationType {
+  Kokkos_Tools_Minimize,
+  Kokkos_Tools_Maximize
+};
+
+struct Kokkos_Tools_OptimzationGoal {
+  size_t type_id;
+  enum Kokkos_Tools_OptimizationType goal;
+};
+
+struct Kokkos_Tools_ValueRange {
+  union Kokkos_Tools_VariableValue_ValueUnion lower;
+  union Kokkos_Tools_VariableValue_ValueUnion upper;
+  union Kokkos_Tools_VariableValue_ValueUnion step;
+  bool openLower;
+  bool openUpper;
+};
+
+enum Kokkos_Tools_VariableInfo_ValueType {
+  kokkos_value_double,
+  kokkos_value_int64,
+  kokkos_value_string,
+};
+
+enum Kokkos_Tools_VariableInfo_StatisticalCategory {
+  kokkos_value_categorical,  // unordered distinct objects
+  kokkos_value_ordinal,      // ordered distinct objects
+  kokkos_value_interval,  // ordered distinct objects for which distance matters
+  kokkos_value_ratio  // ordered distinct objects for which distance matters,
+                      // division matters, and the concept of zero exists
+};
+
+enum Kokkos_Tools_VariableInfo_CandidateValueType {
+  kokkos_value_set,       // I am one of [2,3,4,5]
+  kokkos_value_range,     // I am somewhere in [2,12)
+  kokkos_value_unbounded  // I am [text/int/float], but we don't know at
+                          // declaration time what values are appropriate. Only
+                          // valid for Context Variables
+};
+
+union Kokkos_Tools_VariableInfo_SetOrRange {
+  struct Kokkos_Tools_ValueSet set;
+  struct Kokkos_Tools_ValueRange range;
+};
+
+struct Kokkos_Tools_VariableInfo {
+  enum Kokkos_Tools_VariableInfo_ValueType type;
+  enum Kokkos_Tools_VariableInfo_StatisticalCategory category;
+  enum Kokkos_Tools_VariableInfo_CandidateValueType valueQuantity;
+  union Kokkos_Tools_VariableInfo_SetOrRange candidates;
+  void* toolProvidedInfo;
+};
+
+struct Kokkos_Tools_VariableValue {
+  size_t type_id;
+  union Kokkos_Tools_VariableValue_ValueUnion value;
+  struct Kokkos_Tools_VariableInfo* metadata;
+};
+
+typedef void (*Kokkos_Tools_outputTypeDeclarationFunction)(
+    const char*, const size_t, struct Kokkos_Tools_VariableInfo* info);
+typedef void (*Kokkos_Tools_inputTypeDeclarationFunction)(
+    const char*, const size_t, struct Kokkos_Tools_VariableInfo* info);
+
+typedef void (*Kokkos_Tools_requestValueFunction)(
+    const size_t, const size_t, const struct Kokkos_Tools_VariableValue*,
+    const size_t count, struct Kokkos_Tools_VariableValue*);
+typedef void (*Kokkos_Tools_contextBeginFunction)(const size_t);
+typedef void (*Kokkos_Tools_contextEndFunction)(
+    const size_t, struct Kokkos_Tools_VariableValue);
+typedef void (*Kokkos_Tools_optimizationGoalDeclarationFunction)(
+    const size_t, const struct Kokkos_Tools_OptimzationGoal goal);
+
+struct Kokkos_Profiling_EventSet {
+  Kokkos_Profiling_initFunction init;
+  Kokkos_Profiling_finalizeFunction finalize;
+  Kokkos_Profiling_parseArgsFunction parse_args;
+  Kokkos_Profiling_printHelpFunction print_help;
+  Kokkos_Profiling_beginFunction begin_parallel_for;
+  Kokkos_Profiling_endFunction end_parallel_for;
+  Kokkos_Profiling_beginFunction begin_parallel_reduce;
+  Kokkos_Profiling_endFunction end_parallel_reduce;
+  Kokkos_Profiling_beginFunction begin_parallel_scan;
+  Kokkos_Profiling_endFunction end_parallel_scan;
+  Kokkos_Profiling_pushFunction push_region;
+  Kokkos_Profiling_popFunction pop_region;
+  Kokkos_Profiling_allocateDataFunction allocate_data;
+  Kokkos_Profiling_deallocateDataFunction deallocate_data;
+  Kokkos_Profiling_createProfileSectionFunction create_profile_section;
+  Kokkos_Profiling_startProfileSectionFunction start_profile_section;
+  Kokkos_Profiling_stopProfileSectionFunction stop_profile_section;
+  Kokkos_Profiling_destroyProfileSectionFunction destroy_profile_section;
+  Kokkos_Profiling_profileEventFunction profile_event;
+  Kokkos_Profiling_beginDeepCopyFunction begin_deep_copy;
+  Kokkos_Profiling_endDeepCopyFunction end_deep_copy;
+  Kokkos_Profiling_beginFenceFunction begin_fence;
+  Kokkos_Profiling_endFenceFunction end_fence;
+  Kokkos_Profiling_dualViewSyncFunction sync_dual_view;
+  Kokkos_Profiling_dualViewModifyFunction modify_dual_view;
+  Kokkos_Profiling_declareMetadataFunction declare_metadata;
+  Kokkos_Tools_provideToolProgrammingInterfaceFunction
+      provide_tool_programming_interface;
+  Kokkos_Tools_requestToolSettingsFunction request_tool_settings;
+  char profiling_padding[9 * sizeof(Kokkos_Tools_functionPointer)];
+  Kokkos_Tools_outputTypeDeclarationFunction declare_output_type;
+  Kokkos_Tools_inputTypeDeclarationFunction declare_input_type;
+  Kokkos_Tools_requestValueFunction request_output_values;
+  Kokkos_Tools_contextBeginFunction begin_tuning_context;
+  Kokkos_Tools_contextEndFunction end_tuning_context;
+  Kokkos_Tools_optimizationGoalDeclarationFunction declare_optimization_goal;
+  char padding[232 *
+               sizeof(
+                   Kokkos_Tools_functionPointer)];  // allows us to add another
+                                                    // 256 events to the Tools
+                                                    // interface without
+                                                    // changing struct layout
+};
+
+#endif  // KOKKOS_PROFILING_C_INTERFACE_HPP

--- a/src/services/kokkos/include/impl/Kokkos_Profiling_DeviceInfo.hpp
+++ b/src/services/kokkos/include/impl/Kokkos_Profiling_DeviceInfo.hpp
@@ -1,0 +1,56 @@
+/*
+ //@HEADER
+ // ************************************************************************
+ //
+ //                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+ //
+ // Under the terms of Contract DE-NA0003525 with NTESS,
+ // the U.S. Government retains certain rights in this software.
+ //
+ // Redistribution and use in source and binary forms, with or without
+ // modification, are permitted provided that the following conditions are
+ // met:
+ //
+ // 1. Redistributions of source code must retain the above copyright
+ // notice, this list of conditions and the following disclaimer.
+ //
+ // 2. Redistributions in binary form must reproduce the above copyright
+ // notice, this list of conditions and the following disclaimer in the
+ // documentation and/or other materials provided with the distribution.
+ //
+ // 3. Neither the name of the Corporation nor the names of the
+ // contributors may be used to endorse or promote products derived from
+ // this software without specific prior written permission.
+ //
+ // THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+ // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ // IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ // PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+ // CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ // EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ // PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ // PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ // LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ //
+ // Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+ //
+ // ************************************************************************
+ //@HEADER
+*/
+
+#ifndef KOKKOSP_DEVICE_INFO_HPP
+#define KOKKOSP_DEVICE_INFO_HPP
+
+#include <cstdint>
+#include <impl/Kokkos_Profiling_C_Interface.h>
+namespace Kokkos {
+namespace Profiling {
+using KokkosPDeviceInfo = Kokkos_Profiling_KokkosPDeviceInfo;
+}  // namespace Profiling
+}  // namespace Kokkos
+
+#endif

--- a/src/services/kokkos/include/impl/Kokkos_Profiling_Interface.hpp
+++ b/src/services/kokkos/include/impl/Kokkos_Profiling_Interface.hpp
@@ -1,0 +1,223 @@
+/*
+ //@HEADER
+ // ************************************************************************
+ //
+ //                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+ //
+ // Under the terms of Contract DE-NA0003525 with NTESS,
+ // the U.S. Government retains certain rights in this software.
+ //
+ // Redistribution and use in source and binary forms, with or without
+ // modification, are permitted provided that the following conditions are
+ // met:
+ //
+ // 1. Redistributions of source code must retain the above copyright
+ // notice, this list of conditions and the following disclaimer.
+ //
+ // 2. Redistributions in binary form must reproduce the above copyright
+ // notice, this list of conditions and the following disclaimer in the
+ // documentation and/or other materials provided with the distribution.
+ //
+ // 3. Neither the name of the Corporation nor the names of the
+ // contributors may be used to endorse or promote products derived from
+ // this software without specific prior written permission.
+ //
+ // THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+ // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ // IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ // PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+ // CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ // EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ // PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ // PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ // LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ //
+ // Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+ //
+ // ************************************************************************
+ //@HEADER
+ */
+
+#ifndef KOKKOSP_INTERFACE_HPP
+#define KOKKOSP_INTERFACE_HPP
+
+#include <cinttypes>
+#include <cstddef>
+
+#include <cstdlib>
+
+// NOTE: in this Kokkos::Profiling block, do not define anything that shouldn't
+// exist should Profiling be disabled
+
+namespace Kokkos {
+namespace Tools {
+namespace Experimental {
+enum struct DeviceType {
+  Serial,
+  OpenMP,
+  Cuda,
+  HIP,
+  OpenMPTarget,
+  HPX,
+  Threads,
+  SYCL,
+  Unknown
+};
+
+template <typename ExecutionSpace>
+struct DeviceTypeTraits;
+
+constexpr const size_t device_type_bits = 8;
+constexpr const size_t instance_bits    = 24;
+template <typename ExecutionSpace>
+inline uint32_t device_id(ExecutionSpace const& space) noexcept {
+  auto device_id = static_cast<uint32_t>(DeviceTypeTraits<ExecutionSpace>::id);
+  return (device_id << instance_bits) + space.impl_instance_id();
+}
+}  // namespace Experimental
+}  // namespace Tools
+}  // end namespace Kokkos
+
+#if defined(KOKKOS_ENABLE_LIBDL)
+// We check at configure time that libdl is available.
+#include <dlfcn.h>
+#endif
+
+#include <impl/Kokkos_Profiling_DeviceInfo.hpp>
+#include <impl/Kokkos_Profiling_C_Interface.h>
+
+namespace Kokkos {
+namespace Tools {
+
+using SpaceHandle = Kokkos_Profiling_SpaceHandle;
+
+}  // namespace Tools
+
+namespace Tools {
+
+namespace Experimental {
+using EventSet = Kokkos_Profiling_EventSet;
+static_assert(sizeof(EventSet) / sizeof(Kokkos_Tools_functionPointer) == 275,
+              "sizeof EventSet has changed, this is an error on the part of a "
+              "Kokkos developer");
+static_assert(sizeof(Kokkos_Tools_ToolSettings) / sizeof(bool) == 256,
+              "sizeof EventSet has changed, this is an error on the part of a "
+              "Kokkos developer");
+static_assert(sizeof(Kokkos_Tools_ToolProgrammingInterface) /
+                      sizeof(Kokkos_Tools_functionPointer) ==
+                  32,
+              "sizeof EventSet has changed, this is an error on the part of a "
+              "Kokkos developer");
+
+using toolInvokedFenceFunction = Kokkos_Tools_toolInvokedFenceFunction;
+using provideToolProgrammingInterfaceFunction =
+    Kokkos_Tools_provideToolProgrammingInterfaceFunction;
+using requestToolSettingsFunction = Kokkos_Tools_requestToolSettingsFunction;
+using ToolSettings                = Kokkos_Tools_ToolSettings;
+using ToolProgrammingInterface    = Kokkos_Tools_ToolProgrammingInterface;
+}  // namespace Experimental
+using initFunction           = Kokkos_Profiling_initFunction;
+using finalizeFunction       = Kokkos_Profiling_finalizeFunction;
+using parseArgsFunction      = Kokkos_Profiling_parseArgsFunction;
+using printHelpFunction      = Kokkos_Profiling_printHelpFunction;
+using beginFunction          = Kokkos_Profiling_beginFunction;
+using endFunction            = Kokkos_Profiling_endFunction;
+using pushFunction           = Kokkos_Profiling_pushFunction;
+using popFunction            = Kokkos_Profiling_popFunction;
+using allocateDataFunction   = Kokkos_Profiling_allocateDataFunction;
+using deallocateDataFunction = Kokkos_Profiling_deallocateDataFunction;
+using createProfileSectionFunction =
+    Kokkos_Profiling_createProfileSectionFunction;
+using startProfileSectionFunction =
+    Kokkos_Profiling_startProfileSectionFunction;
+using stopProfileSectionFunction = Kokkos_Profiling_stopProfileSectionFunction;
+using destroyProfileSectionFunction =
+    Kokkos_Profiling_destroyProfileSectionFunction;
+using profileEventFunction    = Kokkos_Profiling_profileEventFunction;
+using beginDeepCopyFunction   = Kokkos_Profiling_beginDeepCopyFunction;
+using endDeepCopyFunction     = Kokkos_Profiling_endDeepCopyFunction;
+using beginFenceFunction      = Kokkos_Profiling_beginFenceFunction;
+using endFenceFunction        = Kokkos_Profiling_endFenceFunction;
+using dualViewSyncFunction    = Kokkos_Profiling_dualViewSyncFunction;
+using dualViewModifyFunction  = Kokkos_Profiling_dualViewModifyFunction;
+using declareMetadataFunction = Kokkos_Profiling_declareMetadataFunction;
+
+}  // namespace Tools
+
+}  // namespace Kokkos
+
+// Profiling
+
+namespace Kokkos {
+
+namespace Profiling {
+
+/** The Profiling namespace is being renamed to Tools.
+ * This is reexposing the contents of what used to be the Profiling
+ * Interface with their original names, to avoid breaking old code
+ */
+
+namespace Experimental {
+
+using Kokkos::Tools::Experimental::device_id;
+using Kokkos::Tools::Experimental::DeviceType;
+using Kokkos::Tools::Experimental::DeviceTypeTraits;
+
+}  // namespace Experimental
+
+using Kokkos::Tools::allocateDataFunction;
+using Kokkos::Tools::beginDeepCopyFunction;
+using Kokkos::Tools::beginFunction;
+using Kokkos::Tools::createProfileSectionFunction;
+using Kokkos::Tools::deallocateDataFunction;
+using Kokkos::Tools::destroyProfileSectionFunction;
+using Kokkos::Tools::endDeepCopyFunction;
+using Kokkos::Tools::endFunction;
+using Kokkos::Tools::finalizeFunction;
+using Kokkos::Tools::initFunction;
+using Kokkos::Tools::parseArgsFunction;
+using Kokkos::Tools::popFunction;
+using Kokkos::Tools::printHelpFunction;
+using Kokkos::Tools::profileEventFunction;
+using Kokkos::Tools::pushFunction;
+using Kokkos::Tools::SpaceHandle;
+using Kokkos::Tools::startProfileSectionFunction;
+using Kokkos::Tools::stopProfileSectionFunction;
+
+}  // namespace Profiling
+}  // namespace Kokkos
+
+// Tuning
+
+namespace Kokkos {
+namespace Tools {
+namespace Experimental {
+using ValueSet            = Kokkos_Tools_ValueSet;
+using ValueRange          = Kokkos_Tools_ValueRange;
+using StatisticalCategory = Kokkos_Tools_VariableInfo_StatisticalCategory;
+using ValueType           = Kokkos_Tools_VariableInfo_ValueType;
+using CandidateValueType  = Kokkos_Tools_VariableInfo_CandidateValueType;
+using SetOrRange          = Kokkos_Tools_VariableInfo_SetOrRange;
+using VariableInfo        = Kokkos_Tools_VariableInfo;
+using OptimizationGoal    = Kokkos_Tools_OptimzationGoal;
+using TuningString        = Kokkos_Tools_Tuning_String;
+using VariableValue       = Kokkos_Tools_VariableValue;
+
+using outputTypeDeclarationFunction =
+    Kokkos_Tools_outputTypeDeclarationFunction;
+using inputTypeDeclarationFunction = Kokkos_Tools_inputTypeDeclarationFunction;
+using requestValueFunction         = Kokkos_Tools_requestValueFunction;
+using contextBeginFunction         = Kokkos_Tools_contextBeginFunction;
+using contextEndFunction           = Kokkos_Tools_contextEndFunction;
+using optimizationGoalDeclarationFunction =
+    Kokkos_Tools_optimizationGoalDeclarationFunction;
+}  // end namespace Experimental
+}  // end namespace Tools
+
+}  // end namespace Kokkos
+
+#endif


### PR DESCRIPTION
Many Kokkos PR's ago we added the ability for a tool to control the fencing behavior of Kokkos. In the case of Caliper, this could minimize overhead in one place currently, and more in the future.

What I do right now is just tell Kokkos only to fence if a callback subscribes to a given event. This could allow us in the future to do things like "only profile Regions" and not induce fences in parallel kernels. There's also room to do extremely clever things with GPU backends where we don't introduce syncs at all using CUPTI, but that's beyond the scope of what I want to do here.

Note that this _does_ introduce some header files, which are extremely backwards compatible, we have about six years of history of these files not breaking anything