### PR TITLE
Support channels running on sub-communicators

### DIFF
--- a/include/caliper/CollectiveOutputChannel.h
+++ b/include/caliper/CollectiveOutputChannel.h
@@ -25,28 +25,17 @@ class OutputStream;
 /// \brief A ChannelController for %Caliper configurations that aggregate
 ///   output over MPI.
 ///
-/// A CollectiveOutputChannel object controls a %Caliper measurement channel
-/// that produces a single output in an MPI program. The output can be written
-/// into a user-provided C++ I/O stream.
+/// A CollectiveOutputChannel provides the collective_flush() interface to 
+/// produce output in an MPI program via a user-provided MPI 
+/// communicator and/or C++ I/O stream.
 ///
 /// \sa make_collective_output_channel()
 class CollectiveOutputChannel : public cali::ChannelController
 {
-    struct CollectiveOutputChannelImpl;
-    std::shared_ptr<CollectiveOutputChannelImpl> mP;
-
 public:
 
     /// \brief Create channel controller with given name, flags, and config.
     CollectiveOutputChannel(const char* name, int flags, const config_map_t& cfg);
-
-    /// \brief Create channel controller with given queries, name, flags,
-    ///   and config.
-    CollectiveOutputChannel(const char* local_query,
-                            const char* cross_query,
-                            const char* name,
-                            int flags,
-                            const config_map_t& cfg);
 
     /// \brief Try to create a CollectiveOutputChannel based on the
     ///   configuration in \a from.
@@ -54,9 +43,6 @@ public:
     /// Can be used to convert a control channel created by ConfigManager
     /// into a CollectiveOutputChannel object that can be flushed
     /// into a user-defined stream with collective_flush().
-    ///
-    /// Currently, this only works for input configurations that use the
-    /// \e mpireport service.
     ///
     /// \return A new <tt>std::shared_ptr</tt>-wrapped CollectiveOutputChannel, or
     ///   an empty \c std::shared_ptr object if \a from couldn't be
@@ -76,10 +62,21 @@ public:
     /// \param os Output stream object. Used only on rank 0 and ignored
     ///   on all other ranks.
     /// \param comm MPI communicator
-    virtual void collective_flush(OutputStream& os, MPI_Comm comm);
+    virtual void collective_flush(OutputStream& os, MPI_Comm comm) = 0;
 
     /// \copydoc CollectiveOutputChannel::collective_flush(OutputStream&, MPI_Comm)
     std::ostream& collective_flush(std::ostream& os, MPI_Comm comm);
+
+    /// \brief Aggregate data from MPI ranks in \a comm and write output.
+    ///
+    /// This is a collective operation on the MPI communicator \a comm.
+    /// Rank 0 in \a comm collects all output, and formats and writes it into
+    /// an output stream defined by the channel (stdout by default).
+    /// If \a comm is \c MPI_COMM_NULL, the calling process will aggregate and
+    /// write its local data.
+    ///
+    /// \param comm MPI communicator
+    virtual void collective_flush(MPI_Comm comm);
 
     /// \brief Aggregate and flush data.
     ///

--- a/include/caliper/CollectiveOutputChannel.h
+++ b/include/caliper/CollectiveOutputChannel.h
@@ -25,8 +25,8 @@ class OutputStream;
 /// \brief A ChannelController for %Caliper configurations that aggregate
 ///   output over MPI.
 ///
-/// A CollectiveOutputChannel provides the collective_flush() interface to 
-/// produce output in an MPI program via a user-provided MPI 
+/// A CollectiveOutputChannel provides the collective_flush() interface to
+/// produce output in an MPI program via a user-provided MPI
 /// communicator and/or C++ I/O stream.
 ///
 /// \sa make_collective_output_channel()

--- a/include/caliper/ConfigManager.h
+++ b/include/caliper/ConfigManager.h
@@ -428,7 +428,7 @@ public:
     /// \return An STL container with C++ shared_ptr objects to the
     /// ChannelController instances created from the configuration strings.
     ChannelList
-    get_all_channels();
+    get_all_channels() const;
 
     /// \brief Return a channel controller instance for configuration \a name
     ///
@@ -436,7 +436,7 @@ public:
     /// with the given \a name, or an empty shared_ptr object when no such
     /// channel exists.
     ChannelPtr
-    get_channel(const char* name);
+    get_channel(const char* name) const;
 
     /// \brief Start all configured measurement channels, or re-start
     ///   paused ones

--- a/include/caliper/MpiChannelManager.h
+++ b/include/caliper/MpiChannelManager.h
@@ -56,7 +56,7 @@ class MpiChannelManager
 public:
 
     /// \brief Create channel manager on communicator \a comm
-    MpiChannelManager(MPI_Comm comm = MPI_COMM_NULL);
+    explicit MpiChannelManager(MPI_Comm comm);
 
     ~MpiChannelManager();
 

--- a/include/caliper/MpiChannelManager.h
+++ b/include/caliper/MpiChannelManager.h
@@ -1,0 +1,89 @@
+// Copyright (c) 2021, Lawrence Livermore National Security, LLC.
+// See top-level LICENSE file for details.
+
+/// \file MpiChannelManager.h
+/// MpiChannelManagerWrapper class
+
+#pragma once
+
+#ifndef CALI_MPI_CHANNEL_MANAGER_H
+#define CALI_MPI_CHANNEL_MANAGER_H
+
+#include <mpi.h>
+
+#include <memory>
+
+namespace cali
+{
+
+class ChannelController;
+class ConfigManager;
+
+/// \brief Manage ConfigManager channels that run on a user-defined MPI
+///   communicator
+///
+/// An MpiChannelManager imports Caliper control channel configurations
+/// from a ConfigManager or other ChannelController objects, but runs their
+/// MPI operations (specifically, flush) on a user-provided MPI
+/// communicator.
+///
+/// Example:
+///
+/// \code
+/// int worldrank;
+/// MPI_Comm subcomm;
+/// MPI_Comm_rank(MPI_COMM_WORLD, &worldrank);
+/// MPI_Comm_split(MPI_COMM_WORLD, worldrank % 2, worldrank, &subcomm);
+///
+/// cali::ConfigManager mgr("runtime-report,profile.mpi");
+/// cali::MpiChannelManager mpimgr(subcomm);
+/// mpimgr.add(mgr);
+///
+/// if (worldrank % 2 == 0)
+///   mpimgr.start();
+///
+/// MPI_Barrier(subcomm);
+///
+/// if (worldrank % 2 == 0)
+///   mpimgr.collective_flush(); // flush() runs on subcomm
+/// \endcode
+
+class MpiChannelManager
+{
+    struct MpiChannelManagerImpl;
+    std::shared_ptr<MpiChannelManagerImpl> mP;
+
+public:
+
+    /// \brief Create channel manager on communicator \a comm
+    MpiChannelManager(MPI_Comm comm = MPI_COMM_NULL);
+
+    ~MpiChannelManager();
+
+    /// \brief Import all channels from \a mgr
+    /// \sa MpiChannelManager::add(const std::shared_ptr<ChannelController>& src)
+    void add(const ConfigManager& mgr);
+
+    /// \brief Import channel configuration from \a src
+    ///
+    /// This creates a new channel with the same configuration as \a src
+    /// that will run MPI operations (if any) on the given MPI communicator.
+    void add(const std::shared_ptr<ChannelController>& src);
+
+    /// \brief Start all channels
+    /// \sa ChannelController::start()
+    void start();
+
+    /// \brief Stop all channels
+    /// \sa ChannelController::stop()
+    void stop();
+
+    /// \brief Flush all channels
+    ///
+    /// This is a collective operation on this channel's MPI communicator.
+    void collective_flush();
+};
+
+} // namespace cali
+
+#endif

--- a/src/caliper/ConfigManager.cpp
+++ b/src/caliper/ConfigManager.cpp
@@ -1309,13 +1309,13 @@ ConfigManager::set_default_parameter_for_config(const char* config, const char* 
 }
 
 ConfigManager::ChannelList
-ConfigManager::get_all_channels()
+ConfigManager::get_all_channels() const
 {
     return mP->m_channels;
 }
 
 ConfigManager::ChannelPtr
-ConfigManager::get_channel(const char* name)
+ConfigManager::get_channel(const char* name) const
 {
     for (ChannelPtr& chn : mP->m_channels)
         if (chn->name() == name)

--- a/src/mpi/CMakeLists.txt
+++ b/src/mpi/CMakeLists.txt
@@ -4,6 +4,7 @@ set(CALIPER_MPI_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
 set(CALIPER_MPI_SOURCES
   CollectiveOutputChannel.cpp
+  MpiChannelManager.cpp
   aggregate_over_mpi.cpp
   collective_flush.cpp
   mpi_flush.cpp

--- a/src/mpi/CollectiveOutputChannel.cpp
+++ b/src/mpi/CollectiveOutputChannel.cpp
@@ -167,6 +167,8 @@ CollectiveOutputChannel::from(const std::shared_ptr<ChannelController>& from)
     config_map_t cfg(from->copy_config());
 
     cfg["CALI_SERVICES_ENABLE"] = ::remove_from_stringlist(cfg["CALI_SERVICES_ENABLE"], "mpireport");
+    cfg["CALI_CHANNEL_CONFIG_CHECK" ] = "false";
+    cfg["CALI_CHANNEL_FLUSH_AT_EXIT"] = "false";
 
     std::string cross_query = cfg["CALI_MPIREPORT_CONFIG"];
     std::string local_query = cfg["CALI_MPIREPORT_LOCAL_CONFIG"];

--- a/src/mpi/MpiChannelManager.cpp
+++ b/src/mpi/MpiChannelManager.cpp
@@ -1,0 +1,94 @@
+// Copyright (c) 2021, Lawrence Livermore National Security, LLC.
+// See top-level LICENSE file for details.
+
+#include "caliper/MpiChannelManager.h"
+
+#include "caliper/CollectiveOutputChannel.h"
+#include "caliper/ConfigManager.h"
+
+#include <vector>
+
+using namespace cali;
+
+
+struct MpiChannelManager::MpiChannelManagerImpl
+{
+    MPI_Comm comm  { MPI_COMM_NULL };
+
+    // mpi channels are those using collective_flush()
+    std::vector< std::shared_ptr<CollectiveOutputChannel> > mpi_channels;
+    // serial channels just use flush()
+    std::vector< std::shared_ptr<ChannelController      > > ser_channels;
+
+    void add(const std::shared_ptr<ChannelController>& src) {
+        if (!src)
+            return;
+
+        auto mpi_chn = CollectiveOutputChannel::from(src);
+
+        if (mpi_chn)
+            mpi_channels.push_back(mpi_chn);
+        else
+            ser_channels.push_back(src);
+    }
+
+    void start() const {
+        for (auto channel : mpi_channels)
+            channel->start();
+        for (auto channel : ser_channels)
+            channel->start();
+    }
+
+    void stop() const {
+        for (auto channel : mpi_channels)
+            channel->stop();
+        for (auto channel : ser_channels)
+            channel->stop();
+    }
+
+    void flush() const {
+        for (auto channel : mpi_channels)
+            channel->collective_flush(comm);
+        for (auto channel : ser_channels)
+            channel->flush();
+    }
+
+    MpiChannelManagerImpl(MPI_Comm comm_)
+        : comm { comm_ }
+    { }
+};
+
+
+MpiChannelManager::MpiChannelManager(MPI_Comm comm)
+    : mP { new MpiChannelManagerImpl(comm) }
+{ }
+
+MpiChannelManager::~MpiChannelManager()
+{ }
+
+void MpiChannelManager::add(const std::shared_ptr<ChannelController>& src)
+{
+    mP->add(src);
+}
+
+void MpiChannelManager::add(const ConfigManager& mgr)
+{
+    auto channels = mgr.get_all_channels();
+    for (auto c : channels)
+        mP->add(c);
+}
+
+void MpiChannelManager::start()
+{
+    mP->start();
+}
+
+void MpiChannelManager::stop()
+{
+    mP->stop();
+}
+
+void MpiChannelManager::collective_flush()
+{
+    mP->flush();
+}

--- a/src/mpi/services/mpiwrap/Wrapper.w
+++ b/src/mpi/services/mpiwrap/Wrapper.w
@@ -1152,8 +1152,6 @@ post_init_cb(Caliper* c, Channel* channel)
     bool run_init_evts = Caliper::is_initialized();
     Caliper c;
 
-    // cheat a bit: put begin/ends around a barrier here
-
     for (MpiWrapperConfig* mwc = MpiWrapperConfig::get_wrapper_config(); mwc; mwc = mwc->next) {
         //   Run mpi init events here if Caliper was initialized before MPI_Init
         // Otherwise they will run via the Caliper initialization above.
@@ -1163,27 +1161,28 @@ post_init_cb(Caliper* c, Channel* channel)
 
     ::push_mpifn(&c, ::{{func}}_wrap_count > 0, "{{func}}");
 
+    /* skip the barrier / tracing, causes problems if not all ranks initialize MPI wrappers
     PMPI_Barrier(MPI_COMM_WORLD);
 
     for (MpiWrapperConfig* mwc = MpiWrapperConfig::get_wrapper_config(); mwc; mwc = mwc->next)
         if (mwc->enable_msg_tracing && mwc->enable_{{func}} && mwc->channel->is_active())
             mwc->tracing.handle_init(&c, mwc->channel);
-
+    */
     ::pop_mpifn(&c, ::{{func}}_wrap_count);
 }{{endfn}}
 
 {{fn func MPI_Finalize}}{
     Caliper c;
 
-    // cheat a bit: put begin/ends around a barrier here
-
     ::push_mpifn(&c, ::{{func}}_wrap_count > 0, "{{func}}");
 
+    /* skip the barrier / tracing, causes problems if not all ranks initialize MPI wrappers
     PMPI_Barrier(MPI_COMM_WORLD);
 
     for (MpiWrapperConfig* mwc = MpiWrapperConfig::get_wrapper_config(); mwc; mwc = mwc->next)
         if (mwc->enable_msg_tracing && mwc->enable_{{func}} && mwc->channel->is_active())
             mwc->tracing.handle_finalize(&c, mwc->channel);
+    */
 
     ::pop_mpifn(&c, ::{{func}}_wrap_count > 0);
 

--- a/test/ci_app_tests/CMakeLists.txt
+++ b/test/ci_app_tests/CMakeLists.txt
@@ -23,7 +23,8 @@ set(CALIPER_CI_C_TEST_APPS
 set(CALIPER_CI_MPI_TEST_APPS
   ci_test_cali_before_mpi
   ci_test_collective_output_channel
-  ci_test_mpi_before_cali)
+  ci_test_mpi_before_cali
+  ci_test_mpi_channel_manager)
 set(CALIPER_CI_Fortran_TEST_APPS
   ci_test_f_ann)
 
@@ -103,7 +104,7 @@ if (CALIPER_HAVE_OMPT AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.9)
 endif()
 
 if (CALIPER_HAVE_MPI)
-  list(APPEND PYTHON_SCRIPTS 
+  list(APPEND PYTHON_SCRIPTS
     test_loopreport.py
     test_spot.py)
 

--- a/test/ci_app_tests/ci_test_collective_output_channel.cpp
+++ b/test/ci_app_tests/ci_test_collective_output_channel.cpp
@@ -35,7 +35,12 @@ int main(int argc, char* argv[])
         MPI_Barrier(MPI_COMM_WORLD);
     }
 
-    channel->collective_flush(std::cout, MPI_COMM_WORLD);
+    channel->stop();
+
+    if (argc > 2 && strcmp(argv[2], "channel_defined_stream") == 0)
+        channel->collective_flush(MPI_COMM_WORLD);
+    else
+        channel->collective_flush(std::cout, MPI_COMM_WORLD);
 
     MPI_Finalize();
 }

--- a/test/ci_app_tests/ci_test_mpi_channel_manager.cpp
+++ b/test/ci_app_tests/ci_test_mpi_channel_manager.cpp
@@ -32,9 +32,7 @@ int main(int argc, char* argv[])
 
     cali::MpiChannelManager mpimgr(subcomm);
     mpimgr.add(mgr);
-
-    if (worldrank % 2 == 0)
-        mpimgr.start();
+    mpimgr.start();
 
     {
         CALI_CXX_MARK_FUNCTION;
@@ -44,10 +42,10 @@ int main(int argc, char* argv[])
 
     MPI_Barrier(MPI_COMM_WORLD);
 
-    if (worldrank % 2 == 0) {
-        mpimgr.stop();
+    mpimgr.stop();
+
+    if (worldrank % 2 == 0)
         mpimgr.collective_flush();
-    }
 
     MPI_Comm_free(&subcomm);
     MPI_Finalize();

--- a/test/ci_app_tests/ci_test_mpi_channel_manager.cpp
+++ b/test/ci_app_tests/ci_test_mpi_channel_manager.cpp
@@ -1,0 +1,54 @@
+// Test MpiChannelManager
+
+#include <caliper/cali.h>
+#include <caliper/cali-mpi.h>
+#include <caliper/Caliper.h>
+
+#include <caliper/ConfigManager.h>
+#include <caliper/MpiChannelManager.h>
+
+#include <mpi.h>
+
+#include <iostream>
+#include <tuple>
+
+int main(int argc, char* argv[])
+{
+    MPI_Init(&argc, &argv);
+
+    int worldrank = 0;
+    MPI_Comm subcomm;
+    MPI_Comm_rank(MPI_COMM_WORLD, &worldrank);
+    MPI_Comm_split(MPI_COMM_WORLD, worldrank % 2, worldrank, &subcomm);
+
+    cali::ConfigManager mgr;
+    if (argc > 1)
+        mgr.add(argv[1]);
+
+    if (mgr.error()) {
+        std::cerr << "Caliper error: " << mgr.error_msg() << std::endl;
+        MPI_Abort(MPI_COMM_WORLD, -1);
+    }
+
+    cali::MpiChannelManager mpimgr(subcomm);
+    mpimgr.add(mgr);
+
+    if (worldrank % 2 == 0)
+        mpimgr.start();
+
+    {
+        CALI_CXX_MARK_FUNCTION;
+
+        MPI_Barrier(subcomm);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if (worldrank % 2 == 0) {
+        mpimgr.stop();
+        mpimgr.collective_flush();
+    }
+
+    MPI_Comm_free(&subcomm);
+    MPI_Finalize();
+}

--- a/test/ci_app_tests/test_mpi.py
+++ b/test/ci_app_tests/test_mpi.py
@@ -213,5 +213,45 @@ class CaliperMPITest(unittest.TestCase):
             else:
                 self.fail('%s not found in log' % target)
 
+    def test_collective_output_channel_with_default_stream(self):
+        target_cmd = [ './ci_test_collective_output_channel', 'mpi-report,output=stdout', 'channel_defined_stream' ]
+
+        caliper_config = {
+            'PATH'                    : '/usr/bin', # for ssh/rsh
+            'CALI_LOG_VERBOSITY'      : '0',
+        }
+
+        log_targets = [
+            'Function',
+            'MPI_Barrier'
+        ]
+
+        report_out,_ = cat.run_test(target_cmd, caliper_config)
+        lines = report_out.decode().splitlines()
+
+        for target in log_targets:
+            for line in lines:
+                if target in line:
+                    break
+            else:
+                self.fail('%s not found in log' % target)
+
+    def test_collective_output_channel_spot(self):
+        target_cmd = [ './ci_test_collective_output_channel', 'spot' ]
+        query_cmd  = [ '../../src/tools/cali-query/cali-query', '-e' ]
+
+        caliper_config = {
+            'PATH'                    : '/usr/bin', # for ssh/rsh
+            'CALI_LOG_VERBOSITY'      : '0',
+        }
+
+        query_output = cat.run_test_with_query(target_cmd, query_cmd, caliper_config)
+        snapshots = cat.get_snapshots_from_text(query_output)
+
+        self.assertTrue(cat.has_snapshot_with_attributes(
+            snapshots, { 'function'          : 'main',
+                         'spot.channel'      : 'regionprofile'
+            }))
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Adds some infrastructure including the `MpiChannelManager` class to support ConfigManager channels running on sub-communicators.