### PR TITLE
Add print metadata option for reports

### DIFF
--- a/include/caliper/reader/QuerySpec.h
+++ b/include/caliper/reader/QuerySpec.h
@@ -105,7 +105,7 @@ struct QuerySpec
             Default, User
         }                        opt;       ///< Default or user-defined formatter
         FunctionSignature        formatter; ///< The formatter to use. Signatures provided by FormatProcessor.
-        std::vector<std::string> args;      ///< Arguments to the formatter.
+        std::map<std::string, std::string> kwargs; ///< Arguments to the formatter.
     };
 
     struct PreprocessSpec {

--- a/src/caliper/controllers/CMakeLists.txt
+++ b/src/caliper/controllers/CMakeLists.txt
@@ -6,7 +6,8 @@ set(CALIPER_CONTROLLERS_SOURCES
   controllers/HatchetSampleProfileController.cpp
   controllers/OpenMPReportController.cpp
   controllers/RuntimeReportController.cpp
-  controllers/controllers.cpp)
+  controllers/controllers.cpp
+  controllers/util.cpp)
 
 list(APPEND CALIPER_RUNTIME_SOURCES ${CALIPER_CONTROLLERS_SOURCES})
 set(CALIPER_RUNTIME_SOURCES ${CALIPER_RUNTIME_SOURCES} PARENT_SCOPE)

--- a/src/caliper/controllers/CallpathSampleReportController.cpp
+++ b/src/caliper/controllers/CallpathSampleReportController.cpp
@@ -3,6 +3,8 @@
 
 #include "caliper/caliper-config.h"
 
+#include "util.h"
+
 #include "caliper/ChannelController.h"
 #include "caliper/ConfigManager.h"
 
@@ -33,10 +35,6 @@ public:
                 + std::to_string(1.0/freq)
                 + ") as \"Time (sec)\" unit sec";
 
-            std::string format = std::string("tree(source.function#callpath.address,")
-                + opts.get("max_column_width", "48").to_string()
-                + ")";
-
             // Config for second aggregation step in MPI mode (cross-process aggregation)
             std::string cross_select =
                   " min(scount) as \"Min time/rank\" unit sec"
@@ -51,6 +49,8 @@ public:
 
             if (have_pthread)
                 config()["CALI_SERVICES_ENABLE"].append(",pthread");
+
+            std::string format = util::build_tree_format_spec(config(), opts, "path-attributes=source.function#callpath.address");
 
             if (use_mpi) {
                 config()["CALI_SERVICES_ENABLE"   ].append(",mpi,mpireport");
@@ -116,7 +116,7 @@ const char* callpath_sample_report_spec =
     "{"
     " \"name\"        : \"callpath-sample-report\","
     " \"description\" : \"Print a call-path sampling profile for the program\","
-    " \"categories\"  : [ \"metric\", \"output\" ],"
+    " \"categories\"  : [ \"metric\", \"output\", \"treeformatter\" ],"
     " \"services\"    : [ \"callpath\", \"sampler\", \"symbollookup\", \"trace\" ],"
     " \"config\"      : "
     "   { \"CALI_CHANNEL_FLUSH_ON_EXIT\"      : \"false\""
@@ -132,11 +132,6 @@ const char* callpath_sample_report_spec =
     "   \"name\": \"aggregate_across_ranks\","
     "   \"type\": \"bool\","
     "   \"description\": \"Aggregate results across MPI ranks\""
-    "  },"
-    "  {"
-    "   \"name\": \"max_column_width\","
-    "   \"type\": \"int\","
-    "   \"description\": \"Maximum column width in the tree display\""
     "  }"
     " ]"
     "}";

--- a/src/caliper/controllers/CudaActivityReportController.cpp
+++ b/src/caliper/controllers/CudaActivityReportController.cpp
@@ -3,6 +3,8 @@
 
 #include "caliper/caliper-config.h"
 
+#include "util.h"
+
 #include "caliper/ChannelController.h"
 #include "caliper/ConfigManager.h"
 
@@ -52,6 +54,8 @@ public:
                     = std::string("cupti.kernel.name as Kernel,") + cross_select;
             }
 
+            std::string format = util::build_tree_format_spec(config(), opts);
+
             if (use_mpi) {
                 config()["CALI_SERVICES_ENABLE"   ].append(",mpi,mpireport");
                 config()["CALI_MPIREPORT_FILENAME"] = opts.get("output", "stderr").to_string();
@@ -65,7 +69,7 @@ public:
                     opts.build_query("cross", {
                             { "select",   cross_select  },
                             { "group by", groupby },
-                            { "format",   "tree"  }
+                            { "format",   format  }
                         });
             } else {
                 config()["CALI_SERVICES_ENABLE"   ].append(",report");
@@ -74,7 +78,7 @@ public:
                     opts.build_query("local", {
                             { "select",   serial_select },
                             { "group by", groupby },
-                            { "format",   "tree"  }
+                            { "format",   format  }
                         });
             }
 
@@ -116,7 +120,7 @@ const char* controller_spec =
     " \"name\"        : \"cuda-activity-report\","
     " \"description\" : \"Record and print CUDA activities (kernel executions, memcopies, etc.)\","
     " \"categories\"  : [ \"output\", \"region\", \"cuptitrace.metric\" ],"
-    " \"services\"    : [ \"aggregate\", \"cupti\", \"cuptitrace\", \"event\" ],"
+    " \"services\"    : [ \"aggregate\", \"cupti\", \"cuptitrace\", \"event\", \"treeformatter\" ],"
     " \"config\"      : "
     "   { \"CALI_CHANNEL_FLUSH_ON_EXIT\"        : \"false\","
     "     \"CALI_EVENT_ENABLE_SNAPSHOT_INFO\"   : \"false\","

--- a/src/caliper/controllers/RuntimeReportController.cpp
+++ b/src/caliper/controllers/RuntimeReportController.cpp
@@ -43,13 +43,22 @@ public:
                 pmetric = "inclusive_percent_total(sum#sum#time.duration)";
             }
 
-            std::string format = "tree";
+            auto avail_services = services::get_available_services();
+            bool have_adiak =
+                std::find(avail_services.begin(), avail_services.end(), "adiak_import") != avail_services.end();
 
-            if (opts.is_set("max_column_width")) {
-                format = "(prop:nested,";
-                format.append(opts.get("max_column_width").to_string());
-                format.append(")");
+            std::string format;
+
+            if (opts.is_set("max_column_width"))
+                format.append("column-width=").append(opts.get("max_column_width").to_string());
+            if (opts.is_set("print.metadata")) {
+                if (have_adiak)
+                    config()["CALI_SERVICES_ENABLE"].append(",adiak_import");
+
+                format.append(format.length() > 0 ? "," : "").append("print-globals");
             }
+
+            format = std::string("tree(") + format + ")";
 
             // Config for second aggregation step in MPI mode (cross-process aggregation)
             std::string cross_select =
@@ -147,6 +156,11 @@ const char* runtime_report_spec =
     "   \"name\": \"max_column_width\","
     "   \"type\": \"int\","
     "   \"description\": \"Maximum column width in the tree display\""
+    "  },"
+    "  {"
+    "   \"name\": \"print.metadata\","
+    "   \"type\": \"bool\","
+    "   \"description\": \"Print program metadata (Caliper globals and Adiak data)\""
     "  }"
     " ]"
     "}";

--- a/src/caliper/controllers/RuntimeReportController.cpp
+++ b/src/caliper/controllers/RuntimeReportController.cpp
@@ -3,6 +3,8 @@
 
 #include "caliper/caliper-config.h"
 
+#include "util.h"
+
 #include "caliper/ChannelController.h"
 #include "caliper/ConfigManager.h"
 
@@ -43,22 +45,7 @@ public:
                 pmetric = "inclusive_percent_total(sum#sum#time.duration)";
             }
 
-            auto avail_services = services::get_available_services();
-            bool have_adiak =
-                std::find(avail_services.begin(), avail_services.end(), "adiak_import") != avail_services.end();
-
-            std::string format;
-
-            if (opts.is_set("max_column_width"))
-                format.append("column-width=").append(opts.get("max_column_width").to_string());
-            if (opts.is_set("print.metadata")) {
-                if (have_adiak)
-                    config()["CALI_SERVICES_ENABLE"].append(",adiak_import");
-
-                format.append(format.length() > 0 ? "," : "").append("print-globals");
-            }
-
-            format = std::string("tree(") + format + ")";
+            std::string format = util::build_tree_format_spec(config(), opts);
 
             // Config for second aggregation step in MPI mode (cross-process aggregation)
             std::string cross_select =
@@ -131,7 +118,7 @@ const char* runtime_report_spec =
     "{"
     " \"name\"        : \"runtime-report\","
     " \"description\" : \"Print a time profile for annotated regions\","
-    " \"categories\"  : [ \"metric\", \"output\", \"region\" ],"
+    " \"categories\"  : [ \"metric\", \"output\", \"region\", \"treeformatter\" ],"
     " \"services\"    : [ \"aggregate\", \"event\", \"timestamp\" ],"
     " \"config\"      : "
     "   { \"CALI_CHANNEL_FLUSH_ON_EXIT\"      : \"false\","
@@ -151,16 +138,6 @@ const char* runtime_report_spec =
     "   \"name\": \"aggregate_across_ranks\","
     "   \"type\": \"bool\","
     "   \"description\": \"Aggregate results across MPI ranks\""
-    "  },"
-    "  {"
-    "   \"name\": \"max_column_width\","
-    "   \"type\": \"int\","
-    "   \"description\": \"Maximum column width in the tree display\""
-    "  },"
-    "  {"
-    "   \"name\": \"print.metadata\","
-    "   \"type\": \"bool\","
-    "   \"description\": \"Print program metadata (Caliper globals and Adiak data)\""
     "  }"
     " ]"
     "}";

--- a/src/caliper/controllers/controllers.cpp
+++ b/src/caliper/controllers/controllers.cpp
@@ -662,6 +662,18 @@ const char* builtin_option_specs =
     " \"description\" : \"Adiak import categories. Comma-separated list of integers.\","
     " \"type\"        : \"string\","
     " \"category\"    : \"adiak\""
+    "},"
+    "{"
+    " \"name\"        : \"max_column_width\","
+    " \"type\"        : \"int\","
+    " \"description\" : \"Maximum column width in the tree display\","
+    " \"category\"    : \"treeformatter\""
+    "},"
+    "{"
+    " \"name\"        : \"print.metadata\","
+    " \"type\"        : \"bool\","
+    " \"description\" : \"Print program metadata (Caliper globals and Adiak data)\","
+    " \"category\"    : \"treeformatter\""
     "}"
     "]";
 

--- a/src/caliper/controllers/util.cpp
+++ b/src/caliper/controllers/util.cpp
@@ -1,0 +1,30 @@
+// Copyright (c) 2021, Lawrence Livermore National Security, LLC.
+// See top-level LICENSE file for details.
+
+#include "util.h"
+
+#include "../../services/Services.h"
+
+#include <algorithm>
+
+using namespace cali;
+
+std::string util::build_tree_format_spec(config_map_t& config, const ConfigManager::Options& opts, const char* initial)
+{
+    std::string format = initial;
+
+    if (opts.is_set("max_column_width"))
+        format.append("column-width=").append(opts.get("max_column_width").to_string());
+    if (opts.is_enabled("print.metadata")) {
+        auto avail_services = services::get_available_services();
+        bool have_adiak =
+            std::find(avail_services.begin(), avail_services.end(), "adiak_import") != avail_services.end();
+
+        if (have_adiak)
+            config["CALI_SERVICES_ENABLE"].append(",adiak_import");
+
+        format.append(format.length() > 0 ? "," : "").append("print-globals");
+    }
+
+    return std::string("tree(") + format + ")";
+}

--- a/src/caliper/controllers/util.h
+++ b/src/caliper/controllers/util.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2021, Lawrence Livermore National Security, LLC.
+// See top-level LICENSE file for details.
+
+#pragma once
+#ifndef CALI_CONTROLLERS_UTIL_H
+#define CALI_CONTROLLERS_UTIL_H
+
+#include "caliper/ConfigManager.h"
+
+#include <string>
+
+namespace cali
+{
+
+namespace util
+{
+
+std::string build_tree_format_spec(config_map_t&, const cali::ConfigManager::Options&, const char* initial = "");
+
+}
+
+}
+
+#endif // CALI_CONTROLLERS_UTIL_H

--- a/src/reader/CMakeLists.txt
+++ b/src/reader/CMakeLists.txt
@@ -14,6 +14,7 @@ set(CALIPER_READER_SOURCES
   QueryProcessor.cpp
   QuerySpec.cpp
   RecordSelector.cpp
+  SnapshotTableFormatter.cpp
   SnapshotTree.cpp
   TableFormatter.cpp
   TreeFormatter.cpp

--- a/src/reader/FormatProcessor.cpp
+++ b/src/reader/FormatProcessor.cpp
@@ -20,8 +20,8 @@ namespace
 {
 
 const char* format_kernel_args[] = { "format", "title" };
-const char* tree_kernel_args[]   = { "path-attributes", "column-width" };
-const char* table_kernel_args[]  = { "column-width" };
+const char* tree_kernel_args[]   = { "path-attributes", "column-width", "print-globals" };
+const char* table_kernel_args[]  = { "column-width", "print-globals" };
 const char* json_kernel_args[]   = { "object", "pretty", "quote-all", "separate-nested", "records", "split" };
 
 enum FormatterID {

--- a/src/reader/FormatProcessor.cpp
+++ b/src/reader/FormatProcessor.cpp
@@ -22,7 +22,7 @@ namespace
 const char* format_kernel_args[] = { "format", "title" };
 const char* tree_kernel_args[]   = { "path-attributes", "column-width" };
 const char* table_kernel_args[]  = { "column-width" };
-const char* json_kernel_args[]   = { "layout", "pretty", "quote-all", "separate-nested" };
+const char* json_kernel_args[]   = { "object", "pretty", "quote-all", "separate-nested", "records", "split" };
 
 enum FormatterID {
     Cali        = 0,
@@ -37,7 +37,7 @@ enum FormatterID {
 const QuerySpec::FunctionSignature formatters[] = {
     { FormatterID::Cali,      "cali",       0, 0, nullptr },
     { FormatterID::Cali,      "csv",        0, 0, nullptr }, // keep old "csv" name for backwards compatibility
-    { FormatterID::Json,      "json",       0, 4, json_kernel_args },
+    { FormatterID::Json,      "json",       0, 6, json_kernel_args },
     { FormatterID::Expand,    "expand",     0, 0, nullptr },
     { FormatterID::Format,    "format",     1, 2, format_kernel_args },
     { FormatterID::Table,     "table",      0, 1, table_kernel_args  },

--- a/src/reader/JsonFormatter.cpp
+++ b/src/reader/JsonFormatter.cpp
@@ -75,18 +75,18 @@ struct JsonFormatter::JsonFormatterImpl
 
 
     void configure(const QuerySpec& spec) {
-        for (auto arg : spec.format.args) {
-            if (arg == "pretty")
+        for (auto p : spec.format.kwargs) {
+            if (p.first == "pretty")
                 m_opt_pretty = true;
-            else if (arg == "quote-all")
+            else if (p.first == "quote-all")
                 m_opt_quote_all = true;
-            else if (arg == "separate-nested")
+            else if (p.first == "separate-nested")
                 m_opt_sep_nested = true;
-            else if (arg == "records")
+            else if (p.first == "records")
                 m_layout = Records;
-            else if (arg == "split")
+            else if (p.first == "split")
                 m_layout = Split;
-            else if (arg == "object")
+            else if (p.first == "object")
                 m_layout = Object;
         }
 

--- a/src/reader/SnapshotTableFormatter.cpp
+++ b/src/reader/SnapshotTableFormatter.cpp
@@ -1,0 +1,100 @@
+#include "SnapshotTableFormatter.h"
+
+#include "caliper/common/CaliperMetadataAccessInterface.h"
+#include "caliper/common/Node.h"
+
+#include "../common/util/format_util.h"
+
+#include <iostream>
+
+using namespace cali;
+
+namespace
+{
+
+struct EntryInfo  {
+    std::string key;
+    std::string val;
+    bool align_right;
+};
+
+struct RecordInfo {
+    std::vector<EntryInfo> entries;
+    size_t max_key_len;
+    size_t max_right_len;
+
+    void add(const CaliperMetadataAccessInterface& db, cali_id_t attr_id, const Variant& data) {
+        Attribute attr = db.get_attribute(attr_id);
+
+        bool align_right =
+            attr.type() == CALI_TYPE_DOUBLE ||
+            attr.type() == CALI_TYPE_INT    ||
+            attr.type() == CALI_TYPE_UINT;
+
+        EntryInfo info { attr.name(), data.to_string(), align_right };
+
+        max_key_len = std::max(max_key_len, info.key.length());
+
+        if (align_right)
+            max_right_len = std::max(max_right_len, info.val.length());
+
+        entries.push_back(info);
+    }
+
+    RecordInfo()
+        : max_key_len { 0 }, max_right_len { 0 }
+        { }
+};
+
+RecordInfo unpack_record(CaliperMetadataAccessInterface& db, const std::vector<Entry>& rec)
+{
+    RecordInfo info;
+
+    for (const Entry& e : rec) {
+        if (e.is_reference()) {
+            for (const Node* node = e.node(); node && node->attribute() != CALI_INV_ID; node = node->parent())
+                info.add(db, node->attribute(), node->data());
+        } else if (e.is_immediate()) {
+            info.add(db, e.attribute(), e.value());
+        }
+    }
+
+    return info;
+}
+
+std::ostream& write_record_data(const RecordInfo& info, std::ostream& os)
+{
+    const size_t MAX_KEY_COL_WIDTH = 24;
+    const size_t MAX_VAL_COL_WIDTH = 52;
+
+    size_t key_width = std::min(info.max_key_len, MAX_KEY_COL_WIDTH);
+    size_t val_width = MAX_VAL_COL_WIDTH;
+
+    int count = 0;
+
+    for (const EntryInfo e : info.entries) {
+        if (count++ > 0)
+            os << "\n";
+
+        util::pad_right(os, util::clamp_string(e.key, key_width), key_width) << ": ";
+
+        if (e.align_right)
+            util::pad_left(os, e.val, info.max_right_len);
+        else
+            os << util::clamp_string(e.val, val_width);
+    }
+
+    return os << "\n";
+}
+
+} // namespace anonymous
+
+namespace cali
+{
+
+std::ostream& format_record_as_table(CaliperMetadataAccessInterface& db, const std::vector<Entry>& rec, std::ostream& os)
+{
+    return ::write_record_data(::unpack_record(db, rec), os);
+}
+
+}

--- a/src/reader/SnapshotTableFormatter.h
+++ b/src/reader/SnapshotTableFormatter.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2021, Lawrence Livermore National Security, LLC.
+// See top-level LICENSE file for details.
+
+/// \file SnapshotTableFormatter.h
+/// \brief Defines SnapshotTableFormatter class
+
+#ifndef CALI_SNAPSHOTTABLEFORMATTER_H
+#define CALI_SNAPSHOTTABLEFORMATTER_H
+
+#include "caliper/common/Entry.h"
+
+#include <vector>
+
+namespace cali
+{
+
+class CaliperMetadataAccessInterface;
+
+std::ostream&
+format_record_as_table(CaliperMetadataAccessInterface& db, const std::vector<Entry>&, std::ostream& os);
+
+} // namespace cali
+
+#endif

--- a/src/reader/TableFormatter.cpp
+++ b/src/reader/TableFormatter.cpp
@@ -95,13 +95,17 @@ struct TableFormatter::TableImpl
 
         // Set max column width
 
-        if (spec.format.args.size() > 0) {
-            bool ok = false;
+        {
+            auto it = spec.format.kwargs.find("column-width");
 
-            m_max_column_width = StringConverter(spec.format.args[0]).to_int(&ok);
+            if (it != spec.format.kwargs.end()) {
+                bool ok = false;
 
-            if (!ok)
-                m_max_column_width = -1;
+                m_max_column_width = StringConverter(it->second).to_int(&ok);
+
+                if (!ok)
+                    m_max_column_width = -1;
+            }
         }
 
         // Fill sort columns

--- a/src/reader/TreeFormatter.cpp
+++ b/src/reader/TreeFormatter.cpp
@@ -5,6 +5,8 @@
 
 #include "caliper/reader/TreeFormatter.h"
 
+#include "SnapshotTableFormatter.h"
+
 #include "caliper/reader/QuerySpec.h"
 #include "caliper/reader/SnapshotTree.h"
 
@@ -47,6 +49,7 @@ struct TreeFormatter::TreeFormatterImpl
     std::map<std::string, std::string> m_aliases;
 
     bool                     m_use_nested;
+    bool                     m_print_globals;
 
     std::vector<std::string> m_path_key_names;
     std::vector<Attribute>   m_path_keys;
@@ -83,6 +86,12 @@ struct TreeFormatter::TreeFormatterImpl
                     m_max_column_width = -1;
                 }
             }
+        }
+
+        {
+            auto it = spec.format.kwargs.find("print-globals");
+            if (it != spec.format.kwargs.end())
+                m_print_globals = true;
         }
 
         {
@@ -343,7 +352,8 @@ struct TreeFormatter::TreeFormatterImpl
     TreeFormatterImpl()
         : m_path_column_width(0),
           m_max_column_width(48),
-          m_use_nested(true)
+          m_use_nested(true),
+          m_print_globals(false)
     { }
 };
 
@@ -368,5 +378,8 @@ TreeFormatter::process_record(CaliperMetadataAccessInterface& db, const EntryLis
 void
 TreeFormatter::flush(CaliperMetadataAccessInterface& db, std::ostream& os)
 {
+    if (mP->m_print_globals)
+        format_record_as_table(db, db.get_globals(), os);
+
     mP->flush(db, os);
 }

--- a/src/reader/TreeFormatter.cpp
+++ b/src/reader/TreeFormatter.cpp
@@ -60,22 +60,28 @@ struct TreeFormatter::TreeFormatterImpl
 
     void configure(const QuerySpec& spec) {
         // set path keys (first argument in spec.format.args)
-        if (spec.format.args.size() > 0)
-            util::split(spec.format.args.front(), ',',
-                        std::back_inserter(m_path_key_names));
+
+        {
+            auto it = spec.format.kwargs.find("path-attributes");
+            if (it != spec.format.kwargs.end())
+                util::split(it->second, ',', std::back_inserter(m_path_key_names));
+        }
 
         // set max column width
-        if (spec.format.args.size() > 1) {
-            bool ok = false;
+        {
+            auto it = spec.format.kwargs.find("column-width");
+            if (it != spec.format.kwargs.end()) {
+                bool ok = false;
 
-            m_max_column_width = StringConverter(spec.format.args[1]).to_int(&ok);
+                m_max_column_width = StringConverter(it->second).to_int(&ok);
 
-            if (!ok) {
-                Log(0).stream() << "TreeFormatter: invalid column width argument \""
-                                << spec.format.args[1] << "\""
-                                << std::endl;
+                if (!ok) {
+                    Log(0).stream() << "TreeFormatter: invalid column width argument \""
+                                    << it->second << "\""
+                                    << std::endl;
 
-                m_max_column_width = -1;
+                    m_max_column_width = -1;
+                }
             }
         }
 

--- a/src/reader/test/CMakeLists.txt
+++ b/src/reader/test/CMakeLists.txt
@@ -8,7 +8,8 @@ set(CALIPER_READER_TEST_SOURCES
   test_nestedexclusiveregionprofile.cpp
   test_nestedinclusiveregionprofile.cpp
   test_nodebuffer.cpp
-  test_preprocessor.cpp)
+  test_preprocessor.cpp
+  test_snapshottableformatter.cpp)
 
 add_executable(test_caliper-reader
   $<TARGET_OBJECTS:caliper-common>

--- a/src/reader/test/test_snapshottableformatter.cpp
+++ b/src/reader/test/test_snapshottableformatter.cpp
@@ -1,0 +1,37 @@
+#include "../SnapshotTableFormatter.h"
+
+#include "caliper/reader/CaliperMetadataDB.h"
+
+#include "caliper/common/Node.h"
+
+#include <gtest/gtest.h>
+
+#include <sstream>
+
+using namespace cali;
+
+TEST(SnapshotTableFormatter, Format) {
+    CaliperMetadataDB db;
+
+    Attribute a = db.create_attribute("aaaa", CALI_TYPE_INT,    CALI_ATTR_ASVALUE);
+    Attribute b = db.create_attribute("bb",   CALI_TYPE_UINT,   CALI_ATTR_ASVALUE);
+    Attribute s = db.create_attribute("str",  CALI_TYPE_STRING, CALI_ATTR_DEFAULT);
+
+    IdMap idmap;
+    const Node* node = db.merge_node(101, s.id(), CALI_INV_ID, Variant("a string value"), idmap);
+
+    std::vector<Entry> rec;
+    rec.push_back(Entry(a,   Variant(42)));
+    rec.push_back(Entry(b, Variant(4242)));
+    rec.push_back(Entry(node));
+
+    std::ostringstream os;
+    format_record_as_table(db, rec, os);
+
+    std::string expect =
+        "aaaa :   42 \n"
+        "bb   : 4242 \n"
+        "str  : a string value\n";
+
+    EXPECT_EQ(os.str(), expect);
+}

--- a/src/services/report/Report.cpp
+++ b/src/services/report/Report.cpp
@@ -63,11 +63,12 @@ class Report {
 
         db.add_attribute_aliases(spec.aliases);
         db.add_attribute_units(spec.units);
-        db.import_globals(*c, c->get_globals(channel));
 
         c->flush(channel, flush_info, [&queryP,&db](CaliperMetadataAccessInterface& in_db, const std::vector<Entry>& rec){
                 queryP.process_record(db, db.merge_snapshot(in_db, rec));
             } );
+
+        db.import_globals(*c, c->get_globals(channel));
 
         queryP.flush(db);
     }

--- a/src/tools/cali-query/query_common.cpp
+++ b/src/tools/cali-query/query_common.cpp
@@ -207,13 +207,11 @@ QueryArgsParser::parse_args(const Args& args)
 
             // Find formatter args (if any)
             for (int i = 0; i < fmtsig->max_args; ++i)
-                if (args.is_set(fmtsig->args[i])) {
-                    m_spec.format.args.resize(i+1);
-                    m_spec.format.args[i] = args.get(fmtsig->args[i]);
-                }
+                if (args.is_set(fmtsig->args[i]))
+                    m_spec.format.kwargs[fmtsig->args[i]] = args.get(fmtsig->args[i]);
 
             // NOTE: This check isn't complete yet.
-            if (m_spec.format.args.size() < static_cast<std::size_t>(fmtsig->min_args)) {
+            if (m_spec.format.kwargs.size() < static_cast<std::size_t>(fmtsig->min_args)) {
                 m_error     = true;
                 m_error_msg = std::string("Insufficient arguments for formatter ") + fmtsig->name;
 


### PR DESCRIPTION
Adds print globals option for tree and table formatter and runtime-report, e.g. `runtime-report(print.metadata)`.  Also, formatter arguments in CalQL can now use kwargs instead of positional args. Addresses #380.