### PR TITLE
Buffer records in JsonSplitFormatter

### DIFF
--- a/include/caliper/reader/JsonSplitFormatter.h
+++ b/include/caliper/reader/JsonSplitFormatter.h
@@ -9,8 +9,6 @@
 #include "Formatter.h"
 #include "RecordProcessor.h"
 
-#include "../common/OutputStream.h"
-
 #include <memory>
 
 namespace cali
@@ -28,7 +26,7 @@ class JsonSplitFormatter : public Formatter
 
 public:
 
-    JsonSplitFormatter(OutputStream& os, const QuerySpec& spec);
+    JsonSplitFormatter(const QuerySpec& spec);
 
     ~JsonSplitFormatter();
 

--- a/src/reader/FormatProcessor.cpp
+++ b/src/reader/FormatProcessor.cpp
@@ -97,7 +97,7 @@ struct FormatProcessor::FormatProcessorImpl
                 m_formatter = new TreeFormatter(spec);
                 break;
             case FormatterID::JsonSplit:
-                m_formatter = new JsonSplitFormatter(m_stream, spec);
+                m_formatter = new JsonSplitFormatter(spec);
                 break;
             }
         }


### PR DESCRIPTION
Use buffering in `JsonSplitFormatter`. Needs more memory but fixes a whole bunch of issues.