### PR TITLE
Move sampling/cupti finalization to pre_finish_evt

### DIFF
--- a/src/services/cupti/Cupti.cpp
+++ b/src/services/cupti/Cupti.cpp
@@ -322,6 +322,14 @@ class CuptiService
     }
 
     void
+    pre_finish_cb() {
+        cuptiUnsubscribe(subscriber);
+        cuptiFinalize();
+
+        event_sampling.stop_all();
+    }
+
+    void
     finish_cb(Caliper* c, Channel* chn)
     {
         if (Log::verbosity() >= 2) {
@@ -336,11 +344,6 @@ class CuptiService
             if (event_sampling.is_enabled())
                 event_sampling.print_statistics(Log(2).stream());
         }
-
-        event_sampling.stop_all();
-
-        cuptiUnsubscribe(subscriber);
-        cuptiFinalize();
     }
 
     void
@@ -477,6 +480,10 @@ public:
         chn->events().post_init_evt.connect(
             [instance](Caliper* c, Channel* channel){
                 instance->subscribe_attributes(c, channel);
+            });
+        chn->events().pre_finish_evt.connect(
+            [instance](Caliper*, Channel*){
+                instance->pre_finish_cb();
             });
         chn->events().finish_evt.connect(
             [instance](Caliper* c, Channel* chn){

--- a/src/services/cupti/CuptiTrace.cpp
+++ b/src/services/cupti/CuptiTrace.cpp
@@ -711,9 +711,14 @@ class CuptiTraceService
         }
     }
 
-    void finish_cb(Caliper* c, Channel* chn) {
-        cuptiFinalize();
+    void pre_finish_cb(Caliper* c, Channel* channel) {
+        if (Log::verbosity() >= 2)
+            Log(2).stream() << channel->name() << ": finalizing CUpti\n";
 
+        cuptiFinalize();
+    }
+
+    void finish_cb(Caliper* c, Channel* chn) {
         if (Log::verbosity() < 1)
             return;
 
@@ -947,6 +952,10 @@ class CuptiTraceService
                 });
         }
 
+        chn->events().pre_finish_evt.connect(
+            [](Caliper* c, Channel* chn){
+                s_instance->pre_finish_cb(c, chn);
+            });
         chn->events().finish_evt.connect(
             [](Caliper* c, Channel* chn){
                 s_instance->finish_cb(c, chn);

--- a/src/services/sampler/Sampler.cpp
+++ b/src/services/sampler/Sampler.cpp
@@ -163,10 +163,12 @@ void release_thread_cb(Caliper* c, Channel* chn) {
     clear_timer(c, chn);
 }
 
-void finish_cb(Caliper* c, Channel* chn) {
+void pre_finish_cb(Caliper* c, Channel* chn) {
     clear_timer(c, chn);
     clear_signal();
+}
 
+void finish_cb(Caliper* c, Channel* chn) {
     Log(1).stream() << chn->name()
                     << ": Sampler: processed " << n_processed_samples << " samples ("
                     << n_samples << " total, "
@@ -217,6 +219,7 @@ void sampler_register(Caliper* c, Channel* chn)
 
     chn->events().create_thread_evt.connect(create_thread_cb);
     chn->events().release_thread_evt.connect(release_thread_cb);
+    chn->events().pre_finish_evt.connect(pre_finish_cb);
     chn->events().finish_evt.connect(finish_cb);
 
     channel = chn;


### PR DESCRIPTION
Move cupti and sampling cleanup to pre_finish_evt callback. Fixes potential race conditions on finalization.