### PR TITLE
Use flag instead of metadata to mark metric attributes

### DIFF
--- a/include/caliper/common/CaliperMetadataAccessInterface.h
+++ b/include/caliper/common/CaliperMetadataAccessInterface.h
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-2022, Lawrence Livermore National Security, LLC.
 // See top-level LICENSE file for details.
 
-/// \file CaliperMetadataAccessInterface.h 
+/// \file CaliperMetadataAccessInterface.h
 /// \brief Abstract Caliper metadata access interface
 
 #pragma once
@@ -28,7 +28,7 @@ public:
     virtual Node*
     node(cali_id_t) const = 0;
 
-    virtual Attribute 
+    virtual Attribute
     get_attribute(cali_id_t id) const = 0;
     virtual Attribute
     get_attribute(const std::string& str) const = 0;
@@ -41,6 +41,10 @@ public:
     std::vector<Attribute>
     find_attributes_with(const Attribute& meta) const;
 
+    /// \brief Return all attributes with the given property flag(s)
+    std::vector<Attribute>
+    find_attributes_with_prop(int prop) const;
+
     // --- modifying operations
 
     virtual Attribute
@@ -51,7 +55,7 @@ public:
                      const Attribute*   meta_attr = nullptr,
                      const Variant*     meta_data = nullptr) = 0;
 
-    virtual Node* 
+    virtual Node*
     make_tree_entry(std::size_t n, const Node* nodelist[], Node* parent = 0) = 0;
 
     // --- globals

--- a/include/caliper/common/cali_types.h
+++ b/include/caliper/common/cali_types.h
@@ -115,7 +115,15 @@ typedef enum {
    * tree branch, but one that is separate from the properly nested
    * region branch. Stack nesting checks are skipped.
    */
-  CALI_ATTR_UNALIGNED     =  1024
+  CALI_ATTR_UNALIGNED     =  1024,
+
+  /** \brief This attribute is aggregatable (i.e., a metric).
+   *
+   * Attributes with this flag will automatically be aggregated by the
+   * \a aggregate service. This flag replaces the previous
+   * \a class.aggregatable meta-attribute.
+   */
+   CALI_ATTR_AGGREGATABLE =  2048
 } cali_attr_properties;
 
 #define CALI_ATTR_SCOPE_MASK 60

--- a/python/caliper-reader/caliperreader/metadatadb.py
+++ b/python/caliper-reader/caliperreader/metadatadb.py
@@ -65,6 +65,7 @@ class Attribute:
     CALI_ATTR_HIDDEN  = 128
     CALI_ATTR_NESTED  = 256
     CALI_ATTR_GLOBAL  = 512
+    CALI_ATTR_AGGREGATABLE = 2048
 
     SCOPE_PROCESS     =  12
     SCOPE_THREAD      =  20
@@ -138,6 +139,12 @@ class Attribute:
 
         return (self.prop & self.CALI_ATTR_HIDDEN) != 0
 
+    def is_aggregatable(self):
+        """ Is this an aggregatable attribute (i.e., a metric)?
+        """
+
+        return (self.prop & self.CALI_ATTR_AGGREGATABLE) != 0
+
     def scope(self):
         """ Returns the attribute's scope ("process", "thread", or "task")
         """
@@ -159,6 +166,8 @@ class Attribute:
             "is_global" : self.is_global() ,
             "is_value"  : self.is_value()  ,
             "is_nested" : self.is_nested() ,
+            "is_aggregatable"    : self.is_aggregatable() ,
+            "class.aggregatable" : self.is_aggregatable() , # legacy support
             "type"      : self.attribute_type()
         }
 

--- a/src/caliper/Caliper.cpp
+++ b/src/caliper/Caliper.cpp
@@ -38,6 +38,8 @@ using namespace std;
 
 using SnapshotRecord = FixedSizeSnapshotRecord<SNAP_MAX>;
 
+extern cali_id_t cali_class_aggregatable_attr_id;
+
 namespace cali
 {
 
@@ -706,6 +708,13 @@ Caliper::create_attribute(const std::string& name, cali_attr_type type, int prop
         // Set scope to default scope if none is set
         if ((prop & CALI_ATTR_SCOPE_MASK) == 0)
             prop |= sG->attribute_default_scope;
+
+        // Set CALI_ATTR_AGGREGATABLE property if class.aggregatable metadata is set
+        for (const Node* tmp = node; tmp; tmp = tmp->parent())
+            if (tmp->attribute() == cali_class_aggregatable_attr_id && tmp->data() == Variant(true)) {
+                prop |= CALI_ATTR_AGGREGATABLE;
+                break;
+            }
 
         Attribute attr[2] { prop_attr, name_attr };
         Variant   data[2] { { prop },  { CALI_TYPE_STRING, name.c_str(), name.size() } };

--- a/src/common/CaliperMetadataAccessInterface.cpp
+++ b/src/common/CaliperMetadataAccessInterface.cpp
@@ -20,3 +20,16 @@ CaliperMetadataAccessInterface::find_attributes_with(const Attribute& meta) cons
 
     return ret;
 }
+
+std::vector<Attribute>
+CaliperMetadataAccessInterface::find_attributes_with_prop(int prop) const
+{
+    std::vector<Attribute> vec = get_all_attributes();
+    std::vector<Attribute> ret;
+
+    for (Attribute attr : vec)
+        if (attr.properties() & prop)
+            ret.push_back(attr);
+
+    return ret;
+}

--- a/src/common/cali_types.c
+++ b/src/common/cali_types.c
@@ -14,7 +14,7 @@
 
 static const struct typemap_t {
   const char* str; cali_attr_type type;
-} typemap[] = { 
+} typemap[] = {
   { "inv",    CALI_TYPE_INV    },
   { "usr",    CALI_TYPE_USR    },
   { "int",    CALI_TYPE_INT    },
@@ -47,17 +47,18 @@ cali_string2type(const char* str)
 static const struct propmap_t {
   const char* str; cali_attr_properties prop; int mask;
 } propmap[] = {
-  { "default",       CALI_ATTR_DEFAULT,       CALI_ATTR_DEFAULT     },
-  { "asvalue",       CALI_ATTR_ASVALUE,       CALI_ATTR_ASVALUE     },
-  { "nomerge",       CALI_ATTR_NOMERGE,       CALI_ATTR_NOMERGE     },
-  { "process_scope", CALI_ATTR_SCOPE_PROCESS, CALI_ATTR_SCOPE_MASK  },
-  { "thread_scope",  CALI_ATTR_SCOPE_THREAD,  CALI_ATTR_SCOPE_MASK  }, 
-  { "task_scope",    CALI_ATTR_SCOPE_TASK,    CALI_ATTR_SCOPE_MASK  },
-  { "skip_events",   CALI_ATTR_SKIP_EVENTS,   CALI_ATTR_SKIP_EVENTS },
-  { "hidden",        CALI_ATTR_HIDDEN,        CALI_ATTR_HIDDEN      },
-  { "nested",        CALI_ATTR_NESTED,        CALI_ATTR_NESTED      },
-  { "global",        CALI_ATTR_GLOBAL,        CALI_ATTR_GLOBAL      },
-  { "unaligned",     CALI_ATTR_UNALIGNED,     CALI_ATTR_UNALIGNED   },
+  { "default",       CALI_ATTR_DEFAULT,       CALI_ATTR_DEFAULT      },
+  { "asvalue",       CALI_ATTR_ASVALUE,       CALI_ATTR_ASVALUE      },
+  { "nomerge",       CALI_ATTR_NOMERGE,       CALI_ATTR_NOMERGE      },
+  { "process_scope", CALI_ATTR_SCOPE_PROCESS, CALI_ATTR_SCOPE_MASK   },
+  { "thread_scope",  CALI_ATTR_SCOPE_THREAD,  CALI_ATTR_SCOPE_MASK   },
+  { "task_scope",    CALI_ATTR_SCOPE_TASK,    CALI_ATTR_SCOPE_MASK   },
+  { "skip_events",   CALI_ATTR_SKIP_EVENTS,   CALI_ATTR_SKIP_EVENTS  },
+  { "hidden",        CALI_ATTR_HIDDEN,        CALI_ATTR_HIDDEN       },
+  { "nested",        CALI_ATTR_NESTED,        CALI_ATTR_NESTED       },
+  { "global",        CALI_ATTR_GLOBAL,        CALI_ATTR_GLOBAL       },
+  { "unaligned",     CALI_ATTR_UNALIGNED,     CALI_ATTR_UNALIGNED    },
+  { "aggregatable",  CALI_ATTR_AGGREGATABLE,  CALI_ATTR_AGGREGATABLE },
   { 0, CALI_ATTR_DEFAULT, CALI_ATTR_DEFAULT }
 };
 
@@ -65,18 +66,18 @@ int
 cali_prop2string(int prop, char* buf, size_t len)
 {
   int ret = 0;
-  
+
   for (const struct propmap_t* p = propmap; p->str; ++p) {
       if (!((prop & p->mask) == (int) p->prop))
       continue;
-    
+
     size_t slen = strlen(p->str);
-    
+
     if ((slen + (ret>0?2:1)) > len)
       return -1;
     if (ret > 0)
       buf[ret++] = ':';
-    
+
     strcpy(buf+ret, p->str);
 
     ret      += slen;
@@ -90,7 +91,7 @@ int
 cali_string2prop(const char* str)
 {
   int prop = 0;
-  
+
   for (const struct propmap_t* p = propmap; p->str; ++p) {
     const char* pos = strstr(str, p->str);
     size_t      len = strlen(p->str);

--- a/src/mpi/services/mpiwrap/MpiTracing.cpp
+++ b/src/mpi/services/mpiwrap/MpiTracing.cpp
@@ -93,28 +93,17 @@ struct MpiTracing::MpiTracingImpl
             { "mpi.comm.list",     CALI_TYPE_USR,   CALI_ATTR_DEFAULT | CALI_ATTR_SKIP_EVENTS,
               &comm_list_attr  },
 
+            { "mpi.msg.size",      CALI_TYPE_INT,   CALI_ATTR_ASVALUE | CALI_ATTR_SKIP_EVENTS | CALI_ATTR_AGGREGATABLE,
+              &msg_size_attr   },
+            { "mpi.send.count",    CALI_TYPE_INT,   CALI_ATTR_ASVALUE | CALI_ATTR_SKIP_EVENTS | CALI_ATTR_AGGREGATABLE,
+              &send_count_attr },
+            { "mpi.recv.count",    CALI_TYPE_INT,   CALI_ATTR_ASVALUE | CALI_ATTR_SKIP_EVENTS | CALI_ATTR_AGGREGATABLE,
+              &recv_count_attr },
+            { "mpi.coll.count",    CALI_TYPE_INT,   CALI_ATTR_ASVALUE | CALI_ATTR_SKIP_EVENTS | CALI_ATTR_AGGREGATABLE,
+              &coll_count_attr },
+
             { nullptr, CALI_TYPE_INV, 0, nullptr }
         };
-
-        for (const attr_info_t* p = attr_info_tbl; p->name; ++p)
-            *(p->ptr) = c->create_attribute(p->name, p->type, p->prop);
-
-        Attribute class_aggr_attr = c->get_attribute("class.aggregatable");
-        Variant v_true(true);
-
-        msg_size_attr =
-            c->create_attribute("mpi.msg.size", CALI_TYPE_INT, CALI_ATTR_ASVALUE | CALI_ATTR_SKIP_EVENTS,
-                                1, &class_aggr_attr, &v_true);
-        send_count_attr =
-            c->create_attribute("mpi.send.count", CALI_TYPE_INT, CALI_ATTR_ASVALUE | CALI_ATTR_SKIP_EVENTS,
-                                1, &class_aggr_attr, &v_true);
-        recv_count_attr =
-            c->create_attribute("mpi.recv.count", CALI_TYPE_INT, CALI_ATTR_ASVALUE | CALI_ATTR_SKIP_EVENTS,
-                                1, &class_aggr_attr, &v_true);
-        coll_count_attr =
-            c->create_attribute("mpi.coll.count", CALI_TYPE_INT, CALI_ATTR_ASVALUE | CALI_ATTR_SKIP_EVENTS,
-                                1, &class_aggr_attr, &v_true);
-        
     }
 
     void init_mpi(Caliper* c, Channel* chn) {

--- a/src/services/aggregate/Aggregate.cpp
+++ b/src/services/aggregate/Aggregate.cpp
@@ -115,8 +115,7 @@ class Aggregate
         if (aggr_attr_names.empty()) {
             // find all attributes of class "class.aggregatable"
 
-            info.aggr_attrs =
-                c->find_attributes_with(c->get_attribute("class.aggregatable"));
+            info.aggr_attrs = c->find_attributes_with_prop(CALI_ATTR_AGGREGATABLE);
         } else if (aggr_attr_names.front() != "none") {
             for (const std::string& name : aggr_attr_names) {
                 Attribute attr = c->get_attribute(name);

--- a/src/services/alloc/AllocService.cpp
+++ b/src/services/alloc/AllocService.cpp
@@ -277,9 +277,9 @@ class AllocService
                 if (!tree_node)
                     continue;
 
-                data[0] = Entry(g_memoryaddress_attrs[i].alloc_uid_attr,  
+                data[0] = Entry(g_memoryaddress_attrs[i].alloc_uid_attr,
                                 (*tree_node).v_uid);
-                data[1] = Entry(g_memoryaddress_attrs[i].alloc_index_attr, 
+                data[1] = Entry(g_memoryaddress_attrs[i].alloc_index_attr,
                                 cali_make_variant_from_uint((*tree_node).index_1D(addr)));
 
                 label_node = (*tree_node).addr_label_nodes[i];
@@ -370,10 +370,6 @@ class AllocService
 
     AllocService(Caliper* c, Channel* chn)
         {
-            Attribute class_aggr_attr =
-                c->get_attribute("class.aggregatable");
-            Variant   v_true(true);
-
             struct attr_info_t {
                 const char*    name;
                 cali_attr_type type;
@@ -411,12 +407,14 @@ class AllocService
                   0, nullptr, nullptr,
                   &alloc_num_elems_attr
                 },
-                { "alloc.total_size", CALI_TYPE_INT,     CALI_ATTR_SCOPE_THREAD  | CALI_ATTR_ASVALUE,
-                  1, &class_aggr_attr, &v_true,
+                { "alloc.total_size", CALI_TYPE_INT,
+                  CALI_ATTR_SCOPE_THREAD  | CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE,
+                  0, nullptr, nullptr,
                   &alloc_total_size_attr
                 },
-                { "alloc.region.highwatermark", CALI_TYPE_UINT, CALI_ATTR_SCOPE_PROCESS | CALI_ATTR_ASVALUE,
-                  1, &class_aggr_attr, &v_true,
+                { "alloc.region.highwatermark", CALI_TYPE_UINT,
+                  CALI_ATTR_SCOPE_PROCESS | CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE,
+                  0, nullptr, nullptr,
                   &region_hwm_attr
                 },
                 { 0, CALI_TYPE_INV, CALI_ATTR_DEFAULT, 0, nullptr, nullptr, nullptr }

--- a/src/services/cupti/CuptiTrace.cpp
+++ b/src/services/cupti/CuptiTrace.cpp
@@ -972,7 +972,8 @@ class CuptiTraceService
                 c->create_attribute("time.unit", CALI_TYPE_STRING, CALI_ATTR_SKIP_EVENTS);
             Attribute addr_class_attr =
                 c->get_attribute("class.memoryaddress");
-            Variant   nsec_val = Variant(CALI_TYPE_STRING, "nsec", 4);
+            Variant nsec_val(CALI_TYPE_STRING, "nsec", 4);
+            Variant true_val(true);
 
             activity_start_attr =
                 c->create_attribute("cupti.activity.start",    CALI_TYPE_UINT,

--- a/src/services/cupti/CuptiTrace.cpp
+++ b/src/services/cupti/CuptiTrace.cpp
@@ -970,16 +970,9 @@ class CuptiTraceService
         {
             Attribute unit_attr =
                 c->create_attribute("time.unit", CALI_TYPE_STRING, CALI_ATTR_SKIP_EVENTS);
-            Attribute aggr_class_attr =
-                c->get_attribute("class.aggregatable");
             Attribute addr_class_attr =
                 c->get_attribute("class.memoryaddress");
-
-            Variant   nsec_val  = Variant(CALI_TYPE_STRING, "nsec", 4);
-            Variant   true_val  = Variant(true);
-
-            Attribute meta_attr[2] = { aggr_class_attr, unit_attr };
-            Variant   meta_vals[2] = { true_val,        nsec_val  };
+            Variant   nsec_val = Variant(CALI_TYPE_STRING, "nsec", 4);
 
             activity_start_attr =
                 c->create_attribute("cupti.activity.start",    CALI_TYPE_UINT,
@@ -989,8 +982,10 @@ class CuptiTraceService
                                     CALI_ATTR_ASVALUE | CALI_ATTR_SKIP_EVENTS);
             activity_duration_attr =
                 c->create_attribute("cupti.activity.duration", CALI_TYPE_UINT,
-                                    CALI_ATTR_ASVALUE | CALI_ATTR_SKIP_EVENTS,
-                                    2, meta_attr, meta_vals);
+                                    CALI_ATTR_ASVALUE     |
+                                    CALI_ATTR_SKIP_EVENTS |
+                                    CALI_ATTR_AGGREGATABLE,
+                                    1, &unit_attr, &nsec_val);
             activity_kind_attr =
                 c->create_attribute("cupti.activity.kind",     CALI_TYPE_STRING,
                                     CALI_ATTR_DEFAULT | CALI_ATTR_SKIP_EVENTS);
@@ -1002,8 +997,9 @@ class CuptiTraceService
                                     CALI_ATTR_DEFAULT | CALI_ATTR_SKIP_EVENTS);
             memcpy_bytes_attr =
                 c->create_attribute("cupti.memcpy.bytes",      CALI_TYPE_UINT,
-                                    CALI_ATTR_ASVALUE | CALI_ATTR_SKIP_EVENTS,
-                                    1, &aggr_class_attr, &true_val);
+                                    CALI_ATTR_ASVALUE     |
+                                    CALI_ATTR_SKIP_EVENTS |
+                                    CALI_ATTR_AGGREGATABLE);
             starttime_attr =
                 c->create_attribute("cupti.starttime",         CALI_TYPE_UINT,
                                     CALI_ATTR_SCOPE_PROCESS |
@@ -1020,12 +1016,14 @@ class CuptiTraceService
                                     CALI_ATTR_DEFAULT | CALI_ATTR_SKIP_EVENTS);
             uvm_bytes_attr =
                 c->create_attribute("cupti.uvm.bytes",      CALI_TYPE_UINT,
-                                    CALI_ATTR_ASVALUE | CALI_ATTR_SKIP_EVENTS,
-                                    1, &aggr_class_attr, &true_val);
+                                    CALI_ATTR_ASVALUE     |
+                                    CALI_ATTR_SKIP_EVENTS |
+                                    CALI_ATTR_AGGREGATABLE);
             uvm_pagefault_groups_attr =
                 c->create_attribute("cupti.uvm.pagefault.groups", CALI_TYPE_UINT,
-                                    CALI_ATTR_ASVALUE | CALI_ATTR_SKIP_EVENTS,
-                                    1, &aggr_class_attr, &true_val);
+                                    CALI_ATTR_ASVALUE     |
+                                    CALI_ATTR_SKIP_EVENTS |
+                                    CALI_ATTR_AGGREGATABLE);
             uvm_migration_cause_attr =
                 c->create_attribute("cupti.uvm.migration.cause", CALI_TYPE_STRING,
                                     CALI_ATTR_DEFAULT | CALI_ATTR_SKIP_EVENTS);
@@ -1052,8 +1050,9 @@ class CuptiTraceService
                     c->create_attribute("cupti.host.duration", CALI_TYPE_UINT,
                                         CALI_ATTR_SCOPE_THREAD |
                                         CALI_ATTR_ASVALUE      |
-                                        CALI_ATTR_SKIP_EVENTS,
-                                        2, meta_attr, meta_vals);
+                                        CALI_ATTR_SKIP_EVENTS  |
+                                        CALI_ATTR_AGGREGATABLE,
+                                        1, &unit_attr, &nsec_val);
             }
 
             flush_info_attributes = config.get("info_attributes").to_stringlist();

--- a/src/services/event/EventTrigger.cpp
+++ b/src/services/event/EventTrigger.cpp
@@ -244,13 +244,11 @@ class EventTrigger
     EventTrigger(Caliper* c, Channel* chn)
         : event_root_node(CALI_INV_ID, CALI_INV_ID, Variant())
         {
-            Attribute aggr_attr = c->get_attribute("class.aggregatable");
-            Variant   v_true(true);
-
             region_count_attr =
                 c->create_attribute("region.count", CALI_TYPE_UINT,
-                                    CALI_ATTR_SKIP_EVENTS | CALI_ATTR_ASVALUE,
-                                    1, &aggr_attr, &v_true);
+                                    CALI_ATTR_SKIP_EVENTS |
+                                    CALI_ATTR_ASVALUE     |
+                                    CALI_ATTR_AGGREGATABLE);
 
             ConfigSet cfg =
                 chn->config().init("event", s_configdata);

--- a/src/services/io/IOService.cpp
+++ b/src/services/io/IOService.cpp
@@ -181,16 +181,16 @@ namespace
       c->create_attribute("io.mount.point",   CALI_TYPE_STRING,
                           CALI_ATTR_SCOPE_THREAD | CALI_ATTR_SKIP_EVENTS);
 
-    Attribute aggr_attr = c->get_attribute("class.aggregatable");
-
     io_bytes_read_attr =
       c->create_attribute("io.bytes.read",    CALI_TYPE_UINT,
-                          CALI_ATTR_SCOPE_THREAD | CALI_ATTR_ASVALUE,
-                          1, &aggr_attr, &v_true);
+                          CALI_ATTR_SCOPE_THREAD |
+                          CALI_ATTR_ASVALUE      |
+                          CALI_ATTR_AGGREGATABLE);
     io_bytes_written_attr =
       c->create_attribute("io.bytes.written", CALI_TYPE_UINT,
-                          CALI_ATTR_SCOPE_THREAD | CALI_ATTR_ASVALUE,
-                          1, &aggr_attr, &v_true);
+                          CALI_ATTR_SCOPE_THREAD |
+                          CALI_ATTR_ASVALUE      |
+                          CALI_ATTR_AGGREGATABLE);
 
     // register Caliper post_init_evt and finish_evt callbacks
     channel->events().post_init_evt.connect(init_curious_in_channel);

--- a/src/services/libpfm/Libpfm.cpp
+++ b/src/services/libpfm/Libpfm.cpp
@@ -466,9 +466,6 @@ class LibpfmService
             }
         }
 
-        Attribute aggr_class_attr = c->get_attribute("class.aggregatable");
-        Variant   v_true(true);
-
         for (size_t i=0; i<events_listed; i++) {
             if (enable_sampling) {
                 try {
@@ -490,8 +487,8 @@ class LibpfmService
                                             CALI_TYPE_UINT,
                                             CALI_ATTR_ASVALUE
                                             | CALI_ATTR_SCOPE_THREAD
-                                            | CALI_ATTR_SKIP_EVENTS,
-                                            1, &aggr_class_attr, &v_true);
+                                            | CALI_ATTR_SKIP_EVENTS
+                                            | CALI_ATTR_AGGREGATABLE);
                 libpfm_event_counter_attrs.push_back(event_counter_attr);
             }
         }

--- a/src/services/memusage/MemUsageService.cpp
+++ b/src/services/memusage/MemUsageService.cpp
@@ -42,19 +42,16 @@ void post_init_cb(Caliper* c, Channel* chn)
 
 void memusage_register(Caliper* c, Channel* chn)
 {
-    Attribute aggr_attr = c->get_attribute("class.aggregatable");
-    Variant v_true(true);
-
     malloc_total_bytes_attr =
         c->create_attribute("malloc.total.bytes", CALI_TYPE_UINT,
                             CALI_ATTR_SCOPE_PROCESS |
-                            CALI_ATTR_ASVALUE,
-                            1, &aggr_attr, &v_true);
+                            CALI_ATTR_ASVALUE       |
+                            CALI_ATTR_AGGREGATABLE);
     malloc_bytes_attr =
         c->create_attribute("malloc.bytes", CALI_TYPE_INT,
                             CALI_ATTR_SCOPE_PROCESS |
-                            CALI_ATTR_ASVALUE,
-                            1, &aggr_attr, &v_true);
+                            CALI_ATTR_ASVALUE       |
+                            CALI_ATTR_AGGREGATABLE);
 
     chn->events().post_init_evt.connect(post_init_cb);
     chn->events().snapshot.connect(snapshot_cb);

--- a/src/services/monitor/LoopMonitor.cpp
+++ b/src/services/monitor/LoopMonitor.cpp
@@ -17,7 +17,6 @@ using namespace cali;
 namespace cali
 {
 
-extern Attribute class_aggregatable_attr;
 extern Attribute class_iteration_attr;
 extern Attribute loop_attr;
 
@@ -129,8 +128,8 @@ class LoopMonitor
         num_iterations_attr =
             c->create_attribute("loop.iterations", CALI_TYPE_INT,
                                 CALI_ATTR_SKIP_EVENTS |
-                                CALI_ATTR_ASVALUE,
-                                1, &class_aggregatable_attr, &v_true);
+                                CALI_ATTR_ASVALUE     |
+                                CALI_ATTR_AGGREGATABLE);
         start_iteration_attr =
             c->create_attribute("loop.start_iteration", CALI_TYPE_INT,
                                 CALI_ATTR_SKIP_EVENTS |

--- a/src/services/monitor/RegionMonitor.cpp
+++ b/src/services/monitor/RegionMonitor.cpp
@@ -14,14 +14,6 @@
 
 using namespace cali;
 
-namespace cali
-{
-
-extern Attribute class_aggregatable_attr;
-extern Attribute class_iteration_attr;
-
-}
-
 namespace
 {
 

--- a/src/services/papi/Papi.cpp
+++ b/src/services/papi/Papi.cpp
@@ -23,13 +23,6 @@ using namespace cali;
 
 #include <papi.h>
 
-namespace cali
-{
-
-extern cali::Attribute class_aggregatable_attr;
-
-}
-
 namespace
 {
 
@@ -93,7 +86,6 @@ class PapiService
     bool setup_event_info(Caliper* c, const std::vector<std::string>& eventlist) {
         m_event_groups.clear();
 
-        Variant v_true(true);
         int count = 0;
 
         for (auto &name : eventlist) {
@@ -124,8 +116,8 @@ class PapiService
                 c->create_attribute(std::string("papi.")+name, CALI_TYPE_UINT,
                                     CALI_ATTR_SCOPE_THREAD |
                                     CALI_ATTR_SKIP_EVENTS  |
-                                    CALI_ATTR_ASVALUE,
-                                    1, &class_aggregatable_attr, &v_true);
+                                    CALI_ATTR_ASVALUE      |
+                                    CALI_ATTR_AGGREGATABLE);
 
             int component = PAPI_get_event_component(code);
 

--- a/src/services/pcp/Pcp.cpp
+++ b/src/services/pcp/Pcp.cpp
@@ -188,7 +188,7 @@ class PcpService {
                                 CALI_ATTR_SCOPE_PROCESS |
                                 CALI_ATTR_SKIP_EVENTS   |
                                 CALI_ATTR_AGGREGATABLE,
-                                1, &unit_attr, &sec_vals);
+                                1, &unit_attr, &sec_val);
     }
 
     static bool init_pcp_context(const char* hostname) {

--- a/src/services/pcp/Pcp.cpp
+++ b/src/services/pcp/Pcp.cpp
@@ -19,13 +19,6 @@
 
 using namespace cali;
 
-namespace cali
-{
-
-extern cali::Attribute class_aggregatable_attr;
-
-}
-
 namespace
 {
 
@@ -95,7 +88,7 @@ class PcpService {
 
                 rec.append(m_metric_info[i].attr, Variant(val));
             }
-            
+
             m_prev_value[i] = total;
         }
 
@@ -148,12 +141,11 @@ class PcpService {
 
             // TODO: Do some sanity checking
 
-            Variant v_true(true);
             Attribute attr =
                 c->create_attribute(std::string("pcp.")+name, CALI_TYPE_DOUBLE,
                                     CALI_ATTR_SKIP_EVENTS |
-                                    CALI_ATTR_ASVALUE,
-                                    1, &class_aggregatable_attr, &v_true);
+                                    CALI_ATTR_ASVALUE     |
+                                    CALI_ATTR_AGGREGATABLE);
 
             list.push_back(pmid);
             info.push_back( { name, attr, pmdesc} );
@@ -176,33 +168,27 @@ class PcpService {
     {
         Attribute unit_attr =
             c->create_attribute("time.unit", CALI_TYPE_STRING, CALI_ATTR_SKIP_EVENTS);
-        Attribute aggr_class_attr =
-            c->get_attribute("class.aggregatable");
-
         Variant   sec_val   = Variant("sec");
-        Variant   true_val  = Variant(true);
-
-        Attribute meta_attr[2] = { aggr_class_attr, unit_attr };
-        Variant   meta_vals[2] = { true_val,        sec_val   };
 
         m_timestamp_sec_attr =
             c->create_attribute("pcp.timestamp.sec", CALI_TYPE_UINT,
                                 CALI_ATTR_ASVALUE       |
                                 CALI_ATTR_SCOPE_PROCESS |
-                                CALI_ATTR_SKIP_EVENTS,
-                                1, &unit_attr, &sec_val);
+                                CALI_ATTR_SKIP_EVENTS   |
+                                CALI_ATTR_AGGREGATABLE);
         m_timestamp_attr =
             c->create_attribute("pcp.timestamp", CALI_TYPE_DOUBLE,
                                 CALI_ATTR_ASVALUE       |
                                 CALI_ATTR_SCOPE_PROCESS |
-                                CALI_ATTR_SKIP_EVENTS,
-                                1, &unit_attr, &sec_val);
+                                CALI_ATTR_SKIP_EVENTS   |
+                                CALI_ATTR_AGGREGATABLE);
         m_time_duration_attr =
             c->create_attribute("pcp.time.duration", CALI_TYPE_DOUBLE,
                                 CALI_ATTR_ASVALUE       |
                                 CALI_ATTR_SCOPE_PROCESS |
-                                CALI_ATTR_SKIP_EVENTS,
-                                2, meta_attr, meta_vals);
+                                CALI_ATTR_SKIP_EVENTS   |
+                                CALI_ATTR_AGGREGATABLE,
+                                1, &unit_attr, &sec_vals);
     }
 
     static bool init_pcp_context(const char* hostname) {

--- a/src/services/pcp/PcpMemory.cpp
+++ b/src/services/pcp/PcpMemory.cpp
@@ -135,19 +135,16 @@ class PcpMemory
     PcpMemory(Caliper* c, Channel*)
         : num_computed(0), num_flushes(0)
         {
-            Attribute aggr_attr = c->get_attribute("class.aggregatable");
-            Variant v_true(true);
-
             rd_result_attr =
                 c->create_attribute("mem.bytes.read", CALI_TYPE_DOUBLE,
-                                    CALI_ATTR_ASVALUE |
-                                    CALI_ATTR_SKIP_EVENTS,
-                                    1, &aggr_attr, &v_true);
+                                    CALI_ATTR_ASVALUE     |
+                                    CALI_ATTR_SKIP_EVENTS |
+                                    CALI_ATTR_AGGREGATABLE);
             wr_result_attr =
                 c->create_attribute("mem.bytes.written", CALI_TYPE_DOUBLE,
-                                    CALI_ATTR_ASVALUE |
-                                    CALI_ATTR_SKIP_EVENTS,
-                                    1, &aggr_attr, &v_true);
+                                    CALI_ATTR_ASVALUE     |
+                                    CALI_ATTR_SKIP_EVENTS |
+                                    CALI_ATTR_AGGREGATABLE);
         }
 
 public:

--- a/src/services/roctracer/RocTracer.cpp
+++ b/src/services/roctracer/RocTracer.cpp
@@ -86,13 +86,11 @@ class RocTracerService {
             c->create_attribute("rocm.endtime", CALI_TYPE_UINT,
                                 CALI_ATTR_ASVALUE | CALI_ATTR_SKIP_EVENTS);
 
-        Attribute aggr_attr = c->get_attribute("class.aggregatable");
-        Variant v_true(true);
-
         m_activity_duration_attr =
             c->create_attribute("rocm.activity.duration", CALI_TYPE_UINT,
-                                CALI_ATTR_ASVALUE | CALI_ATTR_SKIP_EVENTS,
-                                1, &aggr_attr, &v_true);
+                                CALI_ATTR_ASVALUE     | 
+                                CALI_ATTR_SKIP_EVENTS |
+                                CALI_ATTR_AGGREGATABLE);
 
         m_activity_name_attr =
             c->create_attribute("rocm.activity", CALI_TYPE_STRING, CALI_ATTR_SKIP_EVENTS);
@@ -128,15 +126,12 @@ class RocTracerService {
                                 hide_offset);
 
         if (m_record_host_duration) {
-            Attribute aggr_attr = c->get_attribute("class.aggregatable");
-            Variant v_true(true);
-
             m_host_duration_attr =
                 c->create_attribute("rocm.host.duration", CALI_TYPE_UINT,
                                     CALI_ATTR_SCOPE_THREAD |
                                     CALI_ATTR_ASVALUE      |
-                                    CALI_ATTR_SKIP_EVENTS,
-                                    1, &aggr_attr, &v_true);
+                                    CALI_ATTR_SKIP_EVENTS  |
+                                    CALI_ATTR_AGGREGATABLE);
         }
     }
 

--- a/src/services/templates/MeasurementService.cpp
+++ b/src/services/templates/MeasurementService.cpp
@@ -21,13 +21,6 @@
 
 using namespace cali;
 
-namespace cali
-{
-
-extern cali::Attribute class_aggregatable_attr;
-
-}
-
 namespace
 {
 
@@ -151,16 +144,15 @@ class MeasurementTemplateService
         Variant v_true(true);
 
         //   The delta attribute stores the difference of the measurement
-        // value since the last snapshot. We add the "class.aggregatable"
-        // metadata attribute here, which lets Caliper aggregate these values
-        // automatically.
+        // value since the last snapshot. We add the "aggregatable" property
+        // here, which lets Caliper aggregate these values automatically.
         m.delta_attr =
             c->create_attribute(std::string("measurement.") + name,
                         CALI_TYPE_UINT,
                         CALI_ATTR_SCOPE_THREAD |
                         CALI_ATTR_ASVALUE      |
-                        CALI_ATTR_SKIP_EVENTS,
-                        1, &class_aggregatable_attr, &v_true);
+                        CALI_ATTR_SKIP_EVENTS  |
+                        CALI_ATTR_AGGREGATABLE);
 
         //   We use a hidden attribute to store the previous measurement
         // for <name> on Caliper's per-thread blackboard. This is a

--- a/src/services/umpire/UmpireStatistics.cpp
+++ b/src/services/umpire/UmpireStatistics.cpp
@@ -15,13 +15,6 @@
 using namespace cali;
 
 
-namespace cali
-{
-
-extern cali::Attribute class_aggregatable_attr;
-
-}
-
 namespace
 {
 
@@ -108,41 +101,45 @@ class UmpireService
     }
 
     void create_attributes(Caliper* c) {
-        Variant v_true(true);
-
         m_alloc_name_attr =
             c->create_attribute("umpire.alloc.name", CALI_TYPE_STRING,
                                 CALI_ATTR_SKIP_EVENTS);
         m_alloc_current_size_attr =
             c->create_attribute("umpire.alloc.current.size",
                                 CALI_TYPE_UINT,
-                                CALI_ATTR_ASVALUE | CALI_ATTR_SKIP_EVENTS,
-                                1, &class_aggregatable_attr, &v_true);
+                                CALI_ATTR_ASVALUE     |
+                                CALI_ATTR_SKIP_EVENTS |
+                                CALI_ATTR_AGGREGATABLE);
         m_alloc_actual_size_attr =
             c->create_attribute("umpire.alloc.actual.size",
                                 CALI_TYPE_UINT,
-                                CALI_ATTR_ASVALUE | CALI_ATTR_SKIP_EVENTS,
-                                1, &class_aggregatable_attr, &v_true);
+                                CALI_ATTR_ASVALUE     |
+                                CALI_ATTR_SKIP_EVENTS |
+                                CALI_ATTR_AGGREGATABLE);
         m_alloc_hwm_attr =
             c->create_attribute("umpire.alloc.highwatermark",
                                 CALI_TYPE_UINT,
-                                CALI_ATTR_ASVALUE | CALI_ATTR_SKIP_EVENTS,
-                                1, &class_aggregatable_attr, &v_true);
+                                CALI_ATTR_ASVALUE     |
+                                CALI_ATTR_SKIP_EVENTS |
+                                CALI_ATTR_AGGREGATABLE);
         m_alloc_count_attr =
             c->create_attribute("umpire.alloc.count",
                                 CALI_TYPE_UINT,
-                                CALI_ATTR_ASVALUE | CALI_ATTR_SKIP_EVENTS,
-                                1, &class_aggregatable_attr, &v_true);
+                                CALI_ATTR_ASVALUE     |
+                                CALI_ATTR_SKIP_EVENTS |
+                                CALI_ATTR_AGGREGATABLE);
         m_total_size_attr =
             c->create_attribute("umpire.total.size",
                                 CALI_TYPE_UINT,
-                                CALI_ATTR_ASVALUE | CALI_ATTR_SKIP_EVENTS,
-                                1, &class_aggregatable_attr, &v_true);
+                                CALI_ATTR_ASVALUE     |
+                                CALI_ATTR_SKIP_EVENTS |
+                                CALI_ATTR_AGGREGATABLE);
         m_total_count_attr =
             c->create_attribute("umpire.total.count",
                                 CALI_TYPE_UINT,
-                                CALI_ATTR_ASVALUE | CALI_ATTR_SKIP_EVENTS,
-                                1, &class_aggregatable_attr, &v_true);
+                                CALI_ATTR_ASVALUE     |
+                                CALI_ATTR_SKIP_EVENTS |
+                                CALI_ATTR_AGGREGATABLE);
     }
 
     UmpireService(Caliper* c, Channel* channel)

--- a/src/services/variorum/Variorum.cpp
+++ b/src/services/variorum/Variorum.cpp
@@ -26,12 +26,6 @@ extern "C" {
 
 using namespace cali;
 
-namespace cali
-{
-
-extern cali::Attribute class_aggregatable_attr;
-
-}
 
 namespace
 {
@@ -186,20 +180,20 @@ class VariorumService
                                     CALI_TYPE_UINT,
                                     CALI_ATTR_SCOPE_THREAD |
                                     CALI_ATTR_ASVALUE      |
-                                    CALI_ATTR_SKIP_EVENTS,
-                                    1, &class_aggregatable_attr, &v_true);
+                                    CALI_ATTR_SKIP_EVENTS  |
+                                    CALI_ATTR_AGGREGATABLE);
 
             // The delta attribute stores the difference of the measurement
-            // value since the last snapshot. We add the "class.aggregatable"
-            // metadata attribute here, which lets Caliper aggregate these values
+            // value since the last snapshot. We add the "aggregatable"
+            // property here, which lets Caliper aggregate these values
             // automatically.
             m.delta_attr =
                 c->create_attribute(std::string("variorum.") + domain,
                             CALI_TYPE_UINT,
                             CALI_ATTR_SCOPE_THREAD |
                             CALI_ATTR_ASVALUE      |
-                            CALI_ATTR_SKIP_EVENTS,
-                            1, &class_aggregatable_attr, &v_true);
+                            CALI_ATTR_SKIP_EVENTS  |
+                            CALI_ATTR_AGGREGATABLE);
 
             // We use a hidden attribute to store the previous measurement
             // for <name> on Caliper's per-thread blackboard. This is a


### PR DESCRIPTION
This simplifies making metric attributes, which is a common use case.