### PR TITLE
missing standard header

### DIFF
--- a/src/caliper/RegionFilter.cpp
+++ b/src/caliper/RegionFilter.cpp
@@ -6,6 +6,7 @@
 #include "../common/util/parse_util.h"
 
 #include <iostream>
+#include <sstream>
 
 using namespace cali;
 


### PR DESCRIPTION
this file uses std::istringstream, so needs
<sstream>. GCC doesn't complain but Clang does.

In particular, I get this on my Mac:
```
/Users/daibane/src/capp-alegra-ng/source/caliper/src/caliper/RegionFilter.cpp:146:28: error: implicit instantiation of undefined template 'std::basic_istringstream<char>'
        std::istringstream is(include);
                           ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/usr/include/c++/v1/iosfwd:138:32: note: template is declared here
    class _LIBCPP_TEMPLATE_VIS basic_istringstream;
                               ^
/Users/daibane/src/capp-alegra-ng/source/caliper/src/caliper/RegionFilter.cpp:156:28: error: implicit instantiation of undefined template 'std::basic_istringstream<char>'
        std::istringstream is(exclude);
                           ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/usr/include/c++/v1/iosfwd:138:32: note: template is declared here
    class _LIBCPP_TEMPLATE_VIS basic_istringstream;
                               ^
```