### PR TITLE
Add a TraceEvent converter script

### DIFF
--- a/python/cali2traceevent.py
+++ b/python/cali2traceevent.py
@@ -21,9 +21,11 @@ def _get_timestamp(rec):
     """
 
     timestamp_attributes = {
-        "cupti.timestamp"     : 1e-3,
-        "rocm.host.timestamp" : 1e-3,
-        "time.offset"         : 1.0,
+        "cupti.timestamp"      : 1e-3,
+        "rocm.host.timestamp"  : 1e-3,
+        "time.offset"          : 1.0,
+        "cupti.activity.start" : 1e-3,
+        "rocm.starttime"       : 1e-3
     }
 
     for attr,factor in timestamp_attributes.items():
@@ -46,12 +48,29 @@ class CaliTraceEventConverter:
     def __init__(self):
         self.records = []
         self.reader  = caliperreader.CaliperStreamReader()
+        self.rstack  = {}
 
         self.skipped = 0
         self.written = 0
 
     def read(self, filename_or_stream):
         self.reader.read(filename_or_stream, self._process_record)
+
+    def read_and_sort(self, filename_or_stream):
+        trace = []
+
+        def insert_into_trace(rec):
+            ts = _get_timestamp(rec)
+            if ts is None:
+                return
+            trace.append((ts,rec))
+
+        self.reader.read(filename_or_stream, insert_into_trace)
+
+        trace.sort(key=lambda e : e[0])
+
+        for rec in trace:
+            self._process_record(rec[1])
 
     def write(self, output):
         json.dump(self.records, output)
@@ -70,8 +89,11 @@ class CaliTraceEventConverter:
         else:
             keys = list(rec.keys())
             for key in keys:
+                if key.startswith("event.begin#"):
+                    self._process_event_begin_rec(rec, (pid, tid), key)
+                    return
                 if key.startswith("event.end#"):
-                    self._process_event_end_rec(rec, key, trec)
+                    self._process_event_end_rec(rec, (pid, tid), key, trec)
                     break
 
         if "name" in trec:
@@ -79,27 +101,27 @@ class CaliTraceEventConverter:
         else:
             self.skipped += 1
 
-    def _process_event_end_rec(self, rec, key, trec):
+    def _process_event_begin_rec(self, rec, loc, key):
+        attr = key[len("event.begin#"):]
+        tst  = _get_timestamp(rec)
+
+        skey = (loc,attr)
+
+        if skey in self.rstack:
+            self.rstack[skey].append(tst)
+        else:
+            self.rstack[skey] = [ tst ]
+
+    def _process_event_end_rec(self, rec, loc, key, trec):
         attr = key[len("event.end#"):]
+        btst = self.rstack[(loc,attr)].pop()
 
         # if not self.reader.attribute(attr).is_nested():
         #     return
 
-        duration_attributes = [
-            "time.inclusive.duration",
-            "time.duration"
-        ]
+        tst  = _get_timestamp(rec)
 
-        dur = _get_first_from_list(rec, duration_attributes, None)
-        tst = _get_timestamp(rec)
-
-        if tst is None or dur is None:
-            return
-
-        dur = float(dur)*1e6
-        tst = tst-dur
-
-        trec.update(ph="X", name=rec[key], cat=attr, ts=tst, dur=dur)
+        trec.update(ph="X", name=rec[key], cat=attr, ts=btst, dur=(tst-btst))
 
     def _process_cupti_activity_rec(self, rec, trec):
         cat  = rec["cupti.activity.kind"]
@@ -117,14 +139,31 @@ class CaliTraceEventConverter:
 
         trec.update(ph="X", name=name, cat=cat, ts=tst, dur=dur, tid="rocm")
 
+helpstr = """Usage: cali2traceevent.py 1.cali 2.cali ... [output.json]
+Options:
+--sort      Sort the trace before processing.
+            Enable this when encountering stack errors.
+"""
 
 def main():
     args = sys.argv[1:]
 
     if len(args) < 1:
-        sys.exit("Usage: cali2traceevent.py 1.cali 2.cali ... [output.json]")
+        sys.exit(helpstr)
 
     output = sys.stdout
+    sort_the_trace = False
+
+    while args[0].startswith("-"):
+        arg = args.pop(0)
+        if arg == "--":
+            break
+        if arg == "--sort":
+            sort_the_trace = True
+        elif arg == "--help":
+            sys.exit(helpstr)
+        else:
+            sys.exit(f'Unknown argument "{arg}"')
 
     if len(args) > 1 and args[-1].endswith(".json"):
         output = open(args.pop(), "w")
@@ -135,7 +174,10 @@ def main():
 
     for file in args:
         with open(file) as input:
-            converter.read(input)
+            if sort_the_trace:
+                converter.read_and_sort(input)
+            else:
+                converter.read(input)
 
     read_end = time.perf_counter()
 

--- a/python/cali2traceevent.py
+++ b/python/cali2traceevent.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+
+# Convert a .cali trace to Google TraceEvent JSON
+
+import caliperreader
+
+import json
+import sys
+
+
+def _get_first_from_list(rec, attribute_list, fallback=0):
+    for a in attribute_list:
+        if a in rec:
+            return rec[a]
+    return fallback
+
+
+class CaliTraceEventConverter:
+    PID_ATTRIBUTES = [
+        'mpi.rank'
+    ]
+
+    TID_ATTRIBUTES = [
+        'omp.thread.id',
+        'pthread.id'
+    ]
+
+    TS_ATTRIBUTES = [
+        'cupti.timestamp',
+        'cupti.activity.start',
+        'cupti.activity.end',
+        'time.offset'
+    ]
+
+    def __init__(self):
+        self.records = []
+        self.reader  = caliperreader.CaliperStreamReader()
+
+        self.skipped = 0
+        self.written = 0
+
+    def read(self, filename_or_stream):
+        self.reader.read(filename_or_stream, self._process_record)
+
+    def write(self, output):
+        json.dump(self.records, output)
+        self.written += len(self.records)
+
+    def _process_record(self, rec):
+        pid  = int(_get_first_from_list(rec, self.PID_ATTRIBUTES))
+        tid  = int(_get_first_from_list(rec, self.TID_ATTRIBUTES))
+
+        ts   = float(_get_first_from_list(rec, self.TS_ATTRIBUTES, None))
+        ts  *= 1e-3
+
+        if ts is None:
+            self.skipped += 1
+            return
+
+        trec = dict(pid=pid,tid=tid,ts=ts)
+        keys = list(rec.keys())
+
+        for k in keys:
+            if k.startswith("event.begin#"):
+                attr = k[len("event.begin#"):]
+                trec.update(ph="B", name=rec[k], cat=attr)
+                break
+            elif k.startswith("event.end#"):
+                attr = k[len("event.end#"):]
+                trec.update(ph="E", name=rec[k], cat=attr)
+                break
+        
+        if "name" in trec:
+            self.records.append(trec)
+        else:
+            self.skipped += 1
+
+
+def main():
+    args = sys.argv[1:]
+
+    if len(args) < 1:
+        sys.exit("Usage: cali2traceevent.py 1.cali 2.cali ... [output.json]")
+
+    output = sys.stdout
+
+    if len(args) > 1 and args[-1].endswith(".json"):
+        output = open(args.pop(), "w")
+    
+    converter = CaliTraceEventConverter()
+
+    for f in args:
+        with open(f) as input:
+            converter.read(f)
+
+    converter.write(output)
+
+    if output is not sys.stdout:
+        output.close()
+
+    w = converter.written
+    s = converter.skipped
+
+    print("{} records written, {} skipped.".format(w, s), file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/cali2traceevent.py
+++ b/python/cali2traceevent.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 
+# Copyright (c) 2022, Lawrence Livermore National Security, LLC.
+# See top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Convert a .cali trace to Google TraceEvent JSON
 
 import json

--- a/python/json2json_split.py
+++ b/python/json2json_split.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 
+# Copyright (c) 2022, Lawrence Livermore National Security, LLC.
+# See top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Convert the "simple" Caliper json format to Caliper json-split json format
 
 import json
@@ -53,7 +58,7 @@ def json_to_json_split(records):
         for k in rec.keys():
             if not k in coldict:
                 coldict[k] = { "is_value": not isinstance(rec[k], str) }
-    
+
     columns = list(coldict.keys())
     column_metadata = [ coldict[k] for k in columns ]
 
@@ -87,7 +92,7 @@ def main():
 
     with open(args[0]) as input:
         records = json.load(input)
-    
+
     output = open(args[1], "w") if len(args) > 1 else sys.stdout
     json.dump(json_to_json_split(records), output)
 

--- a/src/caliper/controllers/controllers.cpp
+++ b/src/caliper/controllers/controllers.cpp
@@ -19,6 +19,7 @@ const char* event_trace_spec =
     "     \"CALI_TIMER_SNAPSHOT_DURATION\" : \"true\","
     "     \"CALI_TIMER_UNIT\"              : \"sec\""
     "   },"
+    " \"defaults\"    : { \"event.timestamps\": \"true\" },"
     " \"options\": "
     " ["
     "  { \"name\"        : \"trace.io\","


### PR DESCRIPTION
Converts Caliper traces to Google TraceEvent format. Traces can be viewed in Chrome with chrome://tracing.