### PR TITLE
Fix callbacks

### DIFF
--- a/include/caliper/common/util/callback.hpp
+++ b/include/caliper/common/util/callback.hpp
@@ -31,13 +31,13 @@ public:
     template<class... Args>
     void operator()(Args&&... a) {
         for ( auto& f : mCb )
-            f(std::forward<Args>(a)...);
+            f(a...);
     }
 
     template<class Op, class R, class... Args>
     R accumulate(Op op, R init, Args&&... a) {
         for ( auto& f : mCb )
-            init = Op(init, f(std::forward<Args>(a)...));
+            init = Op(init, f(a...));
 
         return init;
     }


### PR DESCRIPTION
Remove std::forward<> in callback handlers. Not necessary and it leads to issues where arguments are being destroyed prematurely when there are multiple callbacks in the vector. In particular, the snapshot post-processing lambda was destroyed when there are multiple flush callback entries (e.g. using trace and aggregate combined) and caused crashes.