### PR TITLE
Use target_compile_features() to specify C++11 requirement

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,13 +1,3 @@
-set(CMAKE_C_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_STANDARD_REQUIRED ON) 
-
-if (WIN32)
-  set(CMAKE_CXX_STANDARD 17)
-else()
-  set(CMAKE_CXX_STANDARD 11)
-endif()
-set(CMAKE_C_STANDARD   99)
-
 set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 
 include(CheckCXXCompilerFlag)
@@ -52,6 +42,8 @@ add_library(caliper-serial ${CALIPER_SERIAL_OBJS})
 set_target_properties(caliper-serial PROPERTIES SOVERSION ${CALIPER_MAJOR_VERSION})
 set_target_properties(caliper-serial PROPERTIES VERSION ${CALIPER_VERSION})
 
+target_compile_features(caliper-serial PUBLIC cxx_std_11 c_std_99)
+
 target_include_directories(
   caliper-serial
   INTERFACE
@@ -74,6 +66,8 @@ add_library(caliper ${CALIPER_ALL_OBJS})
 
 set_target_properties(caliper PROPERTIES SOVERSION ${CALIPER_MAJOR_VERSION})
 set_target_properties(caliper PROPERTIES VERSION ${CALIPER_VERSION})
+
+target_compile_features(caliper PUBLIC cxx_std_11 c_std_99)
 
 target_include_directories(
   caliper

--- a/src/caliper/CMakeLists.txt
+++ b/src/caliper/CMakeLists.txt
@@ -21,6 +21,7 @@ add_subdirectory(controllers)
 add_library(caliper-runtime OBJECT ${CALIPER_RUNTIME_SOURCES})
 
 target_compile_options(caliper-runtime PRIVATE ${Wall_flag})
+target_compile_features(caliper-runtime PUBLIC cxx_std_11)
 
 list(APPEND CALIPER_SERIAL_OBJS
   caliper/machine_serial.cpp

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(caliper-common OBJECT
   ${CALIPER_COMMON_SOURCES})
 
 target_compile_options(caliper-common PRIVATE ${Wall_flag})
+target_compile_features(caliper-common PUBLIC cxx_std_11 c_std_99)
 
 if (BUILD_TESTING)
   add_subdirectory(test)

--- a/src/common/test/CMakeLists.txt
+++ b/src/common/test/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(test_caliper-common
   ${CALIPER_COMMON_TEST_SOURCES})
 
 target_link_libraries(test_caliper-common gtest_main)
+target_compile_features(test_caliper-common PUBLIC cxx_std_11)
 
 add_custom_target(caliper-common_test.config ALL
   COMMAND ${CMAKE_COMMAND} -E create_symlink

--- a/src/interface/c_fortran/CMakeLists.txt
+++ b/src/interface/c_fortran/CMakeLists.txt
@@ -14,3 +14,4 @@ if (WITH_FORTRAN)
 endif()
 
 add_library(caliper-interface OBJECT ${CALIPER_INTERFACE_SOURCES})
+target_compile_features(caliper-interface PUBLIC cxx_std_11)

--- a/src/mpi/CMakeLists.txt
+++ b/src/mpi/CMakeLists.txt
@@ -46,6 +46,7 @@ if (CALIPER_HAVE_MPIT)
 endif()
 
 add_library(caliper-mpi OBJECT ${CALIPER_MPI_SOURCES})
+target_compile_features(caliper-mpi PUBLIC cxx_std_11)
 
 # Add mpi objects and dependencies to global list for combined caliper lib
 list(APPEND CALIPER_ALL_OBJS

--- a/src/mpi/services/mpiwrap/CMakeLists.txt
+++ b/src/mpi/services/mpiwrap/CMakeLists.txt
@@ -17,5 +17,6 @@ set(CALIPER_MPIWRAP_SOURCES
   Wrapper.cpp)
 
 add_library(caliper-mpiwrap OBJECT ${CALIPER_MPIWRAP_SOURCES})
+target_compile_features(caliper-mpiwrap PUBLIC cxx_std_11)
 
 add_mpi_service_objlib(caliper-mpiwrap)

--- a/src/reader/CMakeLists.txt
+++ b/src/reader/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(caliper-reader OBJECT
   ${CALIPER_READER_SOURCES})
 
 target_compile_options(caliper-reader PRIVATE ${Wall_flag})
+target_compile_features(caliper-reader PUBLIC cxx_std_11)
 
 if (BUILD_TESTING)
   add_subdirectory(test)

--- a/src/reader/test/CMakeLists.txt
+++ b/src/reader/test/CMakeLists.txt
@@ -17,5 +17,6 @@ add_executable(test_caliper-reader
   ${CALIPER_READER_TEST_SOURCES})
 
 target_link_libraries(test_caliper-reader gtest_main)
+target_compile_features(test_caliper-reader PUBLIC cxx_std_11)
 
 add_test(NAME test-caliper-reader COMMAND test_caliper-reader)

--- a/src/services/CMakeLists.txt
+++ b/src/services/CMakeLists.txt
@@ -29,6 +29,7 @@ endmacro()
 
 macro(add_service_objlib)
   target_compile_options("${ARGN}" PRIVATE ${Wall_flag})
+  target_compile_features("${ARGN}" PUBLIC cxx_std_11 c_std_99)
   list(APPEND CALIPER_SERVICES_LIBS "$<TARGET_OBJECTS:${ARGN}>")
   set(CALIPER_SERVICES_LIBS ${CALIPER_SERVICES_LIBS} PARENT_SCOPE)
 endmacro()
@@ -143,6 +144,7 @@ add_custom_target(
 add_library(caliper-services OBJECT ${CALIPER_SERVICES_SOURCES})
 
 target_compile_options(caliper-services PRIVATE ${Wall_flag})
+target_compile_features(caliper-services PUBLIC cxx_std_11)
 
 add_dependencies(caliper-services gen-services)
 

--- a/src/tools/cali-query/CMakeLists.txt
+++ b/src/tools/cali-query/CMakeLists.txt
@@ -11,6 +11,7 @@ set(CALIPER_QUERY_SOURCES
   cali-query.cpp)
 
 add_library(query-common OBJECT ${CALIPER_QUERY_COMMON_SOURCES})
+target_compile_features(query-common PUBLIC cxx_std_11)
 
 add_executable(cali-query
   $<TARGET_OBJECTS:query-common>

--- a/src/tools/util/CMakeLists.txt
+++ b/src/tools/util/CMakeLists.txt
@@ -3,6 +3,8 @@ set(CALIPER_TOOLS_UTIL_SOURCES
 
 add_library(caliper-tools-util ${CALIPER_TOOLS_UTIL_SOURCES})
 
+target_compile_features(caliper-tools-util PUBLIC cxx_std_11)
+
 set_target_properties(caliper-tools-util PROPERTIES SOVERSION ${CALIPER_MAJOR_VERSION})
 set_target_properties(caliper-tools-util PROPERTIES VERSION ${CALIPER_VERSION})
 


### PR DESCRIPTION
Use CMake's target_compile_features() to set required language standards instead of CMAKE_[C|CXX]_STANDARD.