### PR TITLE
Option to retain original visit order in output hierarchy

### DIFF
--- a/include/caliper/reader/SnapshotTree.h
+++ b/include/caliper/reader/SnapshotTree.h
@@ -64,6 +64,9 @@ class SnapshotTreeNode : public util::LockfreeIntrusiveTree<SnapshotTreeNode>
 
     std::vector<Record> m_records;
 
+    std::map<Attribute, Variant> m_v_min;
+    std::map<Attribute, Variant> m_v_max;
+
     void add_record(const Record& rec) {
         m_records.push_back(rec);
     }
@@ -95,6 +98,14 @@ public:
     const decltype(m_records)& records() const {
         return m_records;
     }
+
+    /// \brief Recursively find the minimum value for \a key under this node
+    Variant   min_val(const Attribute& key);
+    /// \brief Recursively find the maximum value for \a key under this node
+    Variant   max_val(const Attribute& key);
+
+    /// \brief sort records by \a key
+    void      sort(const Attribute& key, bool ascending);
 
     friend class SnapshotTree;
 }; // SnapshotTreeNode
@@ -163,7 +174,7 @@ public:
                  IsPathPredicateFn is_path);
 
     /// \brief Return the snapshot tree's root node.
-    const SnapshotTreeNode*
+    SnapshotTreeNode*
     root() const;
 };
 

--- a/src/caliper/ConfigManager.cpp
+++ b/src/caliper/ConfigManager.cpp
@@ -621,6 +621,12 @@ struct ConfigManager::Options::OptionsImpl
                 ret.append(" aggregate ").append(it->second);
         }
 
+        {
+            auto it = in.find("order by");
+            if (it != in.end())
+                ret.append(" order by ").append(it->second);
+        }
+
         return ret;
     }
 

--- a/src/caliper/ConfigManager.cpp
+++ b/src/caliper/ConfigManager.cpp
@@ -187,6 +187,8 @@ class ConfigManager::OptionSpec
         std::vector< std::string   > groupby;
         std::vector< std::string   > let;
         std::vector< std::string   > where;
+        std::vector< std::string   > aggregate;
+        std::vector< std::string   > orderby;
     };
 
     struct option_spec_t {
@@ -238,6 +240,14 @@ class ConfigManager::OptionSpec
             it = dict.find("where");
             if (it != dict.end())
                 qarg.where = ::to_stringlist(it->second.rec_list());
+
+            it = dict.find("aggregate");
+            if (it != dict.end())
+                qarg.aggregate = ::to_stringlist(it->second.rec_list());
+
+            it = dict.find("order by");
+            if (it != dict.end())
+                qarg.orderby = ::to_stringlist(it->second.rec_list());
 
             it = dict.find("select");
             if (it != dict.end())
@@ -601,6 +611,42 @@ struct ConfigManager::Options::OptionsImpl
     }
 
     std::string
+    query_aggregate(const char* level, const std::string& in) const {
+        std::string ret = in;
+
+        for (const auto *q : get_enabled_query_args(level)) {
+            for (const auto &s : q->aggregate) {
+                if (!ret.empty())
+                    ret.append(",");
+                ret.append(s);
+            }
+        }
+
+        if (!ret.empty())
+            ret = std::string(" aggregate ") + ret;
+
+        return ret;
+    }
+
+    std::string
+    query_orderby(const char* level, const std::string& in) const {
+        std::string ret = in;
+
+        for (const auto *q : get_enabled_query_args(level)) {
+            for (const auto &s : q->orderby) {
+                if (!ret.empty())
+                    ret.append(",");
+                ret.append(s);
+            }
+        }
+
+        if (!ret.empty())
+            ret = std::string(" order by ") + ret;
+
+        return ret;
+    }
+
+    std::string
     build_query(const char* level, const std::map<std::string, std::string>& in, bool use_alias) {
         std::string ret;
 
@@ -608,23 +654,13 @@ struct ConfigManager::Options::OptionsImpl
         ret.append(query_select(level, ::find_or(in, "select"), use_alias));
         ret.append(query_groupby(level, ::find_or(in, "group by")));
         ret.append(query_where(level, ::find_or(in, "where")));
+        ret.append(query_aggregate(level, ::find_or(in, "aggregate")));
+        ret.append(query_orderby(level, ::find_or(in, "order by")));
 
         {
             auto it = in.find("format");
             if (it != in.end())
                 ret.append(" format ").append(it->second);
-        }
-
-        {
-            auto it = in.find("aggregate");
-            if (it != in.end())
-                ret.append(" aggregate ").append(it->second);
-        }
-
-        {
-            auto it = in.find("order by");
-            if (it != in.end())
-                ret.append(" order by ").append(it->second);
         }
 
         return ret;

--- a/src/caliper/controllers/RuntimeReportController.cpp
+++ b/src/caliper/controllers/RuntimeReportController.cpp
@@ -60,30 +60,23 @@ public:
                 config()["CALI_MPIREPORT_WRITE_ON_FINALIZE"] = "false";
                 config()["CALI_MPIREPORT_LOCAL_CONFIG"] =
                     opts.build_query("local", {
-                            { "let",       "o.slot=first(aggregate.slot)" },
                             { "select",    local_select  },
-                            { "group by",  "path" },
-                            { "aggregate", "min(o.slot)" }
+                            { "group by",  "path" }
                         });
                 config()["CALI_MPIREPORT_CONFIG"  ] =
                     opts.build_query("cross", {
                             { "select",    cross_select  },
                             { "group by",  "path" },
-                            { "format",    format        },
-                            { "aggregate", "min(min#o.slot)" },
-                            { "order by",  "min#min#o.slot" }
+                            { "format",    format        }
                         });
             } else {
                 config()["CALI_SERVICES_ENABLE"   ].append(",report");
                 config()["CALI_REPORT_FILENAME"   ] = opts.get("output", "stderr").to_string();
                 config()["CALI_REPORT_CONFIG"     ] =
                     opts.build_query("local", {
-                            { "let",       "o.slot=first(aggregate.slot)" },
                             { "select",    serial_select },
                             { "group by",  "path" },
-                            { "format",    format        },
-                            { "aggregate", "min(o.slot)" },
-                            { "order by",  "min#o.slot"  }
+                            { "format",    format }
                         });
             }
 
@@ -121,31 +114,50 @@ make_runtime_report_controller(const char* name, const config_map_t& initial_cfg
     return new RuntimeReportController(use_mpi(opts), name, initial_cfg, opts);
 }
 
-const char* runtime_report_spec =
-    "{"
-    " \"name\"        : \"runtime-report\","
-    " \"description\" : \"Print a time profile for annotated regions\","
-    " \"categories\"  : [ \"metric\", \"output\", \"region\", \"treeformatter\", \"event\" ],"
-    " \"services\"    : [ \"aggregate\", \"event\", \"timer\" ],"
-    " \"config\"      : "
-    "   { \"CALI_CHANNEL_FLUSH_ON_EXIT\"      : \"false\","
-    "     \"CALI_EVENT_ENABLE_SNAPSHOT_INFO\" : \"false\","
-    "     \"CALI_TIMER_UNIT\"                 : \"sec\""
-    "   },"
-    " \"options\": "
-    " ["
-    "  {"
-    "   \"name\": \"calc.inclusive\","
-    "   \"type\": \"bool\","
-    "   \"description\": \"Report inclusive instead of exclusive times\""
-    "  },"
-    "  {"
-    "   \"name\": \"aggregate_across_ranks\","
-    "   \"type\": \"bool\","
-    "   \"description\": \"Aggregate results across MPI ranks\""
-    "  }"
-    " ]"
-    "}";
+const char* runtime_report_spec = R"json(
+    {
+     "name"        : "runtime-report",
+     "description" : "Print a time profile for annotated regions",
+     "categories"  : [ "metric", "output", "region", "treeformatter", "event" ],
+     "services"    : [ "aggregate", "event", "timer" ],
+     "config"      :
+       { "CALI_CHANNEL_FLUSH_ON_EXIT"      : "false",
+         "CALI_EVENT_ENABLE_SNAPSHOT_INFO" : "false",
+         "CALI_TIMER_UNIT"                 : "sec"
+       },
+     "defaults"    : { "order_as_visited": "true" },
+     "options":
+     [
+      {
+       "name": "calc.inclusive",
+       "type": "bool",
+       "description": "Report inclusive instead of exclusive times"
+      },
+      {
+       "name": "aggregate_across_ranks",
+       "type": "bool",
+       "description": "Aggregate results across MPI ranks"
+      },
+      {
+       "name": "order_by_time",
+       "type": "bool",
+       "description": "Order tree branches by highest exclusive runtime",
+       "query":
+       [
+        {
+         "level": "local",
+         "order by": [ "sum#sum#time.duration\ desc" ]
+        },
+        {
+         "level": "cross",
+         "aggregate": "sum(sum#sum#time.duration)",
+         "order by" : [ "sum#sum#sum#time.duration\ desc" ]
+        }
+       ]
+      }
+     ]
+    };
+)json";
 
 } // namespace [anonymous]
 

--- a/src/caliper/controllers/RuntimeReportController.cpp
+++ b/src/caliper/controllers/RuntimeReportController.cpp
@@ -60,23 +60,30 @@ public:
                 config()["CALI_MPIREPORT_WRITE_ON_FINALIZE"] = "false";
                 config()["CALI_MPIREPORT_LOCAL_CONFIG"] =
                     opts.build_query("local", {
-                            { "select",   local_select  },
-                            { "group by", "path" }
+                            { "let",       "o.slot=first(aggregate.slot)" },
+                            { "select",    local_select  },
+                            { "group by",  "path" },
+                            { "aggregate", "min(o.slot)" }
                         });
                 config()["CALI_MPIREPORT_CONFIG"  ] =
                     opts.build_query("cross", {
-                            { "select",   cross_select  },
-                            { "group by", "path" },
-                            { "format",   format        }
+                            { "select",    cross_select  },
+                            { "group by",  "path" },
+                            { "format",    format        },
+                            { "aggregate", "min(min#o.slot)" },
+                            { "order by",  "min#min#o.slot" }
                         });
             } else {
                 config()["CALI_SERVICES_ENABLE"   ].append(",report");
                 config()["CALI_REPORT_FILENAME"   ] = opts.get("output", "stderr").to_string();
                 config()["CALI_REPORT_CONFIG"     ] =
                     opts.build_query("local", {
-                            { "select",   serial_select },
-                            { "group by", "path" },
-                            { "format",   format        }
+                            { "let",       "o.slot=first(aggregate.slot)" },
+                            { "select",    serial_select },
+                            { "group by",  "path" },
+                            { "format",    format        },
+                            { "aggregate", "min(o.slot)" },
+                            { "order by",  "min#o.slot"  }
                         });
             }
 

--- a/src/caliper/controllers/controllers.cpp
+++ b/src/caliper/controllers/controllers.cpp
@@ -307,6 +307,23 @@ const char* builtin_option_specs = R"json(
      ]
     },
     {
+     "name"        : "node.order",
+     "description" : "Report order in which regions first appeared",
+     "type"        : "bool",
+     "category"    : "metric",
+     "query"  :
+     [
+       { "level"   : "local",
+         "select"  : [ { "expr": "min(aggregate.slot)", "as": "Node order" } ]
+       },
+       { "level"   : "cross", "select":
+         [ 
+          { "expr": "min(min#aggregate.slot)", "as": "Node order" }
+         ]
+       }
+     ]
+    },
+    {
      "name"        : "source.module",
      "type"        : "bool",
      "category"    : "sampling",

--- a/src/caliper/controllers/controllers.cpp
+++ b/src/caliper/controllers/controllers.cpp
@@ -317,7 +317,7 @@ const char* builtin_option_specs = R"json(
          "select"  : [ { "expr": "min(aggregate.slot)", "as": "Node order" } ]
        },
        { "level"   : "cross", "select":
-         [ 
+         [
           { "expr": "min(min#aggregate.slot)", "as": "Node order" }
          ]
        }
@@ -819,7 +819,7 @@ const char* builtin_option_specs = R"json(
      "query"  :
      [
        { "level"   : "local",
-         "let"     : [ "mwb.time=first(pcp.time.duration,sum#pcp.time.duration) " ],
+         "let"     : [ "mwb.time=first(pcp.time.duration,sum#pcp.time.duration)" ],
          "select"  : [ { "expr": "ratio(mem.bytes.written,mwb.time,1e-6)", "as": "MB/s (w)", "unit": "MB/s" } ]
        },
        { "level"   : "cross", "select":
@@ -1039,6 +1039,24 @@ const char* builtin_option_specs = R"json(
      "type"        : "bool",
      "description" : "Print program metadata (Caliper globals and Adiak data)",
      "category"    : "treeformatter"
+    },
+    {
+     "name"        : "order_as_visited",
+     "type"        : "bool",
+     "description" : "Print tree nodes in the original visit order",
+     "category"    : "treeformatter",
+     "query"       :
+     [
+      { "level":     "local",
+        "let":       [ "o_a_v.slot=first(aggregate.slot)" ],
+        "aggregate": [ "min(o_a_v.slot)" ],
+        "order by":  [ "min#o_a_v.slot"  ]
+      },
+      { "level":     "cross",
+        "aggregate": [ "min(min#o_a_v.slot)" ],
+        "order by":  [ "min#min#o_a_v.slot"  ]
+      }
+     ]
     }
     ]
 )json";

--- a/src/caliper/test/test_configmanager.cpp
+++ b/src/caliper/test/test_configmanager.cpp
@@ -188,7 +188,8 @@ const char* testcontroller_spec = R"json(
        "query": 
         [
          { "level": "local", "group by": "g", "let": "x=scale(y,2)", "select": 
-           [ { "expr": "sum(x)", "as": X, "unit": "Foos" } ]
+           [ { "expr": "sum(x)", "as": X, "unit": "Foos" } ],
+           "aggregate": [ "min(y)", "max(y)" ], "order by": [ "min#y desc" ]
          }
         ]
       },
@@ -371,6 +372,8 @@ TEST(ConfigManagerTest, BuildQuery)
             " select me,sum(x) as \"X\" unit \"Foos\""
             " group by z,g"
             " where xyz=42"
+            " aggregate min(y),max(y)"
+            " order by min#y desc"
             " format expand";
 
         EXPECT_STREQ(q1.c_str(), expect);
@@ -383,6 +386,8 @@ TEST(ConfigManagerTest, BuildQuery)
             " let x=scale(y,2)"
             " select me,sum(x)"
             " group by g"
+            " aggregate min(y),max(y)"
+            " order by min#y desc"
             " format expand";
 
         EXPECT_STREQ(q2.c_str(), expect);

--- a/src/services/aggregate/Aggregate.cpp
+++ b/src/services/aggregate/Aggregate.cpp
@@ -148,7 +148,11 @@ class Aggregate
             check_aggregation_attribute(c, a);
 
         const int prop = CALI_ATTR_ASVALUE | CALI_ATTR_SCOPE_THREAD | CALI_ATTR_SKIP_EVENTS;
-        info.count_attr = c->create_attribute("count", CALI_TYPE_INT, prop);
+
+        info.count_attr = 
+            c->create_attribute("count", CALI_TYPE_UINT, prop);
+        info.slot_attr =
+            c->create_attribute("aggregate.slot", CALI_TYPE_UINT, prop);
     }
 
     void flush_cb(Caliper* c, Channel* chn, SnapshotFlushFn proc_fn) {

--- a/src/services/aggregate/AggregationDB.cpp
+++ b/src/services/aggregate/AggregationDB.cpp
@@ -286,7 +286,7 @@ struct AggregationDB::AggregationDBImpl
             SnapshotView kv(entry.key_len, &m_keyents[entry.key_idx]);
 
             std::vector<Entry> rec;
-            rec.reserve(kv.size() + entry.num_kernels + 1);
+            rec.reserve(kv.size() + entry.num_kernels + 2);
 
             std::copy(kv.begin(), kv.end(), std::back_inserter(rec));
 
@@ -309,7 +309,8 @@ struct AggregationDB::AggregationDBImpl
     #endif
             }
 
-            rec.push_back(Entry(info.count_attr, Variant(cali_make_variant_from_uint(entry.count))));
+            rec.push_back(Entry(info.count_attr, cali_make_variant_from_uint(entry.count)));
+            rec.push_back(Entry(info.slot_attr, cali_make_variant_from_uint(num_written)));
 
             // --- write snapshot record
             proc_fn(*c, rec);

--- a/src/services/aggregate/AggregationDB.h
+++ b/src/services/aggregate/AggregationDB.h
@@ -39,6 +39,7 @@ struct AttributeInfo
     std::vector<ResultAttributes> result_attrs;
 
     cali::Attribute               count_attr;
+    cali::Attribute               slot_attr;
 
     bool implicit_grouping;
     bool group_nested;


### PR DESCRIPTION
New aggregate.slot attribute in aggregator retains the order in which entries were created. New node.order, order_as_visited, and order_by_time (for runtime-report) ConfigManager options. Also adds sorting capability to the tree formatter.