### PR TITLE
Remove public c_std_99 cmake flag

### DIFF
--- a/examples/apps/CMakeLists.txt
+++ b/examples/apps/CMakeLists.txt
@@ -26,6 +26,7 @@ endforeach()
 foreach(app ${CALIPER_C_EXAMPLE_APPS})
   add_executable(${app} ${app}.c)
   target_link_libraries(${app} caliper)
+  target_compile_features(${app} PRIVATE c_std_99)
   set_target_properties(${app} PROPERTIES LINKER_LANGUAGE CXX)
 endforeach()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,7 +42,7 @@ add_library(caliper-serial ${CALIPER_SERIAL_OBJS})
 set_target_properties(caliper-serial PROPERTIES SOVERSION ${CALIPER_MAJOR_VERSION})
 set_target_properties(caliper-serial PROPERTIES VERSION ${CALIPER_VERSION})
 
-target_compile_features(caliper-serial PUBLIC cxx_std_11 c_std_99)
+target_compile_features(caliper-serial PUBLIC cxx_std_11)
 
 target_include_directories(
   caliper-serial
@@ -67,7 +67,7 @@ add_library(caliper ${CALIPER_ALL_OBJS})
 set_target_properties(caliper PROPERTIES SOVERSION ${CALIPER_MAJOR_VERSION})
 set_target_properties(caliper PROPERTIES VERSION ${CALIPER_VERSION})
 
-target_compile_features(caliper PUBLIC cxx_std_11 c_std_99)
+target_compile_features(caliper PUBLIC cxx_std_11)
 
 target_include_directories(
   caliper

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -20,7 +20,8 @@ add_library(caliper-common OBJECT
   ${CALIPER_COMMON_SOURCES})
 
 target_compile_options(caliper-common PRIVATE ${Wall_flag})
-target_compile_features(caliper-common PUBLIC cxx_std_11 c_std_99)
+target_compile_features(caliper-common PUBLIC cxx_std_11)
+target_compile_features(caliper-common PRIVATE c_std_99)
 
 if (BUILD_TESTING)
   add_subdirectory(test)

--- a/src/services/CMakeLists.txt
+++ b/src/services/CMakeLists.txt
@@ -29,7 +29,7 @@ endmacro()
 
 macro(add_service_objlib)
   target_compile_options("${ARGN}" PRIVATE ${Wall_flag})
-  target_compile_features("${ARGN}" PUBLIC cxx_std_11 c_std_99)
+  target_compile_features("${ARGN}" PUBLIC cxx_std_11)
   list(APPEND CALIPER_SERVICES_LIBS "$<TARGET_OBJECTS:${ARGN}>")
   set(CALIPER_SERVICES_LIBS ${CALIPER_SERVICES_LIBS} PARENT_SCOPE)
 endmacro()

--- a/test/ci_app_tests/CMakeLists.txt
+++ b/test/ci_app_tests/CMakeLists.txt
@@ -36,6 +36,7 @@ target_link_libraries(ci_test_nesting Threads::Threads)
 foreach(app ${CALIPER_CI_C_TEST_APPS})
   add_executable(${app} ${app}.c)
   set_target_properties(${app} PROPERTIES LINKER_LANGUAGE CXX)
+  target_compile_features(${app} PRIVATE c_std_99)
   target_link_libraries(${app} caliper-serial)
 endforeach()
 


### PR DESCRIPTION
Remove the public c_std_99 flag for the caliper and caliper-serial CMake targets. This is a workaround for an issue where CMake fails if a projects doesn't have the C language enabled. As a consequence target apps using the C interface must explicitly enable at least C99 support.