### PR TITLE
Add missing std header for uint64_t

### DIFF
--- a/src/mpi/mpi_machine.cpp
+++ b/src/mpi/mpi_machine.cpp
@@ -6,6 +6,7 @@
 #include <mpi.h>
 
 #include <unistd.h>
+#include <cstdint>
 
 #include <string>
 #include <vector>


### PR DESCRIPTION
Caliper build fails on master using Manjaro with GCC 13.

```
...
[ 65%] Building CXX object src/reader/CMakeFiles/caliper-reader.dir/RecordSelector.cpp.o
/home/dogiermann/Repos/Caliper-fork/src/mpi/mpi_machine.cpp:19:23: error: ‘uint64_t’ was not declared in this scope
   19 | int get_rank_for_hash(uint64_t hash, MPI_Comm comm)
...
```

This PR adds the "missing" header to fix the build failure.