### PR TITLE
Some config spec updates

### DIFF
--- a/src/caliper/controllers/SpotController.cpp
+++ b/src/caliper/controllers/SpotController.cpp
@@ -574,6 +574,8 @@ const char* spot_controller_spec = R"json(
          "level"  : "cross",
          "select" :
          [
+          { "expr": "min(scale#sum#time.duration.ns)", "as": "Min time/rank (exc)", "unit": "sec" },
+          { "expr": "max(scale#sum#time.duration.ns)", "as": "Max time/rank (exc)", "unit": "sec" },
           { "expr": "avg(scale#sum#time.duration.ns)", "as": "Avg time/rank (exc)", "unit": "sec" },
           { "expr": "sum(scale#sum#time.duration.ns)", "as": "Total time (exc)", "unit": "sec" }
          ]

--- a/src/caliper/controllers/controllers.cpp
+++ b/src/caliper/controllers/controllers.cpp
@@ -416,14 +416,14 @@ const char* builtin_option_specs = R"json(
      [
        { "level"   : "local",
          "select"  :
-         [ { "expr": "inclusive_scale(cupti.activity.duration,1e-9)", "as": "GPU Time (I)", "unit": "sec" },
+         [ { "expr": "inclusive_scale(cupti.activity.duration,1e-9)", "as": "GPU time (I)", "unit": "sec" },
          ]
        },
        { "level"   : "cross", "select":
-         [ { "expr": "avg(iscale#cupti.activity.duration)", "as": "Avg GPU Time/rank", "unit": "sec" },
-           { "expr": "min(iscale#cupti.activity.duration)", "as": "Min GPU Time/rank", "unit": "sec" },
-           { "expr": "max(iscale#cupti.activity.duration)", "as": "Max GPU Time/rank", "unit": "sec" },
-           { "expr": "sum(iscale#cupti.activity.duration)", "as": "Total GPU Time", "unit": "sec" }
+         [ { "expr": "avg(iscale#cupti.activity.duration)", "as": "Avg GPU time/rank", "unit": "sec" },
+           { "expr": "min(iscale#cupti.activity.duration)", "as": "Min GPU time/rank", "unit": "sec" },
+           { "expr": "max(iscale#cupti.activity.duration)", "as": "Max GPU time/rank", "unit": "sec" },
+           { "expr": "sum(iscale#cupti.activity.duration)", "as": "Total GPU time", "unit": "sec" }
          ]
        }
      ]
@@ -439,14 +439,14 @@ const char* builtin_option_specs = R"json(
      [
        { "level"   : "local",
          "select"  :
-         [ { "expr": "inclusive_scale(sum#rocm.activity.duration,1e-9)", "as": "GPU Time (I)", "unit": "sec" },
+         [ { "expr": "inclusive_scale(sum#rocm.activity.duration,1e-9)", "as": "GPU time (I)", "unit": "sec" },
          ]
        },
        { "level"   : "cross", "select":
-         [ { "expr": "avg(iscale#sum#rocm.activity.duration)", "as": "Avg GPU Time/rank", "unit": "sec" },
-           { "expr": "min(iscale#sum#rocm.activity.duration)", "as": "Min GPU Time/rank", "unit": "sec" },
-           { "expr": "max(iscale#sum#rocm.activity.duration)", "as": "Max GPU Time/rank", "unit": "sec" },
-           { "expr": "sum(iscale#sum#rocm.activity.duration)", "as": "Total GPU Time", "unit": "sec" }
+         [ { "expr": "avg(iscale#sum#rocm.activity.duration)", "as": "Avg GPU time/rank", "unit": "sec" },
+           { "expr": "min(iscale#sum#rocm.activity.duration)", "as": "Min GPU time/rank", "unit": "sec" },
+           { "expr": "max(iscale#sum#rocm.activity.duration)", "as": "Max GPU time/rank", "unit": "sec" },
+           { "expr": "sum(iscale#sum#rocm.activity.duration)", "as": "Total GPU time", "unit": "sec" }
          ]
        }
      ]

--- a/src/services/monitor/LoopMonitor.cpp
+++ b/src/services/monitor/LoopMonitor.cpp
@@ -181,7 +181,7 @@ const char* LoopMonitor::s_spec = R"json(
         {   "name"        : "time_interval",
             "description" : "Trigger snapshots every t seconds",
             "type"        : "double",
-            "value"       : "0.5"
+            "value"       : "0.0"
         },
         {   "name"        : "target_loops",
             "description" : "List of loops to instrument",


### PR DESCRIPTION
Adds min/max metrics for time.exclusive option in spot controller. Makes GPU and CPU metric names consistent. Removes default time interval setting for loop_monitor service (fixes #504).