### PR TITLE
Hatchet profile recipe improvements

### DIFF
--- a/src/caliper/controllers/HatchetRegionProfileController.cpp
+++ b/src/caliper/controllers/HatchetRegionProfileController.cpp
@@ -98,10 +98,10 @@ check_args(const cali::ConfigManager::Options& opts) {
 cali::ChannelController*
 make_controller(const char* name, const config_map_t& initial_cfg, const cali::ConfigManager::Options& opts)
 {
-    std::string format = opts.get("output.format", "json-split").to_string();
+    std::string format = opts.get("output.format", "cali").to_string();
 
     if (format == "hatchet")
-        format = "json-split";
+        format = "cali";
 
     if (!(format == "json-split" || format == "json" || format == "cali")) {
         format = "json-split";
@@ -113,32 +113,49 @@ make_controller(const char* name, const config_map_t& initial_cfg, const cali::C
     return new HatchetRegionProfileController(name, initial_cfg, opts, format);
 }
 
-const char* controller_spec =
-    "{"
-    " \"name\"        : \"hatchet-region-profile\","
-    " \"description\" : \"Record a region time profile for processing with hatchet\","
-    " \"categories\"  : [ \"adiak\", \"metric\", \"output\", \"region\", \"event\" ],"
-    " \"services\"    : [ \"aggregate\", \"event\", \"timer\" ],"
-    " \"config\"      : "
-    "   { \"CALI_CHANNEL_FLUSH_ON_EXIT\"      : \"false\","
-    "     \"CALI_EVENT_ENABLE_SNAPSHOT_INFO\" : \"false\","
-    "     \"CALI_TIMER_UNIT\"                 : \"sec\""
-    "   },"
-    " \"defaults\"    : { \"node.order\": \"true\" },"
-    " \"options\": "
-    " ["
-    "  { "
-    "    \"name\": \"output.format\","
-    "    \"type\": \"string\","
-    "    \"description\": \"Output format ('hatchet', 'cali', 'json')\""
-    "  },"
-    "  { "
-    "    \"name\": \"use.mpi\","
-    "    \"type\": \"bool\","
-    "    \"description\": \"Merge results into a single output stream in MPI programs\""
-    "  }"
-    " ]"
-    "}";
+const char* controller_spec = R"json(
+    {
+     "name"        : "hatchet-region-profile",
+     "description" : "Record a region time profile for processing with hatchet",
+     "categories"  : [ "adiak", "metric", "output", "region", "event" ],
+     "services"    : [ "aggregate", "event", "timer" ],
+     "config"      :
+       { "CALI_CHANNEL_FLUSH_ON_EXIT"      : "false",
+         "CALI_EVENT_ENABLE_SNAPSHOT_INFO" : "false",
+         "CALI_TIMER_UNIT"                 : "sec"
+       },
+     "defaults"    : { "node.order": "true" },
+     "options":
+     [
+      {
+       "name": "output.format",
+       "type": "string",
+       "description": "Output format ('hatchet', 'cali', 'json')"
+      },
+      {
+       "name": "use.mpi",
+       "type": "bool",
+       "description": "Merge results into a single output stream in MPI programs"
+      },
+      {
+       "name": "time.inclusive",
+       "type": "bool",
+       "category": "metric",
+       "description": "Add inclusive time metric",
+       "query":
+       [
+        {
+         "level"  : "local",
+         "select" :
+         [
+          { "expr": "inclusive_scale(sum#time.duration.ns,1e-9)", "as": "time (inc)", "unit": "sec" }
+         ]
+        }
+       ]
+      }
+     ]
+    }
+)json";
 
 } // namespace [anonymous]
 

--- a/src/caliper/controllers/HatchetSampleProfileController.cpp
+++ b/src/caliper/controllers/HatchetSampleProfileController.cpp
@@ -125,10 +125,10 @@ check_args(const cali::ConfigManager::Options& opts) {
 cali::ChannelController*
 make_controller(const char* name, const config_map_t& initial_cfg, const cali::ConfigManager::Options& opts)
 {
-    std::string format = opts.get("output.format", "json-split").to_string();
+    std::string format = opts.get("output.format", "cali").to_string();
 
     if (format == "hatchet")
-        format = "json-split";
+        format = "cali";
 
     if (!(format == "json-split" || format == "json" || format == "cali")) {
         format = "json-split";

--- a/src/tools/cali-query/cali-query.cpp
+++ b/src/tools/cali-query/cali-query.cpp
@@ -60,7 +60,7 @@ namespace
           "ATTRIBUTES"
         },
         { "expand", "expand", 'e', false,
-          "Expand context records and print the selected attributes (default: all)",
+          "Print records as comma-separated key=value lists",
           nullptr
         },
         { "attributes", "print-attributes", 0, true,
@@ -80,7 +80,7 @@ namespace
           "STRING"
         },
         { "table", "table", 't', false,
-          "Print attributes in human-readable table form",
+          "Print records in human-readable table form",
           nullptr
         },
         { "tree" , "tree", 'T', false,
@@ -111,20 +111,16 @@ namespace
           "Set Caliper configuration for profiling cali-query",
           "CALIPER-CONFIG"
         },
-        { "caliper-config-vars", "caliper-config-vars", 0, true,
-          "Caliper configuration flags (for cali-query profiling)",
-          "KEY=VALUE,..."
-        },
         { "verbose", "verbose", 'v', false, "Be verbose.",              nullptr },
         { "version", "version", 'V', false, "Print version number",     nullptr },
         { "output",  "output",  'o', true,  "Set the output file name", "FILE"  },
         { "help",    "help",    'h', true,  "Print help message",       nullptr },
         { "list-attributes", "list-attributes", 0, false,
-          "Extract and list attributes in Caliper stream instead of snapshot records",
+          "List attribute info. Use with -j, -t, etc. to select output format.",
           nullptr
         },
         { "list-globals", "list-globals", 'G', false,
-          "Extract and list global per-run attributes",
+          "List global run metadata. Use with -j, -t, etc. to select output format.",
           nullptr
         },
         Args::Table::Terminator
@@ -203,21 +199,6 @@ void setup_caliper_config(const Args& args)
 
     if (args.is_set("verbose"))
         cali_config_preset("CALI_LOG_VERBOSITY", "1");
-
-    std::vector<std::string> config_list =
-        StringConverter(args.get("caliper-config-vars")).to_stringlist();
-
-    for (const std::string entry : config_list) {
-        auto p = entry.find('=');
-
-        if (p == std::string::npos) {
-            std::cerr << "cali-query: error: invalid Caliper configuration flag format \""
-                      << entry << "\" (missing \"=\")" << std::endl;
-            continue;
-        }
-
-        cali_config_set(entry.substr(0, p).c_str(), entry.substr(p+1).c_str());
-    }
 }
 
 //

--- a/test/ci_app_tests/test_json.py
+++ b/test/ci_app_tests/test_json.py
@@ -107,7 +107,7 @@ class CaliperJSONTest(unittest.TestCase):
     def test_hatchetcontroller(self):
         """ Test hatchet-region-profile controller """
 
-        target_cmd = [ './ci_test_macros', '0', 'hatchet-region-profile,use.mpi=false,output=stdout,node.order=false' ]
+        target_cmd = [ './ci_test_macros', '0', 'hatchet-region-profile,use.mpi=false,output=stdout,output.format=json-split,node.order=false' ]
 
         caliper_config = {
             'CALI_LOG_VERBOSITY'     : '0'

--- a/test/ci_app_tests/test_ompt.py
+++ b/test/ci_app_tests/test_ompt.py
@@ -9,7 +9,7 @@ class CaliperOpenMPMetrics(unittest.TestCase):
     """ Caliper OpenMP/OMPT test case """
 
     def test_ioservice(self):
-        target_cmd = [ './ci_test_openmp', 'hatchet-region-profile,openmp.times,output=stdout' ]
+        target_cmd = [ './ci_test_openmp', 'hatchet-region-profile,openmp.times,output=stdout,output.format=json-split' ]
 
         caliper_config = {
             'CALI_LOG_VERBOSITY'     : '0'

--- a/test/ci_app_tests/test_symbollookup.py
+++ b/test/ci_app_tests/test_symbollookup.py
@@ -36,7 +36,7 @@ class CaliperSamplerTest(unittest.TestCase):
                          'region', 'loop' }))
 
     def test_hatchet_sample_profile_lookup(self):
-        target_cmd = [ './ci_test_macros', '5000', 'hatchet-sample-profile(use.mpi=false,output=stdout,callpath=false,source.location=true,source.module=true)' ]
+        target_cmd = [ './ci_test_macros', '5000', 'hatchet-sample-profile(use.mpi=false,output.format=json-split,output=stdout,callpath=false,source.location=true,source.module=true)' ]
 
         caliper_config = {
             'CALI_LOG_VERBOSITY' : '0'


### PR DESCRIPTION
Makes .cali the default output format for hatchet-region-profile and hatchet-sample-profile. Adds time.inclusive metric for hatchet-region-profile. Also improves cali-query help strings.