### PR TITLE
Update cuda and rocm controllers

### DIFF
--- a/src/caliper/controllers/CudaActivityReportController.cpp
+++ b/src/caliper/controllers/CudaActivityReportController.cpp
@@ -44,7 +44,7 @@ public:
                 ",max(iscale#cupti.activity.duration) as \"Max GPU Time\""
                 ",ratio(iscale#cupti.activity.duration,iscale#sum#cupti.host.duration,100.0) as \"GPU %\"";
 
-            std::string groupby = "prop:nested";
+            std::string groupby = "path";
 
             if (opts.is_enabled("show_kernels")) {
                 groupby += ",cupti.kernel.name";
@@ -116,31 +116,33 @@ make_controller(const char* name, const config_map_t& initial_cfg, const cali::C
     return new CudaActivityReportController(use_mpi(opts), name, initial_cfg, opts);
 }
 
-const char* controller_spec =
-    "{"
-    " \"name\"        : \"cuda-activity-report\","
-    " \"description\" : \"Record and print CUDA activities (kernel executions, memcopies, etc.)\","
-    " \"categories\"  : [ \"output\", \"region\", \"cuptitrace.metric\", \"treeformatter\", \"event\" ],"
-    " \"services\"    : [ \"aggregate\", \"cupti\", \"cuptitrace\", \"event\" ],"
-    " \"config\"      : "
-    "   { \"CALI_CHANNEL_FLUSH_ON_EXIT\"        : \"false\","
-    "     \"CALI_EVENT_ENABLE_SNAPSHOT_INFO\"   : \"false\","
-    "     \"CALI_CUPTITRACE_SNAPSHOT_DURATION\" : \"true\""
-    "   },"
-    " \"options\": "
-    " ["
-    "  {"
-    "   \"name\": \"aggregate_across_ranks\","
-    "   \"type\": \"bool\","
-    "   \"description\": \"Aggregate results across MPI ranks\""
-    "  },"
-    "  {"
-    "   \"name\": \"show_kernels\","
-    "   \"type\": \"bool\","
-    "   \"description\": \"Show kernel names\""
-    "  }"
-    " ]"
-    "}";
+const char* controller_spec = R"json(
+    {
+     "name"        : "cuda-activity-report",
+     "description" : "Record and print CUDA activities (kernel executions, memcopies, etc.)",
+     "categories"  : [ "output", "region", "cuptitrace.metric", "treeformatter", "event" ],
+     "services"    : [ "aggregate", "cupti", "cuptitrace", "event" ],
+     "config"      :
+       { "CALI_CHANNEL_FLUSH_ON_EXIT"        : "false",
+         "CALI_EVENT_ENABLE_SNAPSHOT_INFO"   : "false",
+         "CALI_CUPTITRACE_SNAPSHOT_DURATION" : "true"
+       },
+     "defaults"    : { "order_as_visited": "true" },
+     "options":
+     [
+      {
+       "name": "aggregate_across_ranks",
+       "type": "bool",
+       "description": "Aggregate results across MPI ranks"
+      },
+      {
+       "name": "show_kernels",
+       "type": "bool",
+       "description": "Show kernel names"
+      }
+     ]
+    }
+)json";
 
 } // namespace [anonymous]
 

--- a/src/caliper/controllers/ROCmActivityProfileController.cpp
+++ b/src/caliper/controllers/ROCmActivityProfileController.cpp
@@ -90,7 +90,7 @@ std::string
 check_args(const cali::ConfigManager::Options& opts) {
     // Check if output.format is valid
 
-    std::string format = opts.get("output.format", "json-split").to_string();
+    std::string format = opts.get("output.format", "cali").to_string();
     std::set<std::string> allowed_formats = { "cali", "json", "json-split", "hatchet" };
 
     if (allowed_formats.find(format) == allowed_formats.end())
@@ -102,13 +102,13 @@ check_args(const cali::ConfigManager::Options& opts) {
 cali::ChannelController*
 make_controller(const char* name, const config_map_t& initial_cfg, const cali::ConfigManager::Options& opts)
 {
-    std::string format = opts.get("output.format", "json-split").to_string();
+    std::string format = opts.get("output.format", "cali").to_string();
 
     if (format == "hatchet")
         format = "json-split";
 
     if (!(format == "json-split" || format == "json" || format == "cali")) {
-        format = "json-split";
+        format = "cali";
         Log(0).stream() << "hatchet-region-profile: Unknown output format \"" << format
                         << "\". Using json-split."
                         << std::endl;
@@ -130,6 +130,7 @@ const char* controller_spec = R"json(
          "CALI_ROCTRACER_RECORD_KERNEL_NAMES": "true",
          "CALI_ROCTRACER_SNAPSHOT_DURATION"  : "false"
        },
+     "defaults"    : { "node.order": "true" },
      "options":
      [
       {

--- a/src/caliper/controllers/ROCmActivityReportController.cpp
+++ b/src/caliper/controllers/ROCmActivityReportController.cpp
@@ -127,6 +127,7 @@ const char* controller_spec = R"json(
          "CALI_EVENT_ENABLE_SNAPSHOT_INFO"  : "false",
          "CALI_ROCTRACER_TRACE_ACTIVITIES"  : "true"
        },
+     "defaults"    : { "order_as_visited": "true" },
      "options":
      [
       {


### PR DESCRIPTION
Use .cali format for the profile controllers. Add node order in all controllers. Plus, some general improvements.