### PR TITLE
Implement annotation levels

### DIFF
--- a/doc/sphinx/RegionFiltering.rst
+++ b/doc/sphinx/RegionFiltering.rst
@@ -11,6 +11,9 @@ include_regions
 exclude_regions
     Skip measurements for regions with the given pattern.
 
+include_branches
+    Only take measurements for regions inside a given branch.
+
 The options take a list of region patterns. There are three pattern types:
 
 match
@@ -67,11 +70,26 @@ region - `mainloop` in this case - which is why we still see measurement values
 for the `mainloop` region here. However, these do not represent the actual time
 spent in `mainloop`.
 
+With the `include_branches` option, we can limit measurements to a specific
+branch and its sub-regions, e.g. the `mainloop` branch::
+
+    $ CALI_CONFIG="runtime-report,include_branches=mainloop" ./examples/apps/cxx-example
+    Path       Min time/rank Max time/rank Avg time/rank Time %
+    main            0.000457      0.000457      0.000457 37.527884
+      mainloop      0.000108      0.000108      0.000108  8.882529
+        foo         0.000653      0.000653      0.000653 53.589588
+
+This limits measurement to the `mainloop` region and all its sub-regions.
+Again, measurement values taken when entering the `mainloop` region are
+assigned to its enclosing region (`main` in this case), but don't necessarily
+reflect the actual time spent there.
+
 We can use a pattern like `startswith(main)` to include `main` and `mainloop`.
-Be careful to wrap the option values in quotes to prevent them from being 
+Be careful to wrap the option values in quotes to prevent them from being
 misinterpreted by the config parser::
 
     $ CALI_CONFIG="runtime-report,include_regions=\"startswith(main)\"" ./examples/apps/cxx-example
     Path       Min time/rank Max time/rank Avg time/rank Time %
     main            0.000112      0.000112      0.000112  5.177994
       mainloop      0.000773      0.000773      0.000773 35.737402
+

--- a/include/caliper/cali.h
+++ b/include/caliper/cali.h
@@ -374,6 +374,23 @@ void
 cali_end_region(const char* name);
 
 /**
+ * \brief Begin phase region \a name
+ *
+ * A phase marks high-level, long(er)-running code regions. While regular
+ * regions use the "region" attribute with annotation level 0, phase regions
+ * use the "phase" attribute with annotation level 4. Otherwise phases behave
+ * identical to regular Caliper regions.
+ */
+void
+cali_begin_phase(const char* name);
+
+/**
+ * \brief End phase region \a name
+ */
+void
+cali_end_phase(const char* name);
+
+/**
  * \brief Begin region where the value for \a attr is `true` on the blackboard.
  */
 void

--- a/include/caliper/cali_macros.h
+++ b/include/caliper/cali_macros.h
@@ -203,6 +203,18 @@ extern cali_id_t cali_annotation_attr_id;
 #define CALI_MARK_END(name) \
     cali_end_region(name)
 
+/// \brief Mark begin of a phase region
+///
+/// A phase marks high-level, long(er)-running code regions. While regular
+/// regions use the "region" attribute with annotation level 0, phase regions
+/// use the "phase" attribute with annotation level 4. Otherwise phases behave
+/// identical to regular Caliper regions.
+#define CALI_MARK_PHASE_BEGIN(name) \
+    cali_begin_phase(name)
+
+/// \brief Mark end of a phase region
+#define CALI_MARK_PHASE_END(name) \
+    cali_end_phase(name)
 /**
  * \} (group)
  */

--- a/include/caliper/common/Attribute.h
+++ b/include/caliper/common/Attribute.h
@@ -78,6 +78,9 @@ public:
     bool is_global() const {
         return properties() & CALI_ATTR_GLOBAL;
     }
+    int  level() const {
+        return (properties() & CALI_ATTR_LEVEL_MASK) >> 16;
+    }
 
     static Attribute make_attribute(Node* node);
 

--- a/include/caliper/common/cali_types.h
+++ b/include/caliper/common/cali_types.h
@@ -123,10 +123,33 @@ typedef enum {
    * \a aggregate service. This flag replaces the previous
    * \a class.aggregatable meta-attribute.
    */
-   CALI_ATTR_AGGREGATABLE =  2048
+   CALI_ATTR_AGGREGATABLE =  2048,
+
+   /**
+    * \brief Annotation level 1
+    *
+    * Annotation levels can be used to describe and set the granularity of
+    * region annotations. Level 0 is the finest level, level 7 is the
+    * coarsest.
+    */
+   CALI_ATTR_LEVEL_1      = 0x10000,
+   /** \brief Annotation level 2 */
+   CALI_ATTR_LEVEL_2      = 0x20000,
+   /** \brief Annotation level 3 */
+   CALI_ATTR_LEVEL_3      = 0x30000,
+   /** \brief Annotation level 4 */
+   CALI_ATTR_LEVEL_4      = 0x40000,
+   /** \brief Annotation level 5 */
+   CALI_ATTR_LEVEL_5      = 0x50000,
+   /** \brief Annotation level 6 */
+   CALI_ATTR_LEVEL_6      = 0x60000,
+   /** \brief Annotation level 7 */
+   CALI_ATTR_LEVEL_7      = 0x70000
 } cali_attr_properties;
 
+#define CALI_ATTR_LEVEL_0    0x0
 #define CALI_ATTR_SCOPE_MASK 60
+#define CALI_ATTR_LEVEL_MASK 0x70000
 
 /**
  * \brief  Provides descriptive string of given attribute property flags, separated with ':'

--- a/src/caliper/api.cpp
+++ b/src/caliper/api.cpp
@@ -17,6 +17,7 @@ cali_id_t cali_subscription_event_attr_id  = CALI_INV_ID;
 
 cali_id_t cali_loop_attr_id   = CALI_INV_ID;
 cali_id_t cali_region_attr_id = CALI_INV_ID;
+cali_id_t cali_phase_attr_id  = CALI_INV_ID;
 
 cali_id_t cali_alloc_fn_attr_id                 = CALI_INV_ID;
 cali_id_t cali_alloc_label_attr_id              = CALI_INV_ID;
@@ -36,6 +37,7 @@ namespace cali
     Attribute subscription_event_attr;
 
     Attribute region_attr;
+    Attribute phase_attr;
     Attribute loop_attr;
 
     void init_attribute_classes(Caliper* c) {
@@ -61,8 +63,11 @@ namespace cali
             c->create_attribute("loop", CALI_TYPE_STRING, CALI_ATTR_NESTED);
         region_attr =
             c->create_attribute("region", CALI_TYPE_STRING, CALI_ATTR_NESTED);
+        phase_attr =
+            c->create_attribute("phase", CALI_TYPE_STRING, CALI_ATTR_NESTED | CALI_ATTR_LEVEL_4);
 
         cali_region_attr_id = region_attr.id();
+        cali_phase_attr_id = phase_attr.id();
         cali_loop_attr_id = loop_attr.id();
     }
 }

--- a/src/caliper/cali.cpp
+++ b/src/caliper/cali.cpp
@@ -30,6 +30,7 @@ namespace cali
 {
 
 extern Attribute region_attr;
+extern Attribute phase_attr;
 
 }
 
@@ -385,9 +386,21 @@ void
 cali_end_region(const char* name)
 {
     Caliper c;
-    Variant v_n(name);
+    c.end_with_value_check(cali::region_attr, Variant(name));
+}
 
-    c.end_with_value_check(cali::region_attr, v_n);
+void
+cali_begin_phase(const char* name)
+{
+    Caliper c;
+    c.begin(cali::phase_attr, Variant(name));
+}
+
+void
+cali_end_phase(const char* name)
+{
+    Caliper c;
+    c.end_with_value_check(cali::phase_attr, Variant(name));
 }
 
 void

--- a/src/caliper/controllers/controllers.cpp
+++ b/src/caliper/controllers/controllers.cpp
@@ -273,7 +273,7 @@ const char* builtin_option_specs = R"json(
     {
      "name"        : "include_branches",
      "type"        : "string",
-     "description" : "Only take snapshots for branches from the given region names.",
+     "description" : "Only take snapshots for branches with the given region names.",
      "category"    : "event",
      "config"      : { "CALI_EVENT_INCLUDE_BRANCHES": "{}" }
     },

--- a/src/caliper/controllers/controllers.cpp
+++ b/src/caliper/controllers/controllers.cpp
@@ -264,6 +264,13 @@ const char* builtin_option_specs = R"json(
      ]
     },
     {
+     "name"        : "level",
+     "type"        : "string",
+     "description" : "Minimum region level that triggers snapshots",
+     "category"    : "event",
+     "config"      : { "CALI_EVENT_REGION_LEVEL": "{}" }
+    },
+    {
      "name"        : "include_regions",
      "type"        : "string",
      "description" : "Only take snapshots for the given region names/patterns.",

--- a/src/caliper/controllers/controllers.cpp
+++ b/src/caliper/controllers/controllers.cpp
@@ -271,6 +271,13 @@ const char* builtin_option_specs = R"json(
      "config"      : { "CALI_EVENT_REGION_LEVEL": "{}" }
     },
     {
+     "name"        : "include_branches",
+     "type"        : "string",
+     "description" : "Only take snapshots for branches from the given region names.",
+     "category"    : "event",
+     "config"      : { "CALI_EVENT_INCLUDE_BRANCHES": "{}" }
+    },
+    {
      "name"        : "include_regions",
      "type"        : "string",
      "description" : "Only take snapshots for the given region names/patterns.",

--- a/src/caliper/test/test_attribute.cpp
+++ b/src/caliper/test/test_attribute.cpp
@@ -57,7 +57,7 @@ TEST(AttributeAPITest, ValidAttribute) {
     std::vector<std::string> props;
     util::split(std::string(buf), ':',  std::back_inserter(props));
 
-    std::vector<std::string> props_exp { "nested", "process_scope", "nomerge", "default" };
+    std::vector<std::string> props_exp { "nested", "process_scope", "nomerge", "default", "level_0" };
 
     for (auto s : props) {
         auto it = std::find(props_exp.begin(), props_exp.end(), s);

--- a/src/common/cali_types.c
+++ b/src/common/cali_types.c
@@ -45,7 +45,7 @@ cali_string2type(const char* str)
 }
 
 static const struct propmap_t {
-  const char* str; cali_attr_properties prop; int mask;
+  const char* str; int prop; int mask;
 } propmap[] = {
   { "default",       CALI_ATTR_DEFAULT,       CALI_ATTR_DEFAULT      },
   { "asvalue",       CALI_ATTR_ASVALUE,       CALI_ATTR_ASVALUE      },
@@ -59,6 +59,14 @@ static const struct propmap_t {
   { "global",        CALI_ATTR_GLOBAL,        CALI_ATTR_GLOBAL       },
   { "unaligned",     CALI_ATTR_UNALIGNED,     CALI_ATTR_UNALIGNED    },
   { "aggregatable",  CALI_ATTR_AGGREGATABLE,  CALI_ATTR_AGGREGATABLE },
+  { "level_0",       CALI_ATTR_LEVEL_0,       CALI_ATTR_LEVEL_MASK   },
+  { "level_1",       CALI_ATTR_LEVEL_1,       CALI_ATTR_LEVEL_MASK   },
+  { "level_2",       CALI_ATTR_LEVEL_2,       CALI_ATTR_LEVEL_MASK   },
+  { "level_3",       CALI_ATTR_LEVEL_3,       CALI_ATTR_LEVEL_MASK   },
+  { "level_4",       CALI_ATTR_LEVEL_4,       CALI_ATTR_LEVEL_MASK   },
+  { "level_5",       CALI_ATTR_LEVEL_5,       CALI_ATTR_LEVEL_MASK   },
+  { "level_6",       CALI_ATTR_LEVEL_6,       CALI_ATTR_LEVEL_MASK   },
+  { "level_7",       CALI_ATTR_LEVEL_7,       CALI_ATTR_LEVEL_MASK   },
   { 0, CALI_ATTR_DEFAULT, CALI_ATTR_DEFAULT }
 };
 

--- a/src/services/event/EventTrigger.cpp
+++ b/src/services/event/EventTrigger.cpp
@@ -47,7 +47,7 @@ class EventTrigger
     Attribute                trigger_end_attr   { Attribute::invalid };
     Attribute                trigger_set_attr   { Attribute::invalid };
 
-    Attribute                exp_marker_attr    { Attribute::invalid };
+    Attribute                marker_attr        { Attribute::invalid };
 
     Attribute                region_count_attr  { Attribute::invalid };
 
@@ -59,6 +59,9 @@ class EventTrigger
     Node                     event_root_node;
 
     RegionFilter             region_filter;
+    RegionFilter             branch_filter;
+
+    std::vector<Variant>     branch_filter_stack;
 
     //
     // --- Helpers / misc
@@ -109,7 +112,7 @@ class EventTrigger
                 c->create_attribute(s, type, (prop & ~delete_flags) | CALI_ATTR_SKIP_EVENTS).id();
         }
 
-        c->make_tree_entry(exp_marker_attr,
+        c->make_tree_entry(marker_attr,
                            Variant(CALI_TYPE_USR, evt_attr_ids, sizeof(evt_attr_ids)),
                            attr.node());
 
@@ -130,8 +133,8 @@ class EventTrigger
         mark_attribute(c, chn, attr);
     }
 
-    const Node* find_exp_marker(const Attribute& attr) {
-        cali_id_t marker_id = exp_marker_attr.id();
+    const Node* find_marker(const Attribute& attr) {
+        cali_id_t marker_id = marker_attr.id();
 
         for (const Node* node = attr.node()->first_child(); node; node = node->next_sibling())
             if (node->attribute() == marker_id)
@@ -149,12 +152,18 @@ class EventTrigger
     //
 
     void pre_begin_cb(Caliper* c, Channel* chn, const Attribute& attr, const Variant& value) {
-        const Node* marker_node = find_exp_marker(attr);
+        const Node* marker_node = find_marker(attr);
 
         if (!marker_node)
             return;
         if (attr.type() == CALI_TYPE_STRING && !region_filter.pass(value))
             return;
+        if (branch_filter.has_filters()) {
+            if (branch_filter.pass(value))
+                branch_filter_stack.push_back(value);
+            if (branch_filter_stack.empty())
+                return;
+        }
 
         if (enable_snapshot_info) {
             assert(!marker_node->data().empty());
@@ -183,12 +192,18 @@ class EventTrigger
     }
 
     void pre_set_cb(Caliper* c, Channel* chn, const Attribute& attr, const Variant& value) {
-        const Node* marker_node = find_exp_marker(attr);
+        const Node* marker_node = find_marker(attr);
 
         if (!marker_node)
             return;
         if (attr.type() == CALI_TYPE_STRING && !region_filter.pass(value))
             return;
+        if (branch_filter.has_filters()) {
+            if (branch_filter.pass(value))
+                branch_filter_stack.push_back(value);
+            if (branch_filter_stack.empty())
+                return;
+        }
 
         if (enable_snapshot_info) {
             assert(!marker_node->data().empty());
@@ -217,12 +232,18 @@ class EventTrigger
     }
 
     void pre_end_cb(Caliper* c, Channel* chn, const Attribute& attr, const Variant& value) {
-        const Node* marker_node = find_exp_marker(attr);
+        const Node* marker_node = find_marker(attr);
 
         if (!marker_node)
             return;
         if (attr.type() == CALI_TYPE_STRING && !region_filter.pass(value))
             return;
+        if (branch_filter.has_filters()) {
+            if (branch_filter_stack.empty())
+                return;
+            if (value == branch_filter_stack.back())
+                branch_filter_stack.pop_back();
+        }
 
         if (enable_snapshot_info) {
             assert(!marker_node->data().empty());
@@ -287,10 +308,23 @@ class EventTrigger
 
                 if (!p.second.empty()) {
                     Log(0).stream() << channel->name() << ": event: filter parse error: "
-                                    << p.second
-                                    << std::endl;
+                        << p.second << std::endl;
                 } else {
                     region_filter = p.first;
+                }
+            }
+
+            {
+                std::string i_filter =
+                    cfg.get("include_branches").to_string();
+
+                auto p = RegionFilter::from_config(i_filter, "");
+
+                if (!p.second.empty()) {
+                    Log(0).stream() << channel->name() << ": event: branch filter parse error: "
+                        << p.second << std::endl;
+                } else {
+                    branch_filter = p.first;
                 }
             }
 
@@ -305,8 +339,8 @@ class EventTrigger
             trigger_end_attr =
                 c->create_attribute("cali.event.end",
                                     CALI_TYPE_UINT, CALI_ATTR_SKIP_EVENTS | CALI_ATTR_HIDDEN);
-            exp_marker_attr =
-                c->create_attribute(std::string("event.exp#")+std::to_string(channel->id()),
+            marker_attr =
+                c->create_attribute(std::string("event.marker#")+std::to_string(channel->id()),
                                     CALI_TYPE_USR,
                                     CALI_ATTR_SKIP_EVENTS |
                                     CALI_ATTR_HIDDEN);
@@ -377,6 +411,10 @@ const char* EventTrigger::s_spec = R"json(
             { "name"        : "exclude_regions",
               "type"        : "string",
               "description" : "Region filter to specify regions that won't trigger snapshots"
+            },
+            { "name"        : "include_branches",
+              "type"        : "string",
+              "description" : "Region filter to specify a branch"
             }
         ]
     }

--- a/test/ci_app_tests/ci_test_basic.cpp
+++ b/test/ci_app_tests/ci_test_basic.cpp
@@ -17,7 +17,7 @@ int main(int argc, char* argv[])
     if (argc > 1 && strcmp(argv[1], "newline") == 0)
         cali_set_string_byname("newline", "A newline:\n!");
 
-    cali::Annotation phase_ann("phase", metadata);
+    cali::Annotation phase_ann("myphase", metadata);
     std::size_t size = 8;
     cali::Annotation size_annot("dgs");
     size_annot.begin(size);

--- a/test/ci_app_tests/ci_test_macros.cpp
+++ b/test/ci_app_tests/ci_test_macros.cpp
@@ -30,6 +30,11 @@ void foo(int count, int sleep_usec)
     CALI_MARK_LOOP_END(fooloop);
 }
 
+void bar()
+{
+    CALI_CXX_MARK_FUNCTION;
+}
+
 int main(int argc, char* argv[])
 {
     int sleep_usec = 0;
@@ -62,14 +67,17 @@ int main(int argc, char* argv[])
     }
 
     CALI_CXX_MARK_LOOP_BEGIN(mainloop, "main loop");
-
     for (int i = 0; i < count; ++i) {
         CALI_CXX_MARK_LOOP_ITERATION(mainloop, i);
 
         foo(count, sleep_usec);
     }
-
     CALI_CXX_MARK_LOOP_END(mainloop);
+
+    CALI_MARK_PHASE_BEGIN("after_loop");
+    bar();
+    CALI_MARK_PHASE_END("after_loop");
+
     CALI_MARK_FUNCTION_END;
 
     mgr.flush();

--- a/test/ci_app_tests/test_basictrace.py
+++ b/test/ci_app_tests/test_basictrace.py
@@ -24,11 +24,11 @@ class CaliperBasicTraceTest(unittest.TestCase):
         self.assertTrue(len(snapshots) > 10)
 
         self.assertTrue(cat.has_snapshot_with_keys(
-            snapshots, {'iteration', 'phase', 'time.inclusive.duration.ns'}))
+            snapshots, {'iteration', 'myphase', 'time.inclusive.duration.ns'}))
         self.assertTrue(cat.has_snapshot_with_attributes(
-            snapshots, {'event.end#phase': 'initialization', 'phase': 'initialization'}))
+            snapshots, {'event.end#myphase': 'initialization', 'myphase': 'initialization'}))
         self.assertTrue(cat.has_snapshot_with_attributes(
-            snapshots, {'event.end#iteration': '3', 'iteration': '3', 'phase': 'loop'}))
+            snapshots, {'event.end#iteration': '3', 'iteration': '3', 'myphase': 'loop'}))
 
     def test_cali_config(self):
         # Test the builtin ConfigManager (CALI_CONFIG env var)
@@ -47,11 +47,11 @@ class CaliperBasicTraceTest(unittest.TestCase):
         self.assertTrue(len(snapshots) > 10)
 
         self.assertTrue(cat.has_snapshot_with_keys(
-            snapshots, {'iteration', 'phase', 'time.inclusive.duration.ns'}))
+            snapshots, {'iteration', 'myphase', 'time.inclusive.duration.ns'}))
         self.assertTrue(cat.has_snapshot_with_attributes(
-            snapshots, {'event.end#phase': 'initialization', 'phase': 'initialization'}))
+            snapshots, {'event.end#myphase': 'initialization', 'myphase': 'initialization'}))
         self.assertTrue(cat.has_snapshot_with_attributes(
-            snapshots, {'event.end#iteration': '3', 'iteration': '3', 'phase': 'loop'}))
+            snapshots, {'event.end#iteration': '3', 'iteration': '3', 'myphase': 'loop'}))
 
     def test_ann_metadata(self):
         target_cmd = [ './ci_test_basic' ]
@@ -67,7 +67,7 @@ class CaliperBasicTraceTest(unittest.TestCase):
         snapshots = cat.get_snapshots_from_text(query_output)
 
         self.assertTrue(cat.has_snapshot_with_attributes(
-            snapshots, { 'cali.attribute.name': 'phase',
+            snapshots, { 'cali.attribute.name': 'myphase',
                          'meta.int':            '42',
                          'cali.attribute.prop': '20' # default property: CALI_ATTR_SCOPE_THREAD
             }))
@@ -87,7 +87,7 @@ class CaliperBasicTraceTest(unittest.TestCase):
         snapshots = cat.get_snapshots_from_text(query_output)
 
         self.assertTrue(cat.has_snapshot_with_attributes(
-            snapshots, { 'cali.attribute.name': 'phase',
+            snapshots, { 'cali.attribute.name': 'myphase',
                          'meta.int':            '42',
                          'cali.attribute.prop': '12' # CALI_ATTR_SCOPE_PROCESS
             }))
@@ -279,6 +279,26 @@ class CaliperBasicTraceTest(unittest.TestCase):
         self.assertFalse(cat.has_snapshot_with_attributes(
             snapshots, {
                 'region' : 'main/before_loop' }))
+
+    def test_region_level_filter(self):
+        target_cmd = [ './ci_test_macros', '0', 'hatchet-region-profile,level=phase,output=stdout' ]
+        query_cmd = [ '../../src/tools/cali-query/cali-query', '-e' ]
+
+        query_output = cat.run_test_with_query(target_cmd, query_cmd, None)
+        snapshots = cat.get_snapshots_from_text(query_output)
+
+        self.assertFalse(cat.has_snapshot_with_attributes(
+            snapshots, {
+                'region' : 'main/foo',
+                'loop'   : 'main loop/fooloop' }))
+        self.assertFalse(cat.has_snapshot_with_attributes(
+            snapshots, {
+                'region' : 'main/bar',
+                'phase'  : 'after_loop' }))
+        self.assertTrue(cat.has_snapshot_with_attributes(
+            snapshots, {
+                'region' : 'main',
+                'phase'  : 'after_loop' }))
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/ci_app_tests/test_basictrace.py
+++ b/test/ci_app_tests/test_basictrace.py
@@ -300,5 +300,21 @@ class CaliperBasicTraceTest(unittest.TestCase):
                 'region' : 'main',
                 'phase'  : 'after_loop' }))
 
+    def test_branch_filter(self):
+        target_cmd = [ './ci_test_macros', '0', 'hatchet-region-profile,include_branches=after_loop,output=stdout' ]
+        query_cmd = [ '../../src/tools/cali-query/cali-query', '-e' ]
+
+        query_output = cat.run_test_with_query(target_cmd, query_cmd, None)
+        snapshots = cat.get_snapshots_from_text(query_output)
+
+        self.assertFalse(cat.has_snapshot_with_attributes(
+            snapshots, {
+                'region' : 'main/foo',
+                'loop'   : 'main loop/fooloop' }))
+        self.assertTrue(cat.has_snapshot_with_attributes(
+            snapshots, {
+                'region' : 'main/bar',
+                'phase'  : 'after_loop' }))
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/ci_app_tests/test_cpuinfo.py
+++ b/test/ci_app_tests/test_cpuinfo.py
@@ -25,7 +25,7 @@ class CaliperCpuInfoTest(unittest.TestCase):
         self.assertTrue(calitest.has_snapshot_with_keys(
             snapshots, { 'cpuinfo.cpu',
                          'cpuinfo.numa_node',
-                         'phase',
+                         'myphase',
                          'iteration' }))
 
 

--- a/test/ci_app_tests/test_json.py
+++ b/test/ci_app_tests/test_json.py
@@ -25,7 +25,7 @@ class CaliperJSONTest(unittest.TestCase):
 
         self.assertTrue( { 'records', 'globals', 'attributes' }.issubset(set(obj.keys())) )
 
-        self.assertEqual(len(obj['records']), 7)
+        self.assertEqual(len(obj['records']), 9)
         self.assertTrue('path' in obj['records'][0].keys())
 
         self.assertTrue('cali.caliper.version' in obj['globals'].keys())
@@ -50,7 +50,7 @@ class CaliperJSONTest(unittest.TestCase):
 
         self.assertTrue( { 'records', 'globals', 'attributes' }.issubset(set(obj.keys())) )
 
-        self.assertEqual(len(obj['records']), 7)
+        self.assertEqual(len(obj['records']), 9)
         self.assertTrue('path' in obj['records'][0].keys())
 
         self.assertTrue('cali.caliper.version' in obj['globals'].keys())
@@ -123,7 +123,7 @@ class CaliperJSONTest(unittest.TestCase):
 
         data = obj['data']
 
-        self.assertEqual(len(data), 8)
+        self.assertEqual(len(data), 10)
         self.assertEqual(len(data[0]), 2)
 
         meta = obj['column_metadata']

--- a/test/ci_app_tests/test_memusageservice.py
+++ b/test/ci_app_tests/test_memusageservice.py
@@ -25,7 +25,7 @@ class CaliperMemusageServiceTest(unittest.TestCase):
         self.assertTrue(calitest.has_snapshot_with_keys(
             snapshots, { 'memstat.vmsize',
                          'memstat.data',
-                         'phase',
+                         'myphase',
                          'iteration' }))
 
 if __name__ == "__main__":

--- a/test/ci_app_tests/test_papi.py
+++ b/test/ci_app_tests/test_papi.py
@@ -24,7 +24,7 @@ class CaliperPAPITest(unittest.TestCase):
         self.assertTrue(len(snapshots) > 1)
 
         self.assertTrue(calitest.has_snapshot_with_keys(
-            snapshots, { 'papi.PAPI_TOT_CYC', 'phase', 'iteration' }))
+            snapshots, { 'papi.PAPI_TOT_CYC', 'myphase', 'iteration' }))
 
     def test_papi_aggr(self):
         # PAPI counters should be aggregated
@@ -33,7 +33,7 @@ class CaliperPAPITest(unittest.TestCase):
 
         caliper_config = {
             'CALI_SERVICES_ENABLE'   : 'aggregate:event:papi:recorder',
-            'CALI_AGGREGATE_KEY'     : 'phase',
+            'CALI_AGGREGATE_KEY'     : 'myphase',
             'CALI_PAPI_COUNTERS'     : 'PAPI_TOT_CYC',
             'CALI_RECORDER_FILENAME' : 'stdout',
             'CALI_LOG_VERBOSITY'     : '0'
@@ -48,7 +48,7 @@ class CaliperPAPITest(unittest.TestCase):
             snapshots, { 'sum#papi.PAPI_TOT_CYC', 
                          'min#papi.PAPI_TOT_CYC', 
                          'max#papi.PAPI_TOT_CYC',
-                         'phase' }))
+                         'myphase' }))
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/ci_app_tests/test_report.py
+++ b/test/ci_app_tests/test_report.py
@@ -43,7 +43,7 @@ class CaliperReportTest(unittest.TestCase):
         snapshots = cat.get_snapshots_from_text(query_output)
 
         self.assertTrue(cat.has_snapshot_with_attributes(
-            snapshots, { 'region': 'main', 'count': '16', 'inclusive#count': '77' }))
+            snapshots, { 'region': 'main', 'count': '19', 'inclusive#count': '81' }))
         self.assertTrue(cat.has_snapshot_with_attributes(
             snapshots, { 'region': 'main/foo', 'count': '48', 'inclusive#count': '60' }))
 

--- a/test/ci_app_tests/test_templateservices.py
+++ b/test/ci_app_tests/test_templateservices.py
@@ -24,7 +24,7 @@ class CaliperTemplateServicesTest(unittest.TestCase):
         self.assertTrue(len(snapshots) > 1)
 
         self.assertTrue(calitest.has_snapshot_with_keys(
-            snapshots, { 'phase',
+            snapshots, { 'myphase',
                          'measurement.val.ci_test',
                          'measurement.ci_test' }))
 


### PR DESCRIPTION
Implements levels for region annotation attributes and filtering by level. Adds new macros `CALI_MARK_PHASE_BEGIN` and `CALI_MARK_PHASE_END` for higher-level than regular regions. Also implements a branch filter.