### PR TITLE
Remove mpi.call.id

### DIFF
--- a/src/services/mpiwrap/MpiWrap.cpp
+++ b/src/services/mpiwrap/MpiWrap.cpp
@@ -20,7 +20,6 @@ Attribute mpifn_attr       { Attribute::invalid };
 Attribute mpirank_attr     { Attribute::invalid };
 Attribute mpisize_attr     { Attribute::invalid };
 Attribute mpicall_attr     { Attribute::invalid };
-Attribute mpi_call_id_attr { Attribute::invalid };
 
 extern void mpiwrap_init(Caliper* c, Channel* chn, cali::ConfigSet& cfg);
 
@@ -71,12 +70,6 @@ void mpi_register(Caliper* c, Channel* chn)
         mpisize_attr =
             c->create_attribute("mpi.world.size", CALI_TYPE_INT,
                                 CALI_ATTR_GLOBAL        |
-                                CALI_ATTR_SKIP_EVENTS);
-    if (mpi_call_id_attr == Attribute::invalid)
-        mpi_call_id_attr =
-            c->create_attribute("mpi.call.id", CALI_TYPE_UINT,
-                                CALI_ATTR_SCOPE_THREAD  |
-                                CALI_ATTR_ASVALUE       |
                                 CALI_ATTR_SKIP_EVENTS);
 
     ConfigSet cfg = services::init_config_from_spec(chn->config(), mpi_service_spec);

--- a/src/services/mpiwrap/Wrapper.w
+++ b/src/services/mpiwrap/Wrapper.w
@@ -31,7 +31,7 @@ namespace cali
 extern Attribute mpifn_attr;
 extern Attribute mpirank_attr;
 extern Attribute mpisize_attr;
-extern Attribute mpi_call_id_attr;
+// extern Attribute mpi_call_id_attr;
 
 }
 
@@ -52,12 +52,12 @@ int  {{foo}}_wrap_count = 0;
 
 inline void push_mpifn(Caliper* c, bool enabled, const char* fname)
 {
-    static std::atomic<uint64_t> call_id { 0 };
+    // static std::atomic<uint64_t> call_id { 0 };
 
     if (!enabled)
         return;
 
-    c->begin(mpi_call_id_attr, Variant(cali_make_variant_from_uint(++call_id)));
+    // c->begin(mpi_call_id_attr, Variant(cali_make_variant_from_uint(++call_id)));
     c->begin(mpifn_attr, Variant(fname));
 }
 
@@ -67,7 +67,7 @@ inline void pop_mpifn(Caliper* c, bool enabled)
         return;
 
     c->end(mpifn_attr);
-    c->end(mpi_call_id_attr);
+    // c->end(mpi_call_id_attr);
 }
 
 

--- a/test/ci_app_tests/test_mpi.py
+++ b/test/ci_app_tests/test_mpi.py
@@ -164,7 +164,7 @@ class CaliperMPITest(unittest.TestCase):
                          'mpi.comm.is_world' : 'true'
             }))
         self.assertTrue(cat.has_snapshot_with_keys(
-            snapshots, { 'region', 'mpi.function', 'mpi.coll.type', 'mpi.call.id'
+            snapshots, { 'region', 'mpi.function', 'mpi.coll.type'
             }))
 
     def test_mpireport_controller(self):


### PR DESCRIPTION
Disable the `mpi.call.id` attribute - we're not really using it anywhere right now. Addresses #545.