### PR TITLE
add cstdint header

### DIFF
--- a/src/common/util/format_util.h
+++ b/src/common/util/format_util.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <iostream>
 #include <string>
 


### PR DESCRIPTION
we're seeing a compile failure on fedora 40

I believe newer compilers have lowered the number of indirect included headers, which means it needs adding in client code more often

```
caliper/src/common/util/format_util.h:17:32: error: 'uint64_t' has not been declared
 write_uint64(std::ostream& os, uint64_t value)
```