### PR TITLE
Update Variorum Service to use Energy API.

### DIFF
--- a/ext/gotcha/src/gotcha.c
+++ b/ext/gotcha/src/gotcha.c
@@ -239,7 +239,8 @@ struct Boundary {
 int find_relro_boundary(struct dl_phdr_info *info, size_t size, void *data) {
   struct Boundary *boundary = data;
   int found = 0;
-  for (int i = 0; i < info->dlpi_phnum; ++i) {
+  int i = 0;
+  for (i = 0; i < info->dlpi_phnum; ++i) {
     if (info->dlpi_phdr[i].p_type == PT_LOAD) {
       if (strcmp(boundary->l_name, info->dlpi_name) == 0 &&
           boundary->load_addr == info->dlpi_addr) {
@@ -249,7 +250,8 @@ int find_relro_boundary(struct dl_phdr_info *info, size_t size, void *data) {
     }
   }
   if (found) {
-    for (int i = 0; i < info->dlpi_phnum; ++i) {
+    int i = 0;
+    for (i = 0; i < info->dlpi_phnum; ++i) {
       if (info->dlpi_phdr[i].p_type == PT_GNU_RELRO) {
         boundary->start_addr = boundary->load_addr + info->dlpi_phdr[i].p_vaddr;
         boundary->end_addr = boundary->start_addr + info->dlpi_phdr[i].p_memsz;

--- a/ext/gotcha/src/gotcha_dl.c
+++ b/ext/gotcha/src/gotcha_dl.c
@@ -30,7 +30,8 @@ int lib_header_callback(struct dl_phdr_info *info, size_t size, void *data) {
   struct Addrs *addrs = data;
   const char *name = NULL;
   ElfW(Addr) load_address;
-  for (int i = 0; i < info->dlpi_phnum; ++i) {
+  int i = 0;
+  for (i = 0; i < info->dlpi_phnum; ++i) {
     if (info->dlpi_phdr[i].p_type == PT_LOAD) {
       ElfW(Addr) base_addr = info->dlpi_addr;
       ElfW(Addr) start_addr = base_addr + info->dlpi_phdr[i].p_vaddr;

--- a/src/services/variorum/Variorum.cpp
+++ b/src/services/variorum/Variorum.cpp
@@ -30,40 +30,72 @@ using namespace cali;
 namespace
 {
 
-// Power measurement function
+// Energy measurement function
 std::tuple<bool, uint64_t> measure(const std::string& name)
 {
-    double power_watts;
-    json_t *power_obj = NULL;
-    char *s = NULL;
+	double energy_joules;
+	json_t *energy_obj = NULL;
+	char *s = NULL;
 
-    s = (char *) malloc(800 * sizeof(char));
+	s = (char *) malloc(800 * sizeof(char));
 
-    int ret = variorum_get_node_power_json(&s);
-    if (ret != 0)
-    {
-        std::cout << "Variorum JSON API failed" << std::endl;
-        uint64_t val;
-        return std::make_tuple(false, val);
-    }
+	int ret = variorum_get_energy_json(&s);
+	if (ret != 0)
+	{
+		std::cout << "Variorum Energy JSON API failed!" << std::endl;
+		uint64_t val;
+		return std::make_tuple(false, val);
+	}
 
-    // TODO: Add error if name is an invalid JSON field
-    // TODO: Assume 1 rank/node for aggregation
+	//Extract and print values from JSON object
+	energy_obj = json_loads(s, JSON_DECODE_ANY, NULL);
+	energy_joules = json_real_value(json_object_get(energy_obj, name.c_str()));
 
-    // Extract and print values from JSON object
-    power_obj = json_loads(s, JSON_DECODE_ANY, NULL);
-    power_watts = json_real_value(json_object_get(power_obj, name.c_str()));
+	uint64_t val = (uint64_t)energy_joules;
 
-    uint64_t val = (uint64_t)power_watts;
+	//Deallocate the string
+	free(s);
 
-    // Deallocate the string
-    free(s);
+	//Deallocate JSON object
+	json_decref(energy_obj);
 
-    // Deallocate JSON object
-    json_decref(power_obj);
-
-    return std::make_tuple(true, val);
+	return std::make_tuple(true, val);
 }
+
+//// Power measurement function
+//std::tuple<bool, uint64_t> measure(const std::string& name)
+//{
+//    double power_watts;
+//    json_t *power_obj = NULL;
+//    char *s = NULL;
+//
+//    s = (char *) malloc(800 * sizeof(char));
+//
+//    int ret = variorum_get_node_power_json(&s);
+//    if (ret != 0)
+//    {
+//        std::cout << "Variorum JSON API failed" << std::endl;
+//        uint64_t val;
+//        return std::make_tuple(false, val);
+//    }
+//
+//    // TODO: Add error if name is an invalid JSON field
+//    // TODO: Assume 1 rank/node for aggregation
+//
+//    // Extract and print values from JSON object
+//    power_obj = json_loads(s, JSON_DECODE_ANY, NULL);
+//    power_watts = json_real_value(json_object_get(power_obj, name.c_str()));
+//
+//    uint64_t val = (uint64_t)power_watts;
+//
+//    // Deallocate the string
+//    free(s);
+//
+//    // Deallocate JSON object
+//    json_decref(power_obj);
+//
+//    return std::make_tuple(true, val);
+//}
 
 // The VariorumService class reads a list of domains from the
 // CALI_VARIORUM_DOMAINS config variable. For each domain, it appends a

--- a/src/services/variorum/Variorum.cpp
+++ b/src/services/variorum/Variorum.cpp
@@ -38,11 +38,6 @@ std::tuple<bool, uint64_t> measure(const std::string& name)
 	json_t *energy_obj = NULL;
 	char *s = NULL;
 
-	s = (char *) malloc(10000 * sizeof(char));
-
-    if (s==NULL)
-     printf("\n Something wrong with malloc.\n");
-
 	int ret = variorum_get_energy_json(&s);
 	if (ret != 0)
 	{

--- a/src/services/variorum/Variorum.cpp
+++ b/src/services/variorum/Variorum.cpp
@@ -34,6 +34,7 @@ namespace
 std::tuple<bool, uint64_t> measure(const std::string& name)
 {
 	double energy_joules;
+	json_t *node_obj = NULL;
 	json_t *energy_obj = NULL;
 	char *s = NULL;
 
@@ -49,7 +50,20 @@ std::tuple<bool, uint64_t> measure(const std::string& name)
 
 	//Extract and print values from JSON object
 	energy_obj = json_loads(s, JSON_DECODE_ANY, NULL);
-	energy_joules = json_real_value(json_object_get(energy_obj, name.c_str()));
+	void *iter = json_object_iter(energy_obj);
+	while (iter)
+    	{
+        	//hostname = json_object_iter_key(iter);
+        	node_obj = json_object_iter_value(iter);
+        if (node_obj == NULL)
+		{
+		    printf("JSON object not found");
+		    exit(0);
+		}
+		/* The following should return NULL after the first call per our object. */
+		iter = json_object_iter_next(energy_obj, iter);
+	    }
+	energy_joules = json_real_value(json_object_get(node_obj, name.c_str()));
 
 	uint64_t val = (uint64_t)energy_joules;
 
@@ -318,7 +332,7 @@ const ConfigSet::Entry VariorumService::s_configdata[] = {
       "List of domains to record", // short description
       // long description
       "List of domains to record (separated by ',')\n"
-      "Example: power_node_watts, power_socket_watts, power_gpu_watts, power_mem_watts"
+      "Example: energy_node_joules"
     },
     ConfigSet::Terminator
 };

--- a/src/services/variorum/Variorum.cpp
+++ b/src/services/variorum/Variorum.cpp
@@ -62,41 +62,6 @@ std::tuple<bool, uint64_t> measure(const std::string& name)
 	return std::make_tuple(true, val);
 }
 
-//// Power measurement function
-//std::tuple<bool, uint64_t> measure(const std::string& name)
-//{
-//    double power_watts;
-//    json_t *power_obj = NULL;
-//    char *s = NULL;
-//
-//    s = (char *) malloc(800 * sizeof(char));
-//
-//    int ret = variorum_get_node_power_json(&s);
-//    if (ret != 0)
-//    {
-//        std::cout << "Variorum JSON API failed" << std::endl;
-//        uint64_t val;
-//        return std::make_tuple(false, val);
-//    }
-//
-//    // TODO: Add error if name is an invalid JSON field
-//    // TODO: Assume 1 rank/node for aggregation
-//
-//    // Extract and print values from JSON object
-//    power_obj = json_loads(s, JSON_DECODE_ANY, NULL);
-//    power_watts = json_real_value(json_object_get(power_obj, name.c_str()));
-//
-//    uint64_t val = (uint64_t)power_watts;
-//
-//    // Deallocate the string
-//    free(s);
-//
-//    // Deallocate JSON object
-//    json_decref(power_obj);
-//
-//    return std::make_tuple(true, val);
-//}
-
 // The VariorumService class reads a list of domains from the
 // CALI_VARIORUM_DOMAINS config variable. For each domain, it appends a
 // "measurement.val.<name>" entry (absolute value for a performance

--- a/src/services/variorum/Variorum.cpp
+++ b/src/services/variorum/Variorum.cpp
@@ -33,12 +33,15 @@ namespace
 // Energy measurement function
 std::tuple<bool, uint64_t> measure(const std::string& name)
 {
-	double energy_joules;
+	uint64_t energy_joules;
 	json_t *node_obj = NULL;
 	json_t *energy_obj = NULL;
 	char *s = NULL;
 
-	s = (char *) malloc(800 * sizeof(char));
+	s = (char *) malloc(10000 * sizeof(char));
+
+    if (s==NULL)
+     printf("\n Something wrong with malloc.\n");
 
 	int ret = variorum_get_energy_json(&s);
 	if (ret != 0)
@@ -63,9 +66,17 @@ std::tuple<bool, uint64_t> measure(const std::string& name)
 		/* The following should return NULL after the first call per our object. */
 		iter = json_object_iter_next(energy_obj, iter);
 	    }
-	energy_joules = json_real_value(json_object_get(node_obj, name.c_str()));
 
-	uint64_t val = (uint64_t)energy_joules;
+    /*Patki dump values to screen */
+    if (json_object_get(node_obj, "energy_node_watts") != NULL)
+    {
+        energy_joules = json_integer_value(json_object_get(node_obj, name.c_str()));
+        printf("Node Energy: %lu Joules\n", energy_joules);
+    }
+    else
+     {
+        energy_joules = 0;
+     }
 
 	//Deallocate the string
 	free(s);
@@ -73,7 +84,7 @@ std::tuple<bool, uint64_t> measure(const std::string& name)
 	//Deallocate JSON object
 	json_decref(energy_obj);
 
-	return std::make_tuple(true, val);
+	return std::make_tuple(true, energy_joules);
 }
 
 // The VariorumService class reads a list of domains from the


### PR DESCRIPTION
Problem: 
The existing Variorum service in Caliper uses the `variorum_get_power_json` API, which only returns instantaneous power. This is not meaningful when we are looking at function start/end. 

Solution: 
What we'd like instead is total energy for the function. With Variorum v0.8, we have added the `variorum_get_energy_json` API. This PR updates the existing service to use this newly added API. 

This PR supersedes #567 from @tjeter.

Testing: 
This PR as been tested with multiple caliper examples (`examples/apps/c-example` and a hello-world Caliper example) by @rountree and @tpatki on Lassen. 

ToDo:

- [ ] Update associated README on how to use the Variorum Caliper service before merging. 


Co-authored by @tjeter. 
