### PR TITLE
Update toolchains on tioga, lassen, ruby and poodle

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -73,7 +73,7 @@ stages:
     include:
       - local: '.gitlab/custom-jobs-and-variables.yml'
       - project: 'radiuss/radiuss-shared-ci'
-        ref: 'v2024.04.0'
+        ref: 'v2024.07.0'
         file: 'pipelines/${CI_MACHINE}.yml'
       - artifact: '${CI_MACHINE}-jobs.yml'
         job: 'generate-job-lists'
@@ -86,7 +86,7 @@ include:
     file: 'id_tokens.yml'
   # [Optional] checks preliminary to running the actual CI test
   - project: 'radiuss/radiuss-shared-ci'
-    ref: 'v2024.04.0'
+    ref: 'v2024.07.0'
     file: 'utilities/preliminary-ignore-draft-pr.yml'
   # pipelines subscribed by the project
   - local: '.gitlab/subscribed-pipelines.yml'

--- a/.gitlab/jobs/lassen.yml
+++ b/.gitlab/jobs/lassen.yml
@@ -29,6 +29,14 @@ xl_2022_08_19_gcc_8_3_1_cuda_11_2_0:
   extends: .job_on_lassen
   allow_failure: true
 
+# Allow failure due to weird error only with XL on Lassen. Passes in debug mode.
+xl_2023_06_28_gcc_11_2_1_cuda_11_8_0:
+  variables:
+    SPEC: "${PROJECT_LASSEN_VARIANTS} +cuda %xl@=16.1.1.14.cuda.11.8.0.gcc.11.2.1 ^cuda@11.8.0+allow-unsupported-compilers ${PROJECT_LASSEN_DEPS}"
+    MODULE_LIST: "cuda/11.8.0"
+  extends: .job_on_lassen
+  allow_failure: true
+
 ############
 # Extra jobs
 ############

--- a/.gitlab/jobs/tioga.yml
+++ b/.gitlab/jobs/tioga.yml
@@ -25,9 +25,3 @@ master:
   variables:
     SPEC: " +tests %cce@18.0.0"
   extends: .job_on_tioga
-
-#rocmcc_6_1_2_hip:
-#  variables:
-#    ON_TIOGA: "OFF"
-#    SPEC: "${PROJECT_TIOGA_VARIANTS} +rocm amdgpu_target=gfx90a %rocmcc@6.1.2 ^hip@6.1.2 ${PROJECT_TIOGA_DEPS}"
-#  extends: .job_on_tioga

--- a/.gitlab/jobs/tioga.yml
+++ b/.gitlab/jobs/tioga.yml
@@ -23,11 +23,11 @@ variables:
 
 master:
   variables:
-    SPEC: " +tests %cce@16.0.1"
+    SPEC: " +tests %cce@18.0.0"
   extends: .job_on_tioga
 
-rocmcc_6_1_1_hip:
-  variables:
-    ON_TIOGA: "OFF"
-    SPEC: "${PROJECT_TIOGA_VARIANTS} +rocm amdgpu_target=gfx90a %rocmcc@6.1.1 ^hip@6.1.1 ${PROJECT_TIOGA_DEPS}"
-  extends: .job_on_tioga
+#rocmcc_6_1_2_hip:
+#  variables:
+#    ON_TIOGA: "OFF"
+#    SPEC: "${PROJECT_TIOGA_VARIANTS} +rocm amdgpu_target=gfx90a %rocmcc@6.1.2 ^hip@6.1.2 ${PROJECT_TIOGA_DEPS}"
+#  extends: .job_on_tioga


### PR DESCRIPTION
- [x] Remove Intel 19
- [x] Update to Intel 2023
- [x] ~~Update corona to ROCm 6.0.2~~ -> same error as with tioga, need ROCm 6.1.x , reverted to ROCm 5.7.1
- [x] Update tioga to ROCm 6.1.2
- [x] Remove CUDA 10 job (blueos system default is now 11.2.0)