### PR TITLE
Add metadata via config strings

### DIFF
--- a/doc/sphinx/CaliperBasics.rst
+++ b/doc/sphinx/CaliperBasics.rst
@@ -613,6 +613,25 @@ Adiak (Adiak support must be enabled in the Caliper build configuration). The
 spot config for the Spot web visualization framework requires that metadata
 attributes are recorded through Adiak.
 
+Finally, metadata can be added through the ``CALI_CONFIG`` and ConfigManager
+configuration strings with the ``metadata`` keyword:
+
+.. code-block:: sh
+
+    $ CALI_CONFIG="runtime-report,print.metadata,metadata(foo=fooval,bar=barval)" ./examples/apps/cxx-example
+    caliper.config        :
+    iterations            : 4
+    cali.caliper.version  : 2.12.0-dev
+    opts:print.metadata   : true
+    opts:output.append    : true
+    opts:order_as_visited : true
+    foo                   : fooval
+    bar                   : barval
+    cali.channel          : runtime-report
+    Path       Time (E) Time (I) Time % (E) Time % (I)
+    main       0.000014 0.000547   2.118374  85.205938
+    ...
+
 Third-party tool support (NVidia NSight, Intel VTune)
 -----------------------------------------------------
 

--- a/src/caliper/ChannelController.cpp
+++ b/src/caliper/ChannelController.cpp
@@ -39,12 +39,9 @@ namespace
 void add_channel_metadata(Caliper& c, Channel* channel, const info_map_t& metadata)
 {
     for (const auto &entry : metadata) {
-        std::string key = channel->name();
-        key.append(":");
-        key.append(entry.first);
-
         auto attr =
-            c.create_attribute(key, CALI_TYPE_STRING, CALI_ATTR_GLOBAL | CALI_ATTR_SKIP_EVENTS);
+            c.create_attribute(entry.first, CALI_TYPE_STRING,
+                CALI_ATTR_GLOBAL | CALI_ATTR_SKIP_EVENTS | CALI_ATTR_UNALIGNED);
 
         c.set(channel, attr, Variant(entry.second.c_str()));
     }

--- a/test/ci_app_tests/test_basictrace.py
+++ b/test/ci_app_tests/test_basictrace.py
@@ -151,6 +151,22 @@ class CaliperBasicTraceTest(unittest.TestCase):
         self.assertTrue(cat.has_snapshot_with_keys(
             snapshots, { 'cali.caliper.version' } ) )
 
+    def test_configmanager_metadata_import(self):
+        target_cmd = [ './ci_test_macros', '0', 'hatchet-region-profile(metadata(bla=garbl),output.format=json-split),metadata(file=example_node_info.json,keys=\"host.os,host.name\"),output=stdout' ]
+
+        caliper_config = {
+            'CALI_LOG_VERBOSITY' : '0'
+        }
+
+        obj = json.loads( cat.run_test(target_cmd, caliper_config)[0] )
+
+        self.assertEqual(obj['host.os.name'], 'TestOS')
+        self.assertEqual(obj['host.os.version'], '3.11')
+        self.assertEqual(obj['host.name'], 'test42')
+        self.assertEqual(obj['bla'], 'garbl')
+        self.assertFalse('other' in obj.keys())
+        self.assertFalse('host.cluster' in obj.keys())
+
     def test_lcnodeinfo(self):
         target_cmd = [ './ci_test_basic' ]
         query_cmd = [ '../../src/tools/cali-query/cali-query', '-G', '-e' ]

--- a/test/ci_app_tests/test_spot.py
+++ b/test/ci_app_tests/test_spot.py
@@ -56,7 +56,7 @@ class CaliperSpotControllerTest(unittest.TestCase):
         self.assertEqual(r['spot.channel'], 'regionprofile')
 
         self.assertEqual('regionprofile', obj['globals']['spot.channels'])
-        self.assertEqual('true', obj['globals']['spot:region.count'])
+        self.assertEqual('true', obj['globals']['opts:region.count'])
 
     def test_spot_timeseries(self):
         target_cmd = [ './ci_test_macros', '0', 'spot(output=stdout,timeseries,timeseries.iteration_interval=15)', '75' ]


### PR DESCRIPTION
Adds `metadata` function for ConfigManager to pass in metadata through the config string. Also supports reading data from a json dictionary file.