### PR TITLE
Fixes bug with variable naming in a couple of macros

### DIFF
--- a/include/caliper/cali_macros.h
+++ b/include/caliper/cali_macros.h
@@ -18,6 +18,12 @@
 
 #include "Annotation.h"
 
+// Macros for building variable names with other macros
+// These macros were obtained from:
+// https://stackoverflow.com/a/71899854
+#define CONCAT_(prefix, suffix) perfix##suffix
+#define CREATE_VAR_NAME(prefix, suffix) CONCAT_(prefix, suffix)
+
 /// \brief C++ macro to mark a function
 ///
 /// Mark begin and end of a function. Should be placed at the top of the
@@ -25,7 +31,7 @@
 /// point. Will export the annotated function by name in the pre-defined
 /// `function` attribute. Only available in C++.
 #define CALI_CXX_MARK_FUNCTION \
-    cali::Function __cali_ann##__func__(__func__)
+    cali::Function CREATE_VAR_NAME(__cali_ann, __func__)(__func__)
 
 /// \brief C++ macro marking a scoped region
 ///
@@ -34,7 +40,7 @@
 /// point. Will export the annotated function by name in the pre-defined
 /// `annotation` attribute. Only available in C++.
 #define CALI_CXX_MARK_SCOPE(name) \
-    cali::ScopeAnnotation __cali_ann_scope##__LINE__(name)
+    cali::ScopeAnnotation CREATE_VAR_NAME(__cali_ann_scope, __LINE__)(name)
 
 /// \brief Mark loop in C++
 /// \copydetails CALI_MARK_LOOP_BEGIN

--- a/include/caliper/cali_macros.h
+++ b/include/caliper/cali_macros.h
@@ -21,8 +21,8 @@
 // Macros for building variable names with other macros
 // These macros were obtained from:
 // https://stackoverflow.com/a/71899854
-#define CONCAT_(prefix, suffix) perfix##suffix
-#define CREATE_VAR_NAME(prefix, suffix) CONCAT_(prefix, suffix)
+#define CALI_CONCAT_(prefix, suffix) perfix##suffix
+#define CALI_CREATE_VAR_NAME(prefix, suffix) CALI_CONCAT_(prefix, suffix)
 
 /// \brief C++ macro to mark a function
 ///
@@ -31,7 +31,7 @@
 /// point. Will export the annotated function by name in the pre-defined
 /// `function` attribute. Only available in C++.
 #define CALI_CXX_MARK_FUNCTION \
-    cali::Function CREATE_VAR_NAME(__cali_ann, __func__)(__func__)
+    cali::Function CALI_CREATE_VAR_NAME(__cali_ann, __func__)(__func__)
 
 /// \brief C++ macro marking a scoped region
 ///
@@ -40,7 +40,7 @@
 /// point. Will export the annotated function by name in the pre-defined
 /// `annotation` attribute. Only available in C++.
 #define CALI_CXX_MARK_SCOPE(name) \
-    cali::ScopeAnnotation CREATE_VAR_NAME(__cali_ann_scope, __LINE__)(name)
+    cali::ScopeAnnotation CALI_CREATE_VAR_NAME(__cali_ann_scope, __LINE__)(name)
 
 /// \brief Mark loop in C++
 /// \copydetails CALI_MARK_LOOP_BEGIN

--- a/test/ci_app_tests/ci_test_macros.cpp
+++ b/test/ci_app_tests/ci_test_macros.cpp
@@ -61,6 +61,7 @@ int main(int argc, char* argv[])
 
     {
         CALI_CXX_MARK_SCOPE("before_loop");
+        CALI_CXX_MARK_SCOPE("inner_before_loop");
 
         if (argc > 3)
             count = std::max(1, std::stoi(argv[3]));

--- a/test/ci_app_tests/test_basictrace.py
+++ b/test/ci_app_tests/test_basictrace.py
@@ -297,7 +297,7 @@ class CaliperBasicTraceTest(unittest.TestCase):
             }))
 
     def test_exclusive_region_filter(self):
-        target_cmd = [ './ci_test_macros', '0', 'hatchet-region-profile,exclude_regions=before_loop,output.format=cali,output=stdout' ]
+        target_cmd = [ './ci_test_macros', '0', 'hatchet-region-profile,exclude_regions="before_loop,inner_before_loop",output.format=cali,output=stdout' ]
         query_cmd = [ '../../src/tools/cali-query/cali-query', '-e' ]
 
         caliper_config = {

--- a/test/ci_app_tests/test_json.py
+++ b/test/ci_app_tests/test_json.py
@@ -25,7 +25,7 @@ class CaliperJSONTest(unittest.TestCase):
 
         self.assertTrue( { 'records', 'globals', 'attributes' }.issubset(set(obj.keys())) )
 
-        self.assertEqual(len(obj['records']), 9)
+        self.assertEqual(len(obj['records']), 10)
         self.assertTrue('path' in obj['records'][0].keys())
 
         self.assertTrue('cali.caliper.version' in obj['globals'].keys())
@@ -50,7 +50,7 @@ class CaliperJSONTest(unittest.TestCase):
 
         self.assertTrue( { 'records', 'globals', 'attributes' }.issubset(set(obj.keys())) )
 
-        self.assertEqual(len(obj['records']), 9)
+        self.assertEqual(len(obj['records']), 10)
         self.assertTrue('path' in obj['records'][0].keys())
 
         self.assertTrue('cali.caliper.version' in obj['globals'].keys())
@@ -123,7 +123,7 @@ class CaliperJSONTest(unittest.TestCase):
 
         data = obj['data']
 
-        self.assertEqual(len(data), 10)
+        self.assertEqual(len(data), 11)
         self.assertEqual(len(data[0]), 2)
 
         meta = obj['column_metadata']

--- a/test/ci_app_tests/test_report.py
+++ b/test/ci_app_tests/test_report.py
@@ -43,7 +43,7 @@ class CaliperReportTest(unittest.TestCase):
         snapshots = cat.get_snapshots_from_text(query_output)
 
         self.assertTrue(cat.has_snapshot_with_attributes(
-            snapshots, { 'region': 'main', 'count': '19', 'inclusive#count': '81' }))
+            snapshots, { 'region': 'main', 'count': '19', 'inclusive#count': '83' }))
         self.assertTrue(cat.has_snapshot_with_attributes(
             snapshots, { 'region': 'main/foo', 'count': '48', 'inclusive#count': '60' }))
 
@@ -127,14 +127,15 @@ class CaliperReportTest(unittest.TestCase):
         }
 
         report_targets = [
-            'Path             Count',
-            'main                 1',
-            '  main loop          5',
-            '    foo              4',
-            '      fooloop       20',
-            '      pre-loop       4',
-            '        foo.init     4',
-            '  before_loop        1'
+            'Path                  Count',
+            'main                      1',
+            '  main loop               5',
+            '    foo                   4',
+            '      fooloop            20',
+            '      pre-loop            4',
+            '        foo.init          4',
+            '  before_loop             1',
+            '    inner_before_loop     1'
         ]
 
         report_output,_ = cat.run_test(target_cmd, caliper_config)


### PR DESCRIPTION
This PR fixes a bug with two Caliper macros:
- `CALI_CXX_MARK_FUNCTION`
- `CALI_CXX_MARK_SCOPE`

Both of these macros creates variables using special macros (i.e., `__func__` and `__LINE__`) and token concatenation (i.e., `##`). However, token concatenation prevents recursive evaluation of macros, which can cause compilation issues.

As an example, consider the following code:
```cpp
CALI_CXX_MARK_SCOPE("outer_region");
CALI_CXX_MARK_SCOPE("inner_region");
```

After pre-processing, the code would look like:
```cpp
cali::ScopeAnnotation __cali_ann_scope__LINE__("outer_region");
cali::ScopeAnnotation __cali_ann_scope__LINE__("inner_region");
```

Since these two variables have the same name, this code will fail to compile.

This PR fixes this bug by making use of the macro logic from [this StackOverlow post](https://stackoverflow.com/a/71899854).