### PR TITLE
Improve Variant::from_string()

### DIFF
--- a/include/caliper/common/Variant.h
+++ b/include/caliper/common/Variant.h
@@ -125,7 +125,7 @@ public:
         return Variant(cali_variant_unpack(buf, inc, ok));
     }
 
-    static Variant from_string(cali_attr_type type, const char* str, bool* ok = nullptr);
+    static Variant from_string(cali_attr_type type, const char* str);
 
     // vector<unsigned char> data() const;
 

--- a/src/common/test/test_variant.cpp
+++ b/src/common/test/test_variant.cpp
@@ -50,10 +50,9 @@ TEST(Variant_Test, FromString) {
     };
 
     for (const testcase_t* t = testcases; t->str; ++t) {
-        bool    ok = false;
-        Variant v(Variant::from_string(t->type, t->str, &ok));
+        Variant v(Variant::from_string(t->type, t->str));
 
-        EXPECT_EQ(ok, t->ok) << "for \"" << t->str << "\" (" << cali_type2string(t->type) << ")";
+        EXPECT_EQ(!v.empty(), t->ok) << "for \"" << t->str << "\" (" << cali_type2string(t->type) << ")";
         EXPECT_EQ(v, t->expected) << "for \"" << t->str << "\" (" << cali_type2string(t->type) << ")";
     }
 }
@@ -97,7 +96,7 @@ TEST(Variant_Test, Conversions) {
         EXPECT_EQ(val_int, val_1_int_neg);
     }
     {
-        bool v_1_int_neg_to_i64 = false;        
+        bool v_1_int_neg_to_i64 = false;
         int64_t val_i64 = v_1_int_neg.to_int64(&v_1_int_neg_to_i64);
         EXPECT_TRUE(v_1_int_neg_to_i64);
         EXPECT_EQ(val_i64, static_cast<int64_t>(val_1_int_neg));
@@ -123,7 +122,7 @@ TEST(Variant_Test, Conversions) {
         bool v_2_i64_nlrg_to_uint = true;
         v_2_i64_nlrg.to_uint(&v_2_i64_nlrg_to_uint);
         EXPECT_FALSE(v_2_i64_nlrg_to_uint);
-    }    
+    }
 
     {
         bool v_3_uint_sml_to_int = false;

--- a/src/common/util/parse_util.h
+++ b/src/common/util/parse_util.h
@@ -37,4 +37,14 @@ read_nested_text(std::istream& is, char start_char, char end_char);
 char
 read_char(std::istream& is);
 
+inline std::pair<bool, uint64_t>
+str_to_uint64(const char* str)
+{
+    uint64_t ret = 0;
+    const char* p = str;
+    for ( ; *p >= '0' && *p <= '9'; ++p)
+        ret = ret * 10 + static_cast<uint64_t>(*p - '0');
+    return std::make_pair(p != str, ret);
+}
+
 }

--- a/src/reader/RecordSelector.cpp
+++ b/src/reader/RecordSelector.cpp
@@ -113,7 +113,7 @@ struct RecordSelector::RecordSelectorImpl
         Clause clause { f.op, db.get_attribute(f.attr_name), Variant() };
 
         if (clause.attr)
-            clause.value = Variant::from_string(clause.attr.type(), f.value.c_str(), nullptr);
+            clause.value = Variant::from_string(clause.attr.type(), f.value.c_str());
 
         return clause;
     }


### PR DESCRIPTION
Improves `Variant::from_string()`. This should fix the xlc test failures on Lassen, even though they were probably due to a compiler bug. Also improves performance.