### PR TITLE
Retain data types in aggregation service

### DIFF
--- a/include/caliper/common/Variant.h
+++ b/include/caliper/common/Variant.h
@@ -115,6 +115,11 @@ public:
 
     Variant& operator += (const Variant& val);
 
+    Variant&       min(const Variant& val);
+    Variant&       max(const Variant& val);
+
+    static void    update_minmaxsum(const Variant& val, Variant& min_val, Variant& max_val, Variant& sum_val);
+
     size_t         pack(unsigned char* buf) const {
         return cali_variant_pack(m_v, buf);
     }
@@ -154,4 +159,3 @@ inline bool operator >  (const Variant& lhs, const Variant& rhs) {
 std::ostream& operator << (std::ostream& os, const Variant& v);
 
 } // namespace cali
-

--- a/src/common/Variant.cpp
+++ b/src/common/Variant.cpp
@@ -306,98 +306,45 @@ Variant& Variant::max(const Variant& val)
 
 void Variant::update_minmaxsum(const Variant& val, Variant& min_val, Variant& max_val, Variant& sum_val)
 {
-    auto type = val.type();
-    if (type == min_val.type() && type == max_val.type() && type == sum_val.type()) {
-        switch (type) {
-        case CALI_TYPE_DOUBLE:
-            {
-                double d = val.m_v.value.v_double;
-                sum_val.m_v.value.v_double += d;
-                if (d < min_val.m_v.value.v_double)
-                    min_val.m_v.value.v_double = d;
-                else if (d > max_val.m_v.value.v_double)
-                    max_val.m_v.value.v_double = d;
-            }
-            break;
-        case CALI_TYPE_INT:
-            {
-                int64_t i = val.m_v.value.v_int;
-                sum_val.m_v.value.v_int += i;
-                if (i < min_val.m_v.value.v_int)
-                    min_val.m_v.value.v_int = i;
-                else if (i > max_val.m_v.value.v_int)
-                    max_val.m_v.value.v_int = i;
-            }
-            break;
-        case CALI_TYPE_UINT:
-            {
-                uint64_t u = val.m_v.value.v_uint;
-                sum_val.m_v.value.v_uint += u;
-                if (u < min_val.m_v.value.v_uint)
-                    min_val.m_v.value.v_uint = u;
-                else if (u > max_val.m_v.value.v_uint)
-                    max_val.m_v.value.v_uint = u;
-            }
-            break;
-        default:
-            break;
-        }
-    } else {
-        switch (sum_val.type()) {
-        case CALI_TYPE_INV:
-            sum_val = val;
-            break;
-        case CALI_TYPE_DOUBLE:
-            sum_val.m_v.value.v_double += val.to_double();
-            break;
-        case CALI_TYPE_INT:
-            sum_val.m_v.value.v_int += val.to_int64();
-            break;
-        case CALI_TYPE_UINT:
-            sum_val.m_v.value.v_uint += val.to_uint();
-            break;
-        default:
-            break;
-        }
+    if (!min_val) {
+        min_val = val;
+        max_val = val;
+        sum_val = val;
+        return;
+    }
 
-        switch (min_val.type()) {
-        case CALI_TYPE_INV:
-            min_val = val;
-            break;
-        case CALI_TYPE_DOUBLE:
-            min_val.m_v.value.v_double =
-                std::min(min_val.m_v.value.v_double, val.to_double());
-            break;
-        case CALI_TYPE_INT:
-            min_val.m_v.value.v_int =
-                std::min(min_val.m_v.value.v_int, val.to_int64());
-            break;
-        case CALI_TYPE_UINT:
-            min_val.m_v.value.v_uint =
-                std::min(min_val.m_v.value.v_uint, val.to_uint());
-            break;
-        default:
-            break;
+    switch (val.type()) {
+    case CALI_TYPE_DOUBLE:
+        {
+            double d = val.m_v.value.v_double;
+            sum_val.m_v.value.v_double += d;
+            if (d < min_val.m_v.value.v_double)
+                min_val.m_v.value.v_double = d;
+            else if (d > max_val.m_v.value.v_double)
+                max_val.m_v.value.v_double = d;
         }
-
-        switch (max_val.type()) {
-        case CALI_TYPE_INV:
-            max_val = val;
-            break;
-        case CALI_TYPE_DOUBLE:
-            max_val.m_v.value.v_double =
-                std::max(min_val.m_v.value.v_double, val.to_double());
-            break;
-        case CALI_TYPE_INT:
-            max_val.m_v.value.v_int =
-                std::max(min_val.m_v.value.v_int, val.to_int64());
-            break;
-        case CALI_TYPE_UINT:
-            max_val.m_v.value.v_uint =
-                std::max(min_val.m_v.value.v_uint, val.to_uint());
-            break;
-        default:
-            break;
+        break;
+    case CALI_TYPE_INT:
+        {
+            int64_t i = val.m_v.value.v_int;
+            sum_val.m_v.value.v_int += i;
+            if (i < min_val.m_v.value.v_int)
+                min_val.m_v.value.v_int = i;
+            else if (i > max_val.m_v.value.v_int)
+                max_val.m_v.value.v_int = i;
         }
+        break;
+    case CALI_TYPE_UINT:
+        {
+            uint64_t u = val.m_v.value.v_uint;
+            sum_val.m_v.value.v_uint += u;
+            if (u < min_val.m_v.value.v_uint)
+                min_val.m_v.value.v_uint = u;
+            else if (u > max_val.m_v.value.v_uint)
+                max_val.m_v.value.v_uint = u;
+        }
+        break;
+    default:
+        break;
     }
 }

--- a/src/common/Variant.cpp
+++ b/src/common/Variant.cpp
@@ -223,3 +223,181 @@ Variant& Variant::operator += (const Variant& val)
 
     return *this;
 }
+
+Variant& Variant::min(const Variant& val)
+{
+    cali_attr_type type = this->type();
+
+    if (type == val.type()) {
+        switch (type) {
+        case CALI_TYPE_DOUBLE:
+            m_v.value.v_double = std::min(m_v.value.v_double, val.m_v.value.v_double);
+            break;
+        case CALI_TYPE_INT:
+            m_v.value.v_int = std::min(m_v.value.v_int, val.m_v.value.v_int);
+            break;
+        case CALI_TYPE_UINT:
+            m_v.value.v_uint = std::min(m_v.value.v_uint, val.m_v.value.v_uint);
+            break;
+        default:
+            break;
+        }
+    } else {
+        switch (type) {
+        case CALI_TYPE_INV:
+            *this = val;
+            break;
+        case CALI_TYPE_DOUBLE:
+            m_v.value.v_double = std::min(m_v.value.v_double, val.to_double());
+            break;
+        case CALI_TYPE_INT:
+            m_v.value.v_int = std::min(m_v.value.v_int, val.to_int64());
+            break;
+        case CALI_TYPE_UINT:
+            m_v.value.v_uint = std::min(m_v.value.v_uint, val.to_uint());
+            break;
+        default:
+            break;
+        }
+    }
+
+    return *this;
+}
+
+Variant& Variant::max(const Variant& val)
+{
+    cali_attr_type type = this->type();
+
+    if (type == val.type()) {
+        switch (type) {
+        case CALI_TYPE_DOUBLE:
+            m_v.value.v_double = std::max(m_v.value.v_double, val.m_v.value.v_double);
+            break;
+        case CALI_TYPE_INT:
+            m_v.value.v_int = std::max(m_v.value.v_int, val.m_v.value.v_int);
+            break;
+        case CALI_TYPE_UINT:
+            m_v.value.v_uint = std::max(m_v.value.v_uint, val.m_v.value.v_uint);
+            break;
+        default:
+            break;
+        }
+    } else {
+        switch (type) {
+        case CALI_TYPE_INV:
+            *this = val;
+            break;
+        case CALI_TYPE_DOUBLE:
+            m_v.value.v_double = std::max(m_v.value.v_double, val.to_double());
+            break;
+        case CALI_TYPE_INT:
+            m_v.value.v_int = std::max(m_v.value.v_int, val.to_int64());
+            break;
+        case CALI_TYPE_UINT:
+            m_v.value.v_uint = std::max(m_v.value.v_uint, val.to_uint());
+            break;
+        default:
+            break;
+        }
+    }
+
+    return *this;
+}
+
+void Variant::update_minmaxsum(const Variant& val, Variant& min_val, Variant& max_val, Variant& sum_val)
+{
+    auto type = val.type();
+    if (type == min_val.type() && type == max_val.type() && type == sum_val.type()) {
+        switch (type) {
+        case CALI_TYPE_DOUBLE:
+            {
+                double d = val.m_v.value.v_double;
+                sum_val.m_v.value.v_double += d;
+                if (d < min_val.m_v.value.v_double)
+                    min_val.m_v.value.v_double = d;
+                else if (d > max_val.m_v.value.v_double)
+                    max_val.m_v.value.v_double = d;
+            }
+            break;
+        case CALI_TYPE_INT:
+            {
+                int64_t i = val.m_v.value.v_int;
+                sum_val.m_v.value.v_int += i;
+                if (i < min_val.m_v.value.v_int)
+                    min_val.m_v.value.v_int = i;
+                else if (i > max_val.m_v.value.v_int)
+                    max_val.m_v.value.v_int = i;
+            }
+            break;
+        case CALI_TYPE_UINT:
+            {
+                uint64_t u = val.m_v.value.v_uint;
+                sum_val.m_v.value.v_uint += u;
+                if (u < min_val.m_v.value.v_uint)
+                    min_val.m_v.value.v_uint = u;
+                else if (u > max_val.m_v.value.v_uint)
+                    max_val.m_v.value.v_uint = u;
+            }
+            break;
+        default:
+            break;
+        }
+    } else {
+        switch (sum_val.type()) {
+        case CALI_TYPE_INV:
+            sum_val = val;
+            break;
+        case CALI_TYPE_DOUBLE:
+            sum_val.m_v.value.v_double += val.to_double();
+            break;
+        case CALI_TYPE_INT:
+            sum_val.m_v.value.v_int += val.to_int64();
+            break;
+        case CALI_TYPE_UINT:
+            sum_val.m_v.value.v_uint += val.to_uint();
+            break;
+        default:
+            break;
+        }
+
+        switch (min_val.type()) {
+        case CALI_TYPE_INV:
+            min_val = val;
+            break;
+        case CALI_TYPE_DOUBLE:
+            min_val.m_v.value.v_double =
+                std::min(min_val.m_v.value.v_double, val.to_double());
+            break;
+        case CALI_TYPE_INT:
+            min_val.m_v.value.v_int =
+                std::min(min_val.m_v.value.v_int, val.to_int64());
+            break;
+        case CALI_TYPE_UINT:
+            min_val.m_v.value.v_uint =
+                std::min(min_val.m_v.value.v_uint, val.to_uint());
+            break;
+        default:
+            break;
+        }
+
+        switch (max_val.type()) {
+        case CALI_TYPE_INV:
+            max_val = val;
+            break;
+        case CALI_TYPE_DOUBLE:
+            max_val.m_v.value.v_double =
+                std::max(min_val.m_v.value.v_double, val.to_double());
+            break;
+        case CALI_TYPE_INT:
+            max_val.m_v.value.v_int =
+                std::max(min_val.m_v.value.v_int, val.to_int64());
+            break;
+        case CALI_TYPE_UINT:
+            max_val.m_v.value.v_uint =
+                std::max(min_val.m_v.value.v_uint, val.to_uint());
+            break;
+        default:
+            break;
+        }
+    }
+}

--- a/src/common/Variant.cpp
+++ b/src/common/Variant.cpp
@@ -306,14 +306,14 @@ Variant& Variant::max(const Variant& val)
 
 void Variant::update_minmaxsum(const Variant& val, Variant& min_val, Variant& max_val, Variant& sum_val)
 {
-    if (!min_val) {
+    if (min_val.empty()) {
         min_val = val;
         max_val = val;
         sum_val = val;
         return;
     }
 
-    switch (val.type()) {
+    switch (val.m_v.type_and_size & CALI_VARIANT_TYPE_MASK) {
     case CALI_TYPE_DOUBLE:
         {
             double d = val.m_v.value.v_double;

--- a/src/reader/Aggregator.cpp
+++ b/src/reader/Aggregator.cpp
@@ -507,28 +507,8 @@ public:
             return;
 
         for (const Entry& e : list) {
-            if (e.attribute() == target_attr.id() || e.attribute() == min_attr.id()) {
-                if (m_min.empty()) {
-                    m_min = e.value();
-                } else {
-                    switch (target_attr.type()) {
-                    case CALI_TYPE_INT:
-                        {
-                            int64_t m = std::min(m_min.to_int64(), e.value().to_int64());
-                            m_min = Variant(cali_make_variant_from_int64(m));
-                        }
-                        break;
-                    case CALI_TYPE_DOUBLE:
-                        m_min = Variant(std::min(m_min.to_double(), e.value().to_double()));
-                        break;
-                    case CALI_TYPE_UINT:
-                        m_min = Variant(std::min(m_min.to_uint(),   e.value().to_uint()));
-                        break;
-                    default:
-                        ;
-                    }
-                }
-            }
+            if (e.attribute() == target_attr.id() || e.attribute() == min_attr.id())
+                m_min.min(e.value());
         }
     }
 
@@ -612,28 +592,8 @@ public:
             return;
 
         for (const Entry& e : list) {
-            if (e.attribute() == target_attr.id() || e.attribute() == max_attr.id()) {
-                if (m_max.empty()) {
-                    m_max = e.value();
-                } else {
-                    switch (target_attr.type()) {
-                    case CALI_TYPE_INT:
-                        {
-                            int64_t m = std::max(m_max.to_int64(), e.value().to_int64());
-                            m_max = Variant(cali_make_variant_from_int64(m));
-                        }
-                        break;
-                    case CALI_TYPE_DOUBLE:
-                        m_max = Variant(std::max(m_max.to_double(), e.value().to_double()));
-                        break;
-                    case CALI_TYPE_UINT:
-                        m_max = Variant(std::max(m_max.to_uint(),   e.value().to_uint()));
-                        break;
-                    default:
-                        ;
-                    }
-                }
-            }
+            if (e.attribute() == target_attr.id() || e.attribute() == max_attr.id())
+                m_max.max(e.value());
         }
     }
 

--- a/src/services/aggregate/Aggregate.cpp
+++ b/src/services/aggregate/Aggregate.cpp
@@ -112,10 +112,11 @@ class Aggregate
         ResultAttributes res;
 
         int prop = CALI_ATTR_ASVALUE | CALI_ATTR_SCOPE_THREAD | CALI_ATTR_SKIP_EVENTS;
+        cali_attr_type type = attr.type();
 
-        res.min_attr = c->create_attribute(std::string("min#") + name, CALI_TYPE_DOUBLE, prop);
-        res.max_attr = c->create_attribute(std::string("max#") + name, CALI_TYPE_DOUBLE, prop);
-        res.sum_attr = c->create_attribute(std::string("sum#") + name, CALI_TYPE_DOUBLE, prop);
+        res.min_attr = c->create_attribute(std::string("min#") + name, type, prop);
+        res.max_attr = c->create_attribute(std::string("max#") + name, type, prop);
+        res.sum_attr = c->create_attribute(std::string("sum#") + name, type, prop);
         res.avg_attr = c->create_attribute(std::string("avg#") + name, CALI_TYPE_DOUBLE, prop);
     #ifdef CALIPER_ENABLE_HISTOGRAMS
         for (int jj = 0; jj < CALI_AGG_HISTOGRAM_BINS; jj++) {


### PR DESCRIPTION
Retains the original data types in the aggregation service instead of converting everything to double.