### PR TITLE
include cstdint

### DIFF
--- a/src/common/util/parse_util.h
+++ b/src/common/util/parse_util.h
@@ -6,8 +6,9 @@
 
 #pragma once
 
-#include <iostream>
 #include <string>
+#include <cstdint>
+#include <iostream>
 
 namespace util
 {


### PR DESCRIPTION
newer compilers can have less implicit includes

```
caliper/src/common/util/parse_util.h:40:24: error: 'uint64_t' was not declared in this scope
inline std::pair<bool, uint64_t>
                     ^~~~~~~~
```