### PR TITLE
Split and shorten config recipe strings

### DIFF
--- a/src/caliper/ConfigManager.cpp
+++ b/src/caliper/ConfigManager.cpp
@@ -23,7 +23,18 @@ namespace cali
 
 // defined in controllers/controllers.cpp
 extern const ConfigManager::ConfigInfo* builtin_controllers_table[];
-extern const char*                      builtin_option_specs;
+
+extern const char* builtin_base_option_specs;
+extern const char* builtin_gotcha_option_specs;
+extern const char* builtin_libdw_option_specs;
+extern const char* builtin_mpi_option_specs;
+extern const char* builtin_openmp_option_specs;
+extern const char* builtin_cuda_option_specs;
+extern const char* builtin_rocm_option_specs;
+extern const char* builtin_pcp_option_specs;
+extern const char* builtin_umpire_option_specs;
+extern const char* builtin_papi_option_specs;
+extern const char* builtin_kokkos_option_specs;
 
 extern void add_submodule_controllers_and_services();
 
@@ -31,6 +42,40 @@ extern void add_submodule_controllers_and_services();
 
 namespace
 {
+
+const char* builtin_option_specs_list[] =
+{
+    builtin_base_option_specs,
+#ifdef CALIPER_HAVE_GOTCHA
+    builtin_gotcha_option_specs,
+#endif
+#ifdef CALIPER_HAVE_MPI
+    builtin_mpi_option_specs,
+#endif
+#ifdef CALIPER_HAVE_OMPT
+    builtin_openmp_option_specs,
+#endif
+#ifdef CALIPER_HAVE_CUPTI
+    builtin_cuda_option_specs,
+#endif
+#if defined(CALIPER_HAVE_ROCTRACER) || defined(CALIPER_HAVE_ROCPROFILER)
+    builtin_rocm_option_specs,
+#endif
+#ifdef CALIPER_HAVE_LIBDW
+    builtin_libdw_option_specs,
+#endif
+#ifdef CALIPER_HAVE_PAPI
+    builtin_papi_option_specs,
+#endif
+#ifdef CALIPER_HAVE_PCP
+    builtin_pcp_option_specs,
+#endif
+#ifdef CALIPER_HAVE_UMPIRE
+    builtin_umpire_option_specs,
+#endif
+    builtin_kokkos_option_specs,
+    nullptr
+};
 
 ChannelController* make_basic_channel_controller(
     const char*                   name,
@@ -997,7 +1042,7 @@ struct ConfigManager::ConfigManagerImpl {
         if (m_global_opts.error())
             set_error(m_global_opts.error_msg());
         if (!ok)
-            set_error(std::string("parse error: ") + util::clamp_string(builtin_option_specs, 48));
+            set_error(std::string("parse error: ") + util::clamp_string(json, 48));
     }
 
     void import_builtin_config_specs()
@@ -1360,7 +1405,11 @@ struct ConfigManager::ConfigManagerImpl {
         return ret;
     }
 
-    ConfigManagerImpl() { add_global_option_specs(builtin_option_specs); }
+    ConfigManagerImpl()
+    {
+        for (const char** spec_p = builtin_option_specs_list; *spec_p; ++spec_p)
+            add_global_option_specs(*spec_p);
+    }
 };
 
 ConfigManager::ConfigManager() : mP(new ConfigManagerImpl)

--- a/src/caliper/controllers/CudaActivityProfileController.cpp
+++ b/src/caliper/controllers/CudaActivityProfileController.cpp
@@ -122,31 +122,31 @@ cali::ChannelController* make_controller(
 }
 
 const char* controller_spec = R"json(
-    {
-     "name"        : "cuda-activity-profile",
-     "description" : "Record CUDA activities and a write profile",
-     "categories"  : [ "adiak", "metric", "cuptitrace.metric", "output", "region", "event" ],
-     "services"    : [ "aggregate", "cupti", "cuptitrace", "event" ],
-     "config"      :
-       { "CALI_CHANNEL_FLUSH_ON_EXIT"        : "false",
-         "CALI_EVENT_ENABLE_SNAPSHOT_INFO"   : "false",
-         "CALI_CUPTITRACE_SNAPSHOT_DURATION" : "true"
-       },
-     "defaults"    : { "node.order": "true" },
-     "options":
-     [
-      {
-        "name": "output.format",
-        "type": "string",
-        "description": "Output format ('hatchet', 'cali', 'json')"
-      },
-      {
-        "name": "use.mpi",
-        "type": "bool",
-        "description": "Merge results into a single output stream in MPI programs"
-      }
-     ]
-    };
+{
+ "name"        : "cuda-activity-profile",
+ "description" : "Record CUDA activities and a write profile",
+ "categories"  : [ "adiak", "metric", "cuptitrace.metric", "output", "region", "event" ],
+ "services"    : [ "aggregate", "cupti", "cuptitrace", "event" ],
+ "config"      :
+ { "CALI_CHANNEL_FLUSH_ON_EXIT"        : "false",
+   "CALI_EVENT_ENABLE_SNAPSHOT_INFO"   : "false",
+   "CALI_CUPTITRACE_SNAPSHOT_DURATION" : "true"
+ },
+ "defaults"    : { "node.order": "true" },
+ "options":
+ [
+  {
+   "name": "output.format",
+   "type": "string",
+   "description": "Output format ('hatchet', 'cali', 'json')"
+  },
+  {
+   "name": "use.mpi",
+   "type": "bool",
+   "description": "Merge results into a single output stream in MPI programs"
+  }
+ ]
+};
 )json";
 
 } // namespace

--- a/src/caliper/controllers/CudaActivityReportController.cpp
+++ b/src/caliper/controllers/CudaActivityReportController.cpp
@@ -115,36 +115,36 @@ cali::ChannelController* make_controller(
 }
 
 const char* controller_spec = R"json(
-    {
-     "name"        : "cuda-activity-report",
-     "description" : "Record and print CUDA activities (kernel executions, memcopies, etc.)",
-     "categories"  : [ "output", "region", "cuptitrace.metric", "treeformatter", "event" ],
-     "services"    : [ "aggregate", "cupti", "cuptitrace", "event" ],
-     "config"      :
-       { "CALI_CHANNEL_FLUSH_ON_EXIT"        : "false",
-         "CALI_EVENT_ENABLE_SNAPSHOT_INFO"   : "false",
-         "CALI_CUPTITRACE_SNAPSHOT_DURATION" : "true"
-       },
-     "defaults"    : { "order_as_visited": "true", "output.append": "true" },
-     "options":
-     [
-      {
-       "name": "aggregate_across_ranks",
-       "type": "bool",
-       "description": "Aggregate results across MPI ranks"
-      },
-      {
-       "name": "show_kernels",
-       "type": "bool",
-       "description": "Show kernel names"
-      },
-      {
-       "name": "output.append",
-       "type": "bool",
-       "description": "Use append mode when writing to files"
-      }
-     ]
-    }
+{
+ "name"        : "cuda-activity-report",
+ "description" : "Record and print CUDA activities (kernel executions, memcopies, etc.)",
+ "categories"  : [ "output", "region", "cuptitrace.metric", "treeformatter", "event" ],
+ "services"    : [ "aggregate", "cupti", "cuptitrace", "event" ],
+ "config"      :
+ { "CALI_CHANNEL_FLUSH_ON_EXIT"        : "false",
+   "CALI_EVENT_ENABLE_SNAPSHOT_INFO"   : "false",
+   "CALI_CUPTITRACE_SNAPSHOT_DURATION" : "true"
+ },
+ "defaults"    : { "order_as_visited": "true", "output.append": "true" },
+ "options":
+ [
+  {
+   "name": "aggregate_across_ranks",
+   "type": "bool",
+   "description": "Aggregate results across MPI ranks"
+  },
+  {
+   "name": "show_kernels",
+   "type": "bool",
+   "description": "Show kernel names"
+  },
+  {
+   "name": "output.append",
+   "type": "bool",
+   "description": "Use append mode when writing to files"
+  }
+ ]
+}
 )json";
 
 } // namespace

--- a/src/caliper/controllers/HatchetRegionProfileController.cpp
+++ b/src/caliper/controllers/HatchetRegionProfileController.cpp
@@ -120,47 +120,42 @@ cali::ChannelController* make_controller(
 }
 
 const char* controller_spec = R"json(
+{
+ "name"        : "hatchet-region-profile",
+ "description" : "Record a region time profile for processing with hatchet",
+ "categories"  : [ "adiak", "metadata", "metric", "output", "region", "event" ],
+ "services"    : [ "aggregate", "event", "timer" ],
+ "config"      :
+ { "CALI_CHANNEL_FLUSH_ON_EXIT"      : "false",
+   "CALI_EVENT_ENABLE_SNAPSHOT_INFO" : "false",
+   "CALI_TIMER_UNIT"                 : "sec"
+ },
+ "defaults"    : { "node.order": "true" },
+ "options":
+ [
+  {
+   "name": "output.format",
+   "type": "string",
+   "description": "Output format ('hatchet', 'cali', 'json')"
+  },{
+   "name": "use.mpi",
+   "type": "bool",
+   "description": "Merge results into a single output stream in MPI programs"
+  },{
+   "name": "time.inclusive",
+   "type": "bool",
+   "category": "metric",
+   "description": "Add inclusive time metric",
+   "query":
+   [
     {
-     "name"        : "hatchet-region-profile",
-     "description" : "Record a region time profile for processing with hatchet",
-     "categories"  : [ "adiak", "metadata", "metric", "output", "region", "event" ],
-     "services"    : [ "aggregate", "event", "timer" ],
-     "config"      :
-       { "CALI_CHANNEL_FLUSH_ON_EXIT"      : "false",
-         "CALI_EVENT_ENABLE_SNAPSHOT_INFO" : "false",
-         "CALI_TIMER_UNIT"                 : "sec"
-       },
-     "defaults"    : { "node.order": "true" },
-     "options":
-     [
-      {
-       "name": "output.format",
-       "type": "string",
-       "description": "Output format ('hatchet', 'cali', 'json')"
-      },
-      {
-       "name": "use.mpi",
-       "type": "bool",
-       "description": "Merge results into a single output stream in MPI programs"
-      },
-      {
-       "name": "time.inclusive",
-       "type": "bool",
-       "category": "metric",
-       "description": "Add inclusive time metric",
-       "query":
-       [
-        {
-         "level"  : "local",
-         "select" :
-         [
-          "inclusive_scale(sum#time.duration.ns,1e-9) as \"time (inc)\" unit sec"
-         ]
-        }
-       ]
-      }
-     ]
+     "level"  : "local",
+     "select" : [ "inclusive_scale(sum#time.duration.ns,1e-9) as \"time (inc)\" unit sec" ]
     }
+   ]
+  }
+ ]
+}
 )json";
 
 } // namespace

--- a/src/caliper/controllers/HatchetSampleProfileController.cpp
+++ b/src/caliper/controllers/HatchetSampleProfileController.cpp
@@ -140,44 +140,41 @@ cali::ChannelController* make_controller(
 }
 
 const char* controller_spec = R"json(
-    {
-     "name"        : "hatchet-sample-profile",
-     "description" : "Record a sampling profile for processing with hatchet",
-     "services"    : [ "sampler", "trace" ],
-     "categories"  : [ "adiak", "metadata", "sampling", "output" ],
-     "config"      : { "CALI_CHANNEL_FLUSH_ON_EXIT": "false" },
-     "defaults"    : { "callpath": "true", "source.module": "true" },
-     "options":
-     [
-      {
-        "name": "output.format",
-        "type": "string",
-        "description": "Output format ('hatchet', 'cali', 'json')"
-      },
-      {
-        "name": "sample.frequency",
-        "type": "int",
-        "description": "Sampling frequency in Hz. Default: 200"
-      },
-      {
-        "name": "callpath",
-        "type": "bool",
-        "description": "Perform call-stack unwinding",
-        "services": [ "callpath", "symbollookup" ],
-        "query":
-        [
-         { "level": "local", "group by": "source.function#callpath.address",
-           "select": [ "source.function#callpath.address" ]
-         }
-        ]
-      },
-      {
-        "name": "use.mpi",
-        "type": "bool",
-        "description": "Merge results into a single output stream in MPI programs"
-      }
-     ]
+{
+ "name"        : "hatchet-sample-profile",
+ "description" : "Record a sampling profile for processing with hatchet",
+ "services"    : [ "sampler", "trace" ],
+ "categories"  : [ "adiak", "metadata", "sampling", "output" ],
+ "config"      : { "CALI_CHANNEL_FLUSH_ON_EXIT": "false" },
+ "defaults"    : { "callpath": "true", "source.module": "true" },
+ "options":
+ [
+  {
+   "name": "output.format",
+   "type": "string",
+   "description": "Output format ('hatchet', 'cali', 'json')"
+  },{
+   "name": "sample.frequency",
+   "type": "int",
+   "description": "Sampling frequency in Hz. Default: 200"
+  },{
+   "name": "callpath",
+   "type": "bool",
+   "description": "Perform call-stack unwinding",
+   "services": [ "callpath", "symbollookup" ],
+   "query":
+   [
+    { "level": "local", "group by": "source.function#callpath.address",
+      "select": [ "source.function#callpath.address" ]
     }
+   ]
+  },{
+   "name": "use.mpi",
+   "type": "bool",
+   "description": "Merge results into a single output stream in MPI programs"
+  }
+ ]
+}
 )json";
 
 } // namespace

--- a/src/caliper/controllers/LoopReportController.cpp
+++ b/src/caliper/controllers/LoopReportController.cpp
@@ -293,51 +293,48 @@ public:
     }
 };
 
-const char* loop_report_controller_spec =
-    "{"
-    " \"name\"        : \"loop-report\","
-    " \"description\" : \"Print summary and time-series information for loops\","
-    " \"categories\"  : [ \"metric\", \"output\" ],"
-    " \"services\"    : [ \"loop_monitor\", \"timer\", \"trace\" ],"
-    " \"config\"      : "
-    "   { \"CALI_CHANNEL_FLUSH_ON_EXIT\" : \"false\","
-    "     \"CALI_CHANNEL_CONFIG_CHECK\"  : \"false\","
-    "     \"CALI_TIMER_UNIT\"            : \"sec\""
-    "   },"
-    " \"options\": "
-    " ["
-    "  {"
-    "   \"name\": \"summary\","
-    "   \"type\": \"bool\","
-    "   \"description\": \"Print loop summary\""
-    "  },"
-    "  {"
-    "   \"name\": \"timeseries\","
-    "   \"type\": \"bool\","
-    "   \"description\": \"Print time series\""
-    "  },"
-    "  {"
-    "   \"name\": \"iteration_interval\","
-    "   \"type\": \"int\","
-    "   \"description\": \"Measure every N loop iterations\""
-    "  },"
-    "  {"
-    "   \"name\": \"time_interval\","
-    "   \"type\": \"double\","
-    "   \"description\": \"Measure after t seconds\""
-    "  },"
-    "  {"
-    "   \"name\": \"timeseries.maxrows\","
-    "   \"type\": \"int\","
-    "   \"description\": \"Max number of rows in timeseries display. Set to 0 to show all. Default: 20.\""
-    "  },"
-    "  {"
-    "   \"name\": \"target_loops\","
-    "   \"type\": \"string\","
-    "   \"description\": \"List of loops to target. Default: any top-level loop.\""
-    "  }"
-    " ]"
-    "}";
+const char* loop_report_controller_spec = R"json(
+{
+ "name"        : "loop-report",
+ "description" : "Print summary and time-series information for loops",
+ "categories"  : [ "metric", "output" ],
+ "services"    : [ "loop_monitor", "timer", "trace" ],
+ "config"      :
+ {
+  "CALI_CHANNEL_FLUSH_ON_EXIT" : "false",
+  "CALI_CHANNEL_CONFIG_CHECK"  : "false",
+  "CALI_TIMER_UNIT"            : "sec"
+ },
+ "options":
+ [
+  {
+   "name": "summary",
+   "type": "bool",
+   "description": "Print loop summary"
+  },{
+   "name": "timeseries",
+   "type": "bool",
+   "description": "Print time series"
+  },{
+   "name": "iteration_interval",
+   "type": "int",
+   "description": "Measure every N loop iterations"
+  },{
+   "name": "time_interval",
+   "type": "double",
+   "description": "Measure after t seconds"
+  },{
+   "name": "timeseries.maxrows",
+   "type": "int",
+   "description": "Max number of rows in timeseries display. Set to 0 to show all. Default: 20."
+  },{
+   "name": "target_loops",
+   "type": "string",
+   "description": "List of loops to target. Default: any top-level loop."
+  }
+ ]
+}
+)json";
 
 cali::ChannelController* make_loopreport_controller(
     const char*                         name,

--- a/src/caliper/controllers/ROCmActivityProfileController.cpp
+++ b/src/caliper/controllers/ROCmActivityProfileController.cpp
@@ -122,33 +122,33 @@ cali::ChannelController* make_controller(
 }
 
 const char* controller_spec = R"json(
-    {
-     "name"        : "rocm-activity-profile",
-     "description" : "Record AMD ROCm activities and a write profile",
-     "categories"  : [ "adiak", "metric", "output", "region", "event" ],
-     "services"    : [ "aggregate", "roctracer", "event", "timer" ],
-     "config"      :
-       { "CALI_CHANNEL_FLUSH_ON_EXIT"        : "false",
-         "CALI_EVENT_ENABLE_SNAPSHOT_INFO"   : "false",
-         "CALI_ROCTRACER_TRACE_ACTIVITIES"   : "true",
-         "CALI_ROCTRACER_RECORD_KERNEL_NAMES": "true",
-         "CALI_ROCTRACER_SNAPSHOT_DURATION"  : "false"
-       },
-     "defaults"    : { "node.order": "true" },
-     "options":
-     [
-      {
-        "name": "output.format",
-        "type": "string",
-        "description": "Output format ('hatchet', 'cali', 'json')"
-      },
-      {
-        "name": "use.mpi",
-        "type": "bool",
-        "description": "Merge results into a single output stream in MPI programs"
-      }
-     ]
-    }
+{
+ "name"        : "rocm-activity-profile",
+ "description" : "Record AMD ROCm activities and a write profile",
+ "categories"  : [ "adiak", "metric", "output", "region", "event" ],
+ "services"    : [ "aggregate", "roctracer", "event", "timer" ],
+ "config"      :
+ {
+  "CALI_CHANNEL_FLUSH_ON_EXIT"        : "false",
+  "CALI_EVENT_ENABLE_SNAPSHOT_INFO"   : "false",
+  "CALI_ROCTRACER_TRACE_ACTIVITIES"   : "true",
+  "CALI_ROCTRACER_RECORD_KERNEL_NAMES": "true",
+  "CALI_ROCTRACER_SNAPSHOT_DURATION"  : "false"
+ },
+ "defaults"    : { "node.order": "true" },
+ "options":
+ [
+  {
+   "name": "output.format",
+   "type": "string",
+   "description": "Output format ('hatchet', 'cali', 'json')"
+  },{
+   "name": "use.mpi",
+   "type": "bool",
+   "description": "Merge results into a single output stream in MPI programs"
+  }
+ ]
+}
 )json";
 
 } // namespace

--- a/src/caliper/controllers/ROCmActivityReportController.cpp
+++ b/src/caliper/controllers/ROCmActivityReportController.cpp
@@ -115,37 +115,36 @@ cali::ChannelController* make_controller(
 }
 
 const char* controller_spec = R"json(
-    {
-     "name"        : "rocm-activity-report",
-     "description" : "Record and print AMD ROCm activities (kernel executions, memcopies, etc.)",
-     "categories"  : [ "output", "region", "treeformatter", "event" ],
-     "services"    : [ "aggregate", "roctracer", "event", "timer" ],
-     "config"      :
-       { "CALI_CHANNEL_FLUSH_ON_EXIT"       : "false",
-         "CALI_EVENT_ENABLE_SNAPSHOT_INFO"  : "false",
-         "CALI_ROCTRACER_TRACE_ACTIVITIES"  : "true"
-       },
-     "defaults"    : { "order_as_visited": "true", "output.append": "true" },
-     "options":
-     [
-      {
-       "name": "aggregate_across_ranks",
-       "type": "bool",
-       "description": "Aggregate results across MPI ranks"
-      },
-      {
-       "name": "show_kernels",
-       "type": "bool",
-       "config": { "CALI_ROCTRACER_RECORD_KERNEL_NAMES": "true" },
-       "description": "Show kernel names"
-      },
-      {
-       "name": "output.append",
-       "type": "bool",
-       "description": "Use append mode when writing to files"
-      }
-     ]
-    }
+{
+ "name"        : "rocm-activity-report",
+ "description" : "Record and print AMD ROCm activities (kernel executions, memcopies, etc.)",
+ "categories"  : [ "output", "region", "treeformatter", "event" ],
+ "services"    : [ "aggregate", "roctracer", "event", "timer" ],
+ "config"      :
+ {
+  "CALI_CHANNEL_FLUSH_ON_EXIT"       : "false",
+  "CALI_EVENT_ENABLE_SNAPSHOT_INFO"  : "false",
+  "CALI_ROCTRACER_TRACE_ACTIVITIES"  : "true"
+ },
+ "defaults"    : { "order_as_visited": "true", "output.append": "true" },
+ "options":
+ [
+  {
+   "name": "aggregate_across_ranks",
+   "type": "bool",
+   "description": "Aggregate results across MPI ranks"
+  },{
+   "name": "show_kernels",
+   "type": "bool",
+   "config": { "CALI_ROCTRACER_RECORD_KERNEL_NAMES": "true" },
+   "description": "Show kernel names"
+  },{
+   "name": "output.append",
+   "type": "bool",
+   "description": "Use append mode when writing to files"
+  }
+ ]
+}
 )json";
 
 } // namespace

--- a/src/caliper/controllers/RuntimeReportController.cpp
+++ b/src/caliper/controllers/RuntimeReportController.cpp
@@ -113,53 +113,50 @@ cali::ChannelController* make_runtime_report_controller(
 }
 
 const char* runtime_report_spec = R"json(
+{
+ "name"        : "runtime-report",
+ "description" : "Print a time profile for annotated regions",
+ "categories"  : [ "metric", "output", "region", "treeformatter", "event" ],
+ "services"    : [ "aggregate", "event", "timer" ],
+ "config"      :
+ {
+  "CALI_CHANNEL_FLUSH_ON_EXIT": "false",
+  "CALI_EVENT_ENABLE_SNAPSHOT_INFO": "false",
+  "CALI_TIMER_UNIT": "sec"
+ },
+ "defaults"    : { "order_as_visited": "true", "output.append": "true" },
+ "options"     :
+ [
+  {
+   "name": "calc.inclusive",
+   "type": "bool",
+   "description": "Report inclusive instead of exclusive times"
+  },{
+   "name": "aggregate_across_ranks",
+   "type": "bool",
+   "description": "Aggregate results across MPI ranks"
+  },{
+   "name": "order_by_time",
+   "type": "bool",
+   "description": "Order tree branches by highest exclusive runtime",
+   "query":
+   [
     {
-     "name"        : "runtime-report",
-     "description" : "Print a time profile for annotated regions",
-     "categories"  : [ "metric", "output", "region", "treeformatter", "event" ],
-     "services"    : [ "aggregate", "event", "timer" ],
-     "config"      :
-       { "CALI_CHANNEL_FLUSH_ON_EXIT"      : "false",
-         "CALI_EVENT_ENABLE_SNAPSHOT_INFO" : "false",
-         "CALI_TIMER_UNIT"                 : "sec"
-       },
-     "defaults"    : { "order_as_visited": "true", "output.append": "true" },
-     "options":
-     [
-      {
-       "name": "calc.inclusive",
-       "type": "bool",
-       "description": "Report inclusive instead of exclusive times"
-      },
-      {
-       "name": "aggregate_across_ranks",
-       "type": "bool",
-       "description": "Aggregate results across MPI ranks"
-      },
-      {
-       "name": "order_by_time",
-       "type": "bool",
-       "description": "Order tree branches by highest exclusive runtime",
-       "query":
-       [
-        {
-         "level": "local",
-         "order by": [ "sum#sum#time.duration\ desc" ]
-        },
-        {
-         "level": "cross",
-         "aggregate": "sum(sum#sum#time.duration)",
-         "order by" : [ "sum#sum#sum#time.duration\ desc" ]
-        }
-       ]
-      },
-      {
-       "name": "output.append",
-       "type": "bool",
-       "description": "Use append mode when writing to files"
-      }
-     ]
-    };
+     "level": "local",
+     "order by": [ "sum#sum#time.duration\ desc" ]
+    },{
+     "level": "cross",
+     "aggregate": "sum(sum#sum#time.duration)",
+     "order by" : [ "sum#sum#sum#time.duration\ desc" ]
+    }
+   ]
+  },{
+   "name": "output.append",
+   "type": "bool",
+   "description": "Use append mode when writing to files"
+  }
+ ]
+}
 )json";
 
 } // namespace

--- a/src/caliper/controllers/SampleReportController.cpp
+++ b/src/caliper/controllers/SampleReportController.cpp
@@ -121,38 +121,35 @@ cali::ChannelController* make_sample_report_controller(
 }
 
 const char* sample_report_spec = R"json(
-    {
-     "name"        : "sample-report",
-     "description" : "Print a sampling profile for the program",
-     "categories"  : [ "output", "sampling", "treeformatter", "region" ],
-     "services"    : [ "sampler", "trace" ],
-     "config"      : { "CALI_CHANNEL_FLUSH_ON_EXIT": "false" },
-     "defaults"    : { "source.function": "true", "output.append": "true" },
-     "options":
-     [
-      {
-        "name": "sample.frequency",
-        "type": "int",
-        "description": "Sampling frequency in Hz. Default: 200"
-      },
-      {
-        "name": "callpath",
-        "type": "bool",
-        "description": "Group by function call path instead of instrumented region",
-        "services": [ "callpath", "symbollookup" ]
-      },
-      {
-       "name": "aggregate_across_ranks",
-       "type": "bool",
-       "description": "Aggregate results across MPI ranks"
-      },
-      {
-       "name": "output.append",
-       "type": "bool",
-       "description": "Use append mode when writing to files"
-      }
-     ]
-    }
+{
+ "name"        : "sample-report",
+ "description" : "Print a sampling profile for the program",
+ "categories"  : [ "output", "sampling", "treeformatter", "region" ],
+ "services"    : [ "sampler", "trace" ],
+ "config"      : { "CALI_CHANNEL_FLUSH_ON_EXIT": "false" },
+ "defaults"    : { "source.function": "true", "output.append": "true" },
+ "options":
+ [
+  {
+   "name": "sample.frequency",
+   "type": "int",
+   "description": "Sampling frequency in Hz. Default: 200"
+  },{
+   "name": "callpath",
+   "type": "bool",
+   "description": "Group by function call path instead of instrumented region",
+   "services": [ "callpath", "symbollookup" ]
+  },{
+   "name": "aggregate_across_ranks",
+   "type": "bool",
+   "description": "Aggregate results across MPI ranks"
+  },{
+   "name": "output.append",
+   "type": "bool",
+   "description": "Use append mode when writing to files"
+  }
+ ]
+}
 )json";
 
 } // namespace

--- a/src/caliper/controllers/SpotController.cpp
+++ b/src/caliper/controllers/SpotController.cpp
@@ -557,102 +557,83 @@ std::string check_spot_timeseries_args(const cali::ConfigManager::Options& opts)
 }
 
 const char* spot_controller_spec = R"json(
+{
+ "name"        : "spot",
+ "description" : "Record a time profile for the Spot web visualization framework",
+ "categories"  : [ "adiak", "metadata", "metric", "output", "region", "event" ],
+ "services"    : [ "aggregate", "event", "timer" ],
+ "config"      :
+ {
+  "CALI_CHANNEL_FLUSH_ON_EXIT"      : "false",
+  "CALI_CHANNEL_CONFIG_CHECK"       : "false",
+  "CALI_EVENT_ENABLE_SNAPSHOT_INFO" : "false",
+  "CALI_TIMER_SNAPSHOT_DURATION"    : "true",
+  "CALI_TIMER_INCLUSIVE_DURATION"   : "false"
+ },
+ "defaults"    : { "node.order": "true", "region.count": "true", "time.exclusive" : "true" },
+ "options":
+ [
+  {
+   "name": "time.exclusive",
+   "type": "bool",
+   "category": "metric",
+   "description": "Collect exclusive time per region",
+   "query":
+   [
     {
-     "name"        : "spot",
-     "description" : "Record a time profile for the Spot web visualization framework",
-     "categories"  : [ "adiak", "metadata", "metric", "output", "region", "event" ],
-     "services"    : [ "aggregate", "event", "timer" ],
-     "config"      :
-       { "CALI_CHANNEL_FLUSH_ON_EXIT"      : "false",
-         "CALI_CHANNEL_CONFIG_CHECK"       : "false",
-         "CALI_EVENT_ENABLE_SNAPSHOT_INFO" : "false",
-         "CALI_TIMER_SNAPSHOT_DURATION"    : "true",
-         "CALI_TIMER_INCLUSIVE_DURATION"   : "false",
-         "CALI_TIMER_UNIT"                 : "sec"
-       },
-     "defaults"    :
-     {
-      "node.order"     : "true",
-      "region.count"   : "true",
-      "time.exclusive" : "true"
-     },
-     "options":
+     "level"  : "local",
+     "select" : [ "scale(sum#time.duration.ns,1e-9) as \"Time (exc)\" unit sec" ]
+    },{
+     "level"  : "cross",
+     "select" :
      [
-      {
-       "name": "time.exclusive",
-       "type": "bool",
-       "category": "metric",
-       "description": "Collect exclusive time per region",
-       "query":
-       [
-        {
-         "level"  : "local",
-         "select" :
-         [
-          "scale(sum#time.duration.ns,1e-9) as \"Time (exc)\" unit sec"
-         ]
-        },
-        {
-         "level"  : "cross",
-         "select" :
-         [
-          "min(scale#sum#time.duration.ns) as \"Min time/rank (exc)\" unit sec",
-          "max(scale#sum#time.duration.ns) as \"Max time/rank (exc)\" unit sec",
-          "avg(scale#sum#time.duration.ns) as \"Avg time/rank (exc)\" unit sec",
-          "sum(scale#sum#time.duration.ns) as \"Total time (exc)\" unit sec"
-         ]
-        }
-       ]
-      },
-      {
-       "name": "time.variance",
-       "type": "bool",
-       "category": "metric",
-       "description": "Compute population variance of time across MPI ranks",
-       "query":
-       [
-        {
-         "level": "cross", "select": [ "variance(inclusive#sum#time.duration) as \"Variance time/rank\"" ]
-        }
-       ]
-      },
-      {
-       "name": "timeseries",
-       "type": "bool",
-       "description": "Collect time-series data for annotated loops"
-      },
-      {
-       "name": "timeseries.maxrows",
-       "type": "int",
-       "description": "Max number of rows in timeseries output. Set to 0 to show all. Default: 20."
-      },
-      {
-       "name": "timeseries.iteration_interval",
-       "type": "int",
-       "description": "Measure every N loop iterations in timeseries"
-      },
-      {
-       "name": "timeseries.time_interval",
-       "type": "double",
-       "description": "Measure after t seconds in timeseries"
-      },
-      {
-       "name": "timeseries.target_loops",
-       "type": "string",
-       "description": "List of loops to target for timeseries measurements. Default: any top-level loop."
-      },
-      {
-       "name": "timeseries.metrics",
-       "type": "string",
-       "description": "Metrics to record for timeseries measurements."
-      },
-      {
-       "name": "outdir",
-       "type": "string",
-       "description": "Output directory name"
-      }
+      "min(scale#sum#time.duration.ns) as \"Min time/rank (exc)\" unit sec",
+      "max(scale#sum#time.duration.ns) as \"Max time/rank (exc)\" unit sec",
+      "avg(scale#sum#time.duration.ns) as \"Avg time/rank (exc)\" unit sec",
+      "sum(scale#sum#time.duration.ns) as \"Total time (exc)\" unit sec"
      ]
     }
+   ]
+  },{
+   "name": "time.variance",
+   "type": "bool",
+   "category": "metric",
+   "description": "Compute population variance of time across MPI ranks",
+   "query":
+   [
+    { "level": "cross", "select": [ "variance(inclusive#sum#time.duration) as \"Variance time/rank\"" ] }
+   ]
+  },{
+   "name": "timeseries",
+   "type": "bool",
+   "description": "Collect time-series data for annotated loops"
+  },{
+   "name": "timeseries.maxrows",
+   "type": "int",
+   "description": "Max number of rows in timeseries output. Set to 0 to show all. Default: 20."
+  },{
+   "name": "timeseries.iteration_interval",
+   "type": "int",
+   "description": "Measure every N loop iterations in timeseries"
+  },{
+   "name": "timeseries.time_interval",
+   "type": "double",
+   "description": "Measure after t seconds in timeseries"
+  },{
+   "name": "timeseries.target_loops",
+   "type": "string",
+   "description": "List of loops to target for timeseries measurements. Default: any top-level loop."
+  },{
+   "name": "timeseries.metrics",
+   "type": "string",
+   "description": "Metrics to record for timeseries measurements."
+  },{
+   "name": "outdir",
+   "type": "string",
+   "description": "Output directory name"
+  }
+ ]
+}
 )json";
 
 cali::ChannelController* make_spot_controller(

--- a/src/caliper/controllers/controllers.cpp
+++ b/src/caliper/controllers/controllers.cpp
@@ -9,175 +9,160 @@ namespace
 {
 
 const char* event_trace_spec = R"json(
-    {
-     "name"        : "event-trace",
-     "description" : "Record a trace of region enter/exit events in .cali format",
-     "services"    : [ "event", "recorder", "timer", "trace" ],
-     "categories"  : [ "output", "metadata", "event" ],
-     "config"      : { "CALI_CHANNEL_FLUSH_ON_EXIT" : "false" },
-     "options":
-     [
-      {
-        "name"        : "outdir",
-        "description" : "Output directory",
-        "type"        : "string",
-        "config"      : { "CALI_RECORDER_DIRECTORY": "{}" }
-      },
-      { "name"        : "trace.io",
-        "description" : "Trace I/O events",
-        "type"        : "bool",
-        "services"    : [ "io" ]
-      },
-      { "name"        : "trace.mpi",
-        "description" : "Trace MPI events",
-        "type"        : "bool",
-        "services"    : [ "mpi" ],
-        "config"      : { "CALI_MPI_BLACKLIST": "MPI_Wtime,MPI_Wtick,MPI_Comm_size,MPI_Comm_rank" }
-      },
-      { "name"        : "trace.cuda",
-        "description" : "Trace CUDA API events",
-        "type"        : "bool",
-        "services"    : [ "cupti" ]
-      },
-      { "name"        : "trace.io",
-        "description" : "Trace I/O events",
-        "type"        : "bool",
-        "services"    : [ "io" ]
-      },
-      { "name"        : "trace.openmp",
-        "description" : "Trace OpenMP events",
-        "type"        : "bool",
-        "services"    : [ "ompt" ]
-      },
-      { "name"        : "trace.kokkos",
-        "description" : "Trace Kokkos kernels",
-        "type"        : "bool",
-        "services"    : [ "kokkostime" ]
-      },
-      { "name"        : "event.timestamps",
-        "description" : "Record event timestamps [deprecated; always-on]",
-        "type"        : "bool"
-      },
-      { "name"        : "time.inclusive",
-        "description" : "Record inclusive region times",
-        "type"        : "bool",
-        "config"      : { "CALI_TIMER_INCLUSIVE_DURATION": "true" }
-      },
-      { "name"        : "sampling",
-        "description" : "Enable call-path sampling",
-        "type"        : "bool",
-        "services"    : [ "callpath", "pthread", "sampler", "symbollookup" ],
-        "config"      : { "CALI_SAMPLER_FREQUENCY": "200" }
-      },
-      { "name"        : "sample.frequency",
-        "description" : "Sampling frequency when sampling",
-        "type"        : "int",
-        "inherit"     : "sampling",
-        "config"      : { "CALI_SAMPLER_FREQUENCY": "{}" }
-      },
-      { "name"        : "papi.counters",
-        "description" : "List of PAPI counters to read",
-        "type"        : "string",
-        "services"    : [ "papi" ],
-        "config"      : { "CALI_PAPI_COUNTERS": "{}" }
-      },
-      { "name"        : "cuda.activities",
-        "description" : "Trace CUDA activities",
-        "type"        : "bool",
-        "services"    : [ "cuptitrace" ],
-        "config"      : { "CALI_CUPTITRACE_SNAPSHOT_TIMESTAMPS": "true" }
-      },
-      { "name"        : "rocm.activities",
-        "description" : "Trace ROCm activities",
-        "type"        : "bool",
-        "services"    : [ "roctracer" ],
-        "config"      : { "CALI_ROCTRACER_SNAPSHOT_TIMESTAMPS": "true" }
-      },
-      { "name"        : "umpire.totals",
-        "description" : "Umpire total allocation statistics",
-        "type"        : "bool",
-        "services"    : [ "umpire" ],
-        "config"      : { "CALI_UMPIRE_PER_ALLOCATOR_STATISTICS": "false" }
-      },
-      { "name"        : "umpire.allocators",
-        "description" : "Umpire per-allocator allocation statistics",
-        "type"        : "bool",
-        "services"    : [ "umpire" ],
-        "config"      : { "CALI_UMPIRE_PER_ALLOCATOR_STATISTICS": "true" }
-      },
-      { "name"        : "umpire.filter",
-        "description" : "Names of Umpire allocators to track",
-        "type"        : "string",
-        "config"      : { "CALI_UMPIRE_ALLOCATOR_FILTER": "{}" }
-      }
-     ]
-    }
+{
+ "name"        : "event-trace",
+ "description" : "Record a trace of region enter/exit events in .cali format",
+ "services"    : [ "event", "recorder", "timer", "trace" ],
+ "categories"  : [ "output", "metadata", "event" ],
+ "config"      : { "CALI_CHANNEL_FLUSH_ON_EXIT" : "false" },
+ "options":
+ [
+  {
+   "name"        : "outdir",
+   "description" : "Output directory",
+   "type"        : "string",
+   "config"      : { "CALI_RECORDER_DIRECTORY": "{}" }
+  },{
+   "name"        : "trace.io",
+   "description" : "Trace I/O events",
+   "type"        : "bool",
+   "services"    : [ "io" ]
+  },{
+   "name"        : "trace.mpi",
+   "description" : "Trace MPI events",
+   "type"        : "bool",
+   "services"    : [ "mpi" ],
+   "config"      : { "CALI_MPI_BLACKLIST": "MPI_Wtime,MPI_Wtick,MPI_Comm_size,MPI_Comm_rank" }
+  },{
+   "name"        : "trace.cuda",
+   "description" : "Trace CUDA API events",
+   "type"        : "bool",
+   "services"    : [ "cupti" ]
+  },{
+   "name"        : "trace.io",
+   "description" : "Trace I/O events",
+   "type"        : "bool",
+   "services"    : [ "io" ]
+  },{
+   "name"        : "trace.openmp",
+   "description" : "Trace OpenMP events",
+   "type"        : "bool",
+   "services"    : [ "ompt" ]
+  },{
+   "name"        : "trace.kokkos",
+   "description" : "Trace Kokkos kernels",
+   "type"        : "bool",
+   "services"    : [ "kokkostime" ]
+  },{
+   "name"        : "time.inclusive",
+   "description" : "Record inclusive region times",
+   "type"        : "bool",
+   "config"      : { "CALI_TIMER_INCLUSIVE_DURATION": "true" }
+  },{
+   "name"        : "sampling",
+   "description" : "Enable call-path sampling",
+   "type"        : "bool",
+   "services"    : [ "callpath", "pthread", "sampler", "symbollookup" ],
+   "config"      : { "CALI_SAMPLER_FREQUENCY": "200" }
+  },{
+   "name"        : "sample.frequency",
+   "description" : "Sampling frequency when sampling",
+   "type"        : "int",
+   "inherit"     : "sampling",
+   "config"      : { "CALI_SAMPLER_FREQUENCY": "{}" }
+  },{
+   "name"        : "papi.counters",
+   "description" : "List of PAPI counters to read",
+   "type"        : "string",
+   "services"    : [ "papi" ],
+   "config"      : { "CALI_PAPI_COUNTERS": "{}" }
+  },{
+   "name"        : "cuda.activities",
+   "description" : "Trace CUDA activities",
+   "type"        : "bool",
+   "services"    : [ "cuptitrace" ],
+   "config"      : { "CALI_CUPTITRACE_SNAPSHOT_TIMESTAMPS": "true" }
+  },{
+   "name"        : "rocm.activities",
+   "description" : "Trace ROCm activities",
+   "type"        : "bool",
+   "services"    : [ "roctracer" ],
+   "config"      : { "CALI_ROCTRACER_SNAPSHOT_TIMESTAMPS": "true" }
+  },{
+   "name"        : "umpire.allocators",
+   "description" : "Umpire per-allocator allocation statistics",
+   "type"        : "bool",
+   "services"    : [ "umpire" ],
+   "config"      : { "CALI_UMPIRE_PER_ALLOCATOR_STATISTICS": "true" }
+  }
+ ]
+}
 )json";
 
 const char* nvprof_spec = R"json(
-    {
-     "name"        : "nvprof",
-     "services"    : [ "nvtx" ],
-     "description" : "Forward Caliper regions to NVidia nvprof (deprecated; use nvtx)",
-     "config"      : { "CALI_CHANNEL_FLUSH_ON_EXIT": "false" }
-    }
+{
+ "name"        : "nvprof",
+ "services"    : [ "nvtx" ],
+ "description" : "Forward Caliper regions to NVidia nvprof (deprecated; use nvtx)",
+ "config"      : { "CALI_CHANNEL_FLUSH_ON_EXIT": "false" }
+}
 )json";
 
 const char* nvtx_spec = R"json(
-    {
-     "name"        : "nvtx",
-     "services"    : [ "nvtx" ],
-     "description" : "Forward Caliper regions to NVidia NSight/NVprof",
-     "config"      : { "CALI_CHANNEL_FLUSH_ON_EXIT": "false" }
-    }
+{
+ "name"        : "nvtx",
+ "services"    : [ "nvtx" ],
+ "description" : "Forward Caliper regions to NVidia NSight/NVprof",
+ "config"      : { "CALI_CHANNEL_FLUSH_ON_EXIT": "false" }
+}
 )json";
 
 const char* roctx_spec = R"json(
-    {
-     "name"        : "roctx",
-     "services"    : [ "roctx" ],
-     "description" : "Forward Caliper regions to ROCm rocprofiler",
-     "config"      : { "CALI_CHANNEL_FLUSH_ON_EXIT": "false" }
-    }
+{
+ "name"        : "roctx",
+ "services"    : [ "roctx" ],
+ "description" : "Forward Caliper regions to ROCm rocprofiler",
+ "config"      : { "CALI_CHANNEL_FLUSH_ON_EXIT": "false" }
+}
 )json";
 
 const char* mpireport_spec = R"json(
-    {
-     "name"        : "mpi-report",
-     "services"    : [ "aggregate", "event", "mpi", "mpireport", "timer" ],
-     "description" : "Print time spent in MPI functions",
-     "categories"  : [ "event" ],
-     "config"      :
-      { "CALI_CHANNEL_FLUSH_ON_EXIT"       : "false",
-        "CALI_AGGREGATE_KEY"               : "mpi.function",
-        "CALI_EVENT_TRIGGER"               : "mpi.function",
-        "CALI_EVENT_ENABLE_SNAPSHOT_INFO"  : "false",
-        "CALI_TIMER_SNAPSHOT_DURATION"     : "true",
-        "CALI_TIMER_INCLUSIVE_DURATION"    : "false",
-        "CALI_TIMER_UNIT"                  : "sec",
-        "CALI_MPI_BLACKLIST"    :
-          "MPI_Comm_size,MPI_Comm_rank,MPI_Wtime",
-        "CALI_MPIREPORT_WRITE_ON_FINALIZE" : "false",
-        "CALI_MPIREPORT_CONFIG" :
-          "let
-              sum#time.duration=scale(sum#time.duration.ns,1e-9)
-           select
-              mpi.function as Function,
-              min(count) as \"Count (min)\",
-              max(count) as \"Count (max)\",
-              min(sum#time.duration) as \"Time (min)\",
-              max(sum#time.duration) as \"Time (max)\",
-              avg(sum#time.duration) as \"Time (avg)\",
-              percent_total(sum#time.duration) as \"Time %\"
-            group by
-              mpi.function
-            format
-              table
-            order by
-              percent_total#sum#time.duration desc
-          "
-      }
-    }
+{
+ "name"        : "mpi-report",
+ "services"    : [ "aggregate", "event", "mpi", "mpireport", "timer" ],
+ "description" : "Print time spent in MPI functions",
+ "categories"  : [ "event" ],
+ "config"      :
+ { "CALI_CHANNEL_FLUSH_ON_EXIT"       : "false",
+   "CALI_AGGREGATE_KEY"               : "mpi.function",
+   "CALI_EVENT_TRIGGER"               : "mpi.function",
+   "CALI_EVENT_ENABLE_SNAPSHOT_INFO"  : "false",
+   "CALI_TIMER_SNAPSHOT_DURATION"     : "true",
+   "CALI_TIMER_INCLUSIVE_DURATION"    : "false",
+   "CALI_TIMER_UNIT"                  : "sec",
+   "CALI_MPI_BLACKLIST"    :
+     "MPI_Comm_size,MPI_Comm_rank,MPI_Wtime",
+   "CALI_MPIREPORT_WRITE_ON_FINALIZE" : "false",
+   "CALI_MPIREPORT_CONFIG" :
+     "let
+        sum#time.duration=scale(sum#time.duration.ns,1e-9)
+      select
+        mpi.function as Function,
+        min(count) as \"Count (min)\",
+        max(count) as \"Count (max)\",
+        min(sum#time.duration) as \"Time (min)\",
+        max(sum#time.duration) as \"Time (max)\",
+        avg(sum#time.duration) as \"Time (avg)\",
+        percent_total(sum#time.duration) as \"Time %\"
+      group by
+        mpi.function
+      format
+        table
+      order by
+        percent_total#sum#time.duration desc
+     "
+  }
+}
 )json";
 
 cali::ConfigManager::ConfigInfo event_trace_controller_info { event_trace_spec, nullptr, nullptr };
@@ -221,1039 +206,950 @@ const ConfigManager::ConfigInfo* builtin_controllers_table[] = { &cuda_activity_
                                                                  &spot_controller_info,
                                                                  nullptr };
 
-const char* builtin_option_specs = R"json(
+const char* builtin_base_option_specs = R"json(
+[
+{
+ "name"        : "level",
+ "type"        : "string",
+ "description" : "Minimum region level that triggers snapshots",
+ "category"    : "event",
+ "config"      : { "CALI_EVENT_REGION_LEVEL": "{}" }
+},{
+ "name"        : "include_branches",
+ "type"        : "string",
+ "description" : "Only take snapshots for branches with the given region names.",
+ "category"    : "event",
+ "config"      : { "CALI_EVENT_INCLUDE_BRANCHES": "{}" }
+},{
+ "name"        : "include_regions",
+ "type"        : "string",
+ "description" : "Only take snapshots for the given region names/patterns.",
+ "category"    : "event",
+ "config"      : { "CALI_EVENT_INCLUDE_REGIONS": "{}" }
+},{
+ "name"        : "exclude_regions",
+ "type"        : "string",
+ "description" : "Do not take snapshots for the given region names/patterns.",
+ "category"    : "event",
+ "config"      : { "CALI_EVENT_EXCLUDE_REGIONS": "{}" }
+},{
+ "name"        : "region.count",
+ "description" : "Report number of begin/end region instances",
+ "type"        : "bool",
+ "category"    : "metric",
+ "query"  :
+ [
+  { "level"   : "local",
+    "let"     : [ "rc.count=first(sum#region.count,region.count)" ],
+    "select"  : [ "sum(rc.count) as Calls unit count" ]
+  },
+  { "level"   : "cross", "select":
+   [
+    "min(sum#rc.count) as \"Calls/rank (min)\" unit count",
+    "avg(sum#rc.count) as \"Calls/rank (avg)\" unit count",
+    "max(sum#rc.count) as \"Calls/rank (max)\" unit count",
+    "sum(sum#rc.count) as \"Calls (total)\" unit count"
+   ]
+  }
+ ]
+},{
+ "name"        : "region.stats",
+ "description" : "Detailed region timing statistics (min/max/avg time per visit)",
+ "type"        : "bool",
+ "category"    : "metric",
+ "services"    : [ "timer", "event" ],
+ "config"      :
+ {
+  "CALI_TIMER_INCLUSIVE_DURATION"   : "true",
+  "CALI_EVENT_ENABLE_SNAPSHOT_INFO" : "true"
+ },
+ "query"  :
+ [
+  { "level": "local",
+    "let":
     [
-    {
-     "name"        : "profile.mpi",
-     "type"        : "bool",
-     "description" : "Profile MPI functions",
-     "category"    : "region",
-     "services"    : [ "mpi" ],
-     "config": { "CALI_MPI_BLACKLIST": "MPI_Comm_rank,MPI_Comm_size,MPI_Wtick,MPI_Wtime" }
-    },
-    {
-     "name"        : "profile.cuda",
-     "type"        : "bool",
-     "description" : "Profile CUDA API functions",
-     "category"    : "region",
-     "services"    : [ "cupti" ]
-    },
-    {
-     "name"        : "profile.hip",
-     "type"        : "bool",
-     "description" : "Profile HIP API functions",
-     "category"    : "region",
-     "services"    : [ "roctracer" ],
-     "config"      : { "CALI_ROCTRACER_TRACE_ACTIVITIES": "false" }
-    },
-    {
-     "name"        : "profile.kokkos",
-     "type"        : "bool",
-     "description" : "Profile Kokkos functions",
-     "category"    : "region",
-     "services"    : [ "kokkostime" ]
-    },
-    {
-     "name"        : "main_thread_only",
-     "type"        : "bool",
-     "description" : "Only include measurements from the main thread in results.",
-     "category"    : "region",
-     "services"    : [ "pthread" ],
-     "query"  :
-     [
-      { "level"    : "local",
-        "where"    : "pthread.is_master=true"
-      }
-     ]
-    },
-    {
-     "name"        : "level",
-     "type"        : "string",
-     "description" : "Minimum region level that triggers snapshots",
-     "category"    : "event",
-     "config"      : { "CALI_EVENT_REGION_LEVEL": "{}" }
-    },
-    {
-     "name"        : "include_branches",
-     "type"        : "string",
-     "description" : "Only take snapshots for branches with the given region names.",
-     "category"    : "event",
-     "config"      : { "CALI_EVENT_INCLUDE_BRANCHES": "{}" }
-    },
-    {
-     "name"        : "include_regions",
-     "type"        : "string",
-     "description" : "Only take snapshots for the given region names/patterns.",
-     "category"    : "event",
-     "config"      : { "CALI_EVENT_INCLUDE_REGIONS": "{}" }
-    },
-    {
-     "name"        : "exclude_regions",
-     "type"        : "string",
-     "description" : "Do not take snapshots for the given region names/patterns.",
-     "category"    : "event",
-     "config"      : { "CALI_EVENT_EXCLUDE_REGIONS": "{}" }
-    },
-    {
-     "name"        : "mpi.include",
-     "type"        : "string",
-     "description" : "Only instrument these MPI functions.",
-     "category"    : "region",
-     "config"      : { "CALI_MPI_WHITELIST": "{}" }
-    },
-    {
-     "name"        : "mpi.exclude",
-     "type"        : "string",
-     "description" : "Do not instrument these MPI functions.",
-     "category"    : "region",
-     "config"      : { "CALI_MPI_BLACKLIST": "{}" }
-    },
-    {
-     "name"        : "region.count",
-     "description" : "Report number of begin/end region instances",
-     "type"        : "bool",
-     "category"    : "metric",
-     "query"  :
-     [
-       { "level"   : "local",
-         "let"     : [ "rc.count=first(sum#region.count,region.count)" ],
-         "select"  : [ "sum(rc.count) as Calls unit count" ]
-       },
-       { "level"   : "cross", "select":
-         [
-          "min(sum#rc.count) as \"Calls/rank (min)\" unit count",
-          "avg(sum#rc.count) as \"Calls/rank (avg)\" unit count",
-          "max(sum#rc.count) as \"Calls/rank (max)\" unit count",
-          "sum(sum#rc.count) as \"Calls (total)\" unit count"
-         ]
-       }
-     ]
-    },
-    {
-     "name"        : "region.stats",
-     "description" : "Detailed region timing statistics (min/max/avg time per visit)",
-     "type"        : "bool",
-     "category"    : "metric",
-     "services"    : [ "timer", "event" ],
-     "config"      :
-     {
-      "CALI_TIMER_INCLUSIVE_DURATION"   : "true",
-      "CALI_EVENT_ENABLE_SNAPSHOT_INFO" : "true"
-     },
-     "query"  :
-     [
-       { "level"   : "local",
-         "let"     :
-         [
-          "rs.count=first(sum#region.count,region.count)",
-          "rs.min=scale(min#time.inclusive.duration.ns,1e-9)",
-          "rs.max=scale(max#time.inclusive.duration.ns,1e-9)",
-          "rs.sum=scale(sum#time.inclusive.duration.ns,1e-9)"
-         ],
-         "aggregate":
-         [
-          "sum(rs.sum)"
-         ],
-         "select"  :
-         [
-          "sum(rs.count) as Visits unit count",
-          "min(rs.min) as \"Min time/visit\" unit sec",
-          "ratio(rs.sum,rs.count) as \"Avg time/visit\" unit sec",
-          "max(rs.max) as \"Max time/visit\" unit sec"
-         ]
-       },
-       { "level"   : "cross", "select":
-         [
-          "sum(sum#rs.count) as Visits unit count",
-          "min(min#rs.min) as \"Min time/visit\" unit sec",
-          "ratio(sum#rs.sum,sum#rs.count) as \"Avg time/visit\" unit sec",
-          "max(max#rs.max) as \"Max time/visit\" unit sec"
-         ]
-       }
-     ]
-    },
-    {
-     "name"        : "loop.stats",
-     "description" : "Loop iteration count and time statistics",
-     "type"        : "bool",
-     "category"    : "metric",
-     "services"    : [ "loop_statistics" ],
-     "query"  :
-     [
-       { "level"   : "local",
-         "let"     :
-         [
-          "ls.min=scale(min#iter.duration.ns,1e-9)",
-          "ls.avg=scale(avg#iter.duration.ns,1e-9)",
-          "ls.max=scale(max#iter.duration.ns,1e-9)"
-         ],
-         "select"  :
-         [
-          "max(max#iter.count) as \"Iterations\" unit count",
-          "min(ls.min) as \"Time/iter (min)\" unit sec",
-          "avg(ls.avg) as \"Time/iter (avg)\" unit sec",
-          "max(ls.max) as \"Time/iter (max)\" unit sec"
-         ]
-       },
-       { "level"   : "cross", "select":
-         [
-          "max(max#max#iter.count) as \"Iterations\" unit count",
-          "min(min#ls.min) as \"Time/iter (min)\" unit sec",
-          "avg(avg#ls.avg) as \"Time/iter (avg)\" unit sec",
-          "max(max#ls.max) as \"Time/iter (max)\" unit sec"
-         ]
-       }
-     ]
-    },
-    {
-     "name"        : "node.order",
-     "description" : "Report order in which regions first appeared",
-     "type"        : "bool",
-     "category"    : "metric",
-     "query"  :
-     [
-       { "level"   : "local",
-         "select"  : [ "min(aggregate.slot) as \"Node order\"" ]
-       },
-       { "level"   : "cross",
-         "select"  : [ "min(min#aggregate.slot) as \"Node order\"" ]
-       }
-     ]
-    },
-    {
-     "name"        : "source.module",
-     "type"        : "bool",
-     "category"    : "sampling",
-     "description" : "Report source module (.so/.exe)",
-     "services"    : [ "symbollookup" ],
-     "config"      : { "CALI_SYMBOLLOOKUP_LOOKUP_MODULE": "true" },
-     "query":
-     [
-      { "level": "local", "group by": "module#cali.sampler.pc",
-        "select": [ "module#cali.sampler.pc as \"Module\"" ]
-      },
-      { "level": "cross", "group by": "module#cali.sampler.pc",
-        "select": [ "module#cali.sampler.pc as \"Module\"" ]
-      }
-     ]
-    },
-    {
-     "name"        : "source.function",
-     "type"        : "bool",
-     "category"    : "sampling",
-     "description" : "Report source function symbol names",
-     "services"    : [ "symbollookup" ],
-     "config"      : { "CALI_SYMBOLLOOKUP_LOOKUP_FUNCTION": "true" },
-     "query":
-     [
-      { "level": "local", "group by": "source.function#cali.sampler.pc",
-        "select": [ "source.function#cali.sampler.pc as \"Function\"" ]
-      },
-      { "level": "cross", "group by": "source.function#cali.sampler.pc",
-        "select": [ "source.function#cali.sampler.pc as \"Function\"" ]
-      }
-     ]
-    },
-    {
-     "name"        : "source.location",
-     "type"        : "bool",
-     "category"    : "sampling",
-     "description" : "Report source location (file+line)",
-     "services"    : [ "symbollookup" ],
-     "config"      : { "CALI_SYMBOLLOOKUP_LOOKUP_SOURCELOC": "true" },
-     "query":
-     [
-      { "level": "local", "group by": "sourceloc#cali.sampler.pc",
-        "select": [ "sourceloc#cali.sampler.pc as \"Source\"" ]
-      },
-      { "level": "cross", "group by": "sourceloc#cali.sampler.pc",
-        "select": [ "sourceloc#cali.sampler.pc as \"Source\"" ]
-      }
-     ]
-    },
-    {
-     "name"        : "cuda.memcpy",
-     "description" : "Report MB copied between host and device with cudaMemcpy",
-     "type"        : "bool",
-     "category"    : "cuptitrace.metric",
-     "query"  :
-     [
-       { "level"   : "local",
-         "let"     :
-         [
-          "cuda.memcpy.dtoh=scale(cupti.memcpy.bytes,1e-6) if cupti.memcpy.kind=DtoH",
-          "cuda.memcpy.htod=scale(cupti.memcpy.bytes,1e-6) if cupti.memcpy.kind=HtoD"
-         ],
-         "select"  :
-         [
-          "sum(cuda.memcpy.htod) as \"Copy CPU->GPU\" unit MB",
-          "sum(cuda.memcpy.dtoh) as \"Copy GPU->CPU\" unit MB"
-         ]
-       },
-       { "level"   : "cross", "select":
-         [
-           "avg(sum#cuda.memcpy.htod) as \"Copy CPU->GPU (avg)\" unit MB",
-           "max(sum#cuda.memcpy.htod) as \"Copy CPU->GPU (max)\" unit MB",
-           "avg(sum#cuda.memcpy.dtoh) as \"Copy GPU->CPU (avg)\" unit MB",
-           "max(sum#cuda.memcpy.dtoh) as \"Copy GPU->CPU (max)\" unit MB"
-         ]
-       }
-     ]
-    },
-    {
-     "name"        : "cuda.gputime",
-     "description" : "Report GPU time in CUDA activities",
-     "type"        : "bool",
-     "category"    : "metric",
-     "services"    : [ "cuptitrace" ],
-     "query"  :
-     [
-       { "level"   : "local",
-         "select"  :
-         [
-          "inclusive_scale(cupti.activity.duration,1e-9) as \"GPU time (I)\" unit sec",
-         ]
-       },
-       { "level"   : "cross", "select":
-         [
-           "avg(iscale#cupti.activity.duration) as \"Avg GPU time/rank\" unit sec",
-           "min(iscale#cupti.activity.duration) as \"Min GPU time/rank\" unit sec",
-           "max(iscale#cupti.activity.duration) as \"Max GPU time/rank\" unit sec",
-           "sum(iscale#cupti.activity.duration) as \"Total GPU time\" unit sec"
-         ]
-       }
-     ]
-    },
-    {
-     "name"        : "rocm.gputime",
-     "description" : "Report GPU time in AMD ROCm activities",
-     "type"        : "bool",
-     "category"    : "metric",
-     "services"    : [ "roctracer" ],
-     "config"      : { "CALI_ROCTRACER_TRACE_ACTIVITIES": "true", "CALI_ROCTRACER_RECORD_KERNEL_NAMES": "false" },
-     "query"  :
-     [
-       { "level"   : "local",
-         "select"  :
-         [
-          "inclusive_scale(sum#rocm.activity.duration,1e-9) as \"GPU time (I)\" unit sec"
-         ]
-       },
-       { "level"   : "cross",
-         "select"  :
-         [
-           "avg(iscale#sum#rocm.activity.duration) as \"Avg GPU time/rank\" unit sec",
-           "min(iscale#sum#rocm.activity.duration) as \"Min GPU time/rank\" unit sec",
-           "max(iscale#sum#rocm.activity.duration) as \"Max GPU time/rank\" unit sec",
-           "sum(iscale#sum#rocm.activity.duration) as \"Total GPU time\" unit sec"
-         ]
-       }
-     ]
-    },
-    {
-     "name"       : "mpi.message.size",
-     "description": "MPI message size",
-     "type"       : "bool",
-     "category"   : "metric",
-     "services"   : [ "mpi" ],
-     "config"     : { "CALI_MPI_MSG_TRACING": "true", "CALI_MPI_BLACKLIST": "MPI_Wtime,MPI_Comm_rank,MPI_Comm_size" },
-     "query"      :
-     [
-      { "level"   : "local",
-        "let"     : [
-          "mpimsg.min=first(min#mpi.msg.size,mpi.msg.size)",
-          "mpimsg.avg=first(avg#mpi.msg.size,mpi.msg.size)",
-          "mpimsg.max=first(max#mpi.msg.size,mpi.msg.size)"
-        ],
-        "select"  : [
-          "min(mpimsg.min) as \"Msg size (min)\" unit Byte",
-          "avg(mpimsg.avg) as \"Msg size (avg)\" unit Byte",
-          "max(mpimsg.max) as \"Msg size (max)\" unit Byte"
-        ]
-      },
-      { "level"   : "cross",
-        "select"  : [
-          "min(min#mpimsg.min) as \"Msg size (min)\" unit Byte",
-          "avg(avg#mpimsg.avg) as \"Msg size (avg)\" unit Byte",
-          "max(max#mpimsg.max) as \"Msg size (max)\" unit Byte"
-        ]
-      }
-     ]
-    },
-    {
-     "name"       : "mpi.message.count",
-     "description": "Number of MPI send/recv/collective operations",
-     "type"       : "bool",
-     "category"   : "metric",
-     "services"   : [ "mpi" ],
-     "config"     : { "CALI_MPI_MSG_TRACING": "true", "CALI_MPI_BLACKLIST": "MPI_Wtime,MPI_Comm_rank,MPI_Comm_size" },
-     "query"      :
-     [
-      { "level"   : "local",
-        "let"     : [
-          "mpicount.recv=first(sum#mpi.recv.count,mpi.recv.count)",
-          "mpicount.send=first(sum#mpi.send.count,mpi.send.count)",
-          "mpicount.coll=first(sum#mpi.coll.count,mpi.coll.count)"
-        ],
-        "select"  : [
-          "sum(mpicount.send) as \"Msgs sent\"   unit count",
-          "sum(mpicount.recv) as \"Msgs recvd\"  unit count",
-          "sum(mpicount.coll) as \"Collectives\" unit count"
-        ]
-      },
-      { "level"   : "cross",
-        "select"  : [
-          "avg(sum#mpicount.send) as \"Msgs sent (avg)\"   unit count",
-          "max(sum#mpicount.send) as \"Msgs sent (max)\"   unit count",
-          "avg(sum#mpicount.recv) as \"Msgs recvd (avg)\"  unit count",
-          "max(sum#mpicount.recv) as \"Msgs recvd (max)\"  unit count",
-          "max(sum#mpicount.coll) as \"Collectives (max)\" unit count"
-        ]
-      }
-     ]
-    },
-    {
-     "name"        : "comm.stats",
-     "description" : "MPI message statistics in marked communication regions",
-     "type"        : "bool",
-     "category"    : "metric",
-     "services"    : [ "mpi" ],
-     "config"      : { "CALI_MPI_MSG_PATTERN": "true", "CALI_MPI_BLACKLIST": "MPI_Wtime,MPI_Comm_rank,MPI_Comm_size" },
-     "query"       :
-     [
-      { "level"    : "local",
-        "select"   :
-        [
-         "min(min#total.send.count) as \"Sends (min)\"",
-         "max(max#total.send.count) as \"Sends (max)\"",
-         "sum(sum#total.send.count) as \"Sends (total)\"",
-         "min(min#total.recv.count) as \"Recvs (min)\"",
-         "max(max#total.recv.count) as \"Recvs (max)\"",
-         "sum(sum#total.recv.count) as \"Recvs (total)\"",
-         "min(min#total.dest.ranks) as \"Dst ranks (min)\"",
-         "max(max#total.dest.ranks) as \"Dst ranks (max)\"",
-         "avg(avg#total.dest.ranks) as \"Dst ranks (avg)\"",
-         "min(min#total.src.ranks)  as \"Src ranks (min)\"",
-         "max(max#total.src.ranks)  as \"Src ranks (max)\"",
-         "avg(avg#total.src.ranks)  as \"Src ranks (avg)\"",
-         "max(max#total.coll.count) as \"Collectives (max)\"",
-         "min(min#mpi.send.size) as \"Bytes sent (min)\"",
-         "max(max#mpi.send.size) as \"Bytes sent (max)\"",
-         "sum(sum#mpi.send.size) as \"Bytes sent (total)\"",
-         "min(min#mpi.recv.size) as \"Bytes recv (min)\"",
-         "max(max#mpi.recv.size) as \"Bytes recv (max)\"",
-         "sum(sum#mpi.recv.size) as \"Bytes recv (total)\""
-        ]
-      },
-      { "level"    : "cross",
-        "select"   :
-        [
-         "min(min#min#total.send.count) as \"Sends (min)\"",
-         "max(max#max#total.send.count) as \"Sends (max)\"",
-         "sum(sum#sum#total.send.count) as \"Sends (total)\"",
-         "min(min#min#total.recv.count) as \"Recvs (min)\"",
-         "max(max#max#total.recv.count) as \"Recvs (max)\"",
-         "sum(sum#sum#total.recv.count) as \"Recvs (total)\"",
-         "min(min#min#total.dest.ranks) as \"Dst ranks (min)\"",
-         "max(max#max#total.dest.ranks) as \"Dst ranks (max)\"",
-         "avg(avg#avg#total.dest.ranks) as \"Dst ranks (avg)\"",
-         "min(min#min#total.src.ranks)  as \"Src ranks (min)\"",
-         "max(max#max#total.src.ranks)  as \"Src ranks (max)\"",
-         "avg(avg#avg#total.src.ranks)  as \"Src ranks (avg)\"",
-         "max(max#max#total.coll.count) as \"Coll (max)\"",
-         "min(min#min#mpi.send.size) as \"Bytes sent (min)\"",
-         "max(max#max#mpi.send.size) as \"Bytes sent (max)\"",
-         "sum(sum#sum#mpi.send.size) as \"Bytes sent (total)\"",
-         "min(min#min#mpi.recv.size) as \"Bytes recv (min)\"",
-         "max(max#max#mpi.recv.size) as \"Bytes recv (max)\"",
-         "sum(sum#sum#mpi.recv.size) as \"Bytes recv (total)\""
-        ]
-      }
-     ]
-    },
-    {
-     "name"        : "openmp.times",
-     "description" : "Report time spent in OpenMP work and barrier regions",
-     "type"        : "bool",
-     "category"    : "metric",
-     "services"    : [ "ompt", "timestamp" ],
-     "query"  :
-     [
-       { "level"   : "local",
-         "let"     :
-         [
-          "t.omp.ns=first(sum#time.duration.ns,time.duration.ns)",
-          "t.omp.work=scale(t.omp.ns,1e-9) if omp.work",
-          "t.omp.sync=scale(t.omp.ns,1e-9) if omp.sync",
-          "t.omp.total=first(t.omp.work,t.omp.sync)"
-         ],
-         "select"  :
-         [ "sum(t.omp.work) as \"Time (work)\"    unit sec",
-           "sum(t.omp.sync) as \"Time (barrier)\" unit sec"
-         ]
-       },
-       { "level"   : "cross", "select":
-         [ "avg(sum#t.omp.work) as \"Time (work) (avg)\" unit sec",
-           "avg(sum#t.omp.sync) as \"Time (barrier) (avg)\" unit sec",
-           "sum(sum#t.omp.work) as \"Time (work) (total)\" unit sec",
-           "sum(sum#t.omp.sync) as \"Time (barrier) (total)\" unit sec"
-         ]
-       }
-     ]
-    },
-    {
-     "name"        : "openmp.efficiency",
-     "description" : "Compute OpenMP efficiency metrics",
-     "type"        : "bool",
-     "category"    : "metric",
-     "inherit"     : [ "openmp.times" ],
-     "query"  :
-     [
-       { "level"   : "local",
-         "select"  :
-         [ "inclusive_ratio(t.omp.work,t.omp.total,100.0) as \"Work %\"    unit percent",
-           "inclusive_ratio(t.omp.sync,t.omp.total,100.0) as \"Barrier %\" unit percent"
-         ]
-       },
-       { "level"   : "cross", "select":
-         [ "min(iratio#t.omp.work/t.omp.total) as \"Work % (min)\" unit percent",
-           "avg(iratio#t.omp.work/t.omp.total) as \"Work % (avg)\" unit percent",
-           "avg(iratio#t.omp.sync/t.omp.total) as \"Barrier % (avg)\" unit percent",
-           "max(iratio#t.omp.sync/t.omp.total) as \"Barrier % (max)\" unit percent"
-         ]
-       }
-     ]
-    },
-    {
-     "name"        : "openmp.threads",
-     "description" : "Show OpenMP threads",
-     "type"        : "bool",
-     "category"    : "metric",
-     "services"    : [ "ompt" ],
-     "query"  :
-     [
-       { "level"   : "local",
-         "let"     : [ "n.omp.threads=first(omp.num.threads)" ],
-         "group by": "omp.thread.id,omp.thread.type",
-         "select"  :
-         [ "max(n.omp.threads) as \"#Threads\"",
-           "omp.thread.id as \"Thread\""
-         ]
-       },
-       { "level"   : "cross",
-         "group by": "omp.thread.id,omp.thread.type",
-         "select"  :
-         [ "max(max#n.omp.threads) as \"#Threads\"",
-           "omp.thread.id as Thread"
-         ]
-       }
-     ]
-    },
-    {
-     "name"        : "io.bytes.written",
-     "description" : "Report I/O bytes written",
-     "type"        : "bool",
-     "category"    : "metric",
-     "services"    : [ "io" ],
-     "query"  :
-     [
-       { "level"   : "local",
-         "let"     : [ "ibw.bytes.written=first(sum#io.bytes.written,io.bytes.written)" ],
-         "select"  : [ "sum(ibw.bytes.written) as \"Bytes written\" unit Byte" ]
-       },
-       { "level"   : "cross", "select":
-         [ "avg(sum#ibw.bytes.written) as \"Avg written\" unit Byte",
-           "sum(sum#ibw.bytes.written) as \"Total written\" unit Byte"
-         ]
-       }
-     ]
-    },
-    {
-     "name"        : "io.bytes.read",
-     "description" : "Report I/O bytes read",
-     "type"        : "bool",
-     "category"    : "metric",
-     "services"    : [ "io" ],
-     "query"  :
-     [
-       { "level"   : "local",
-         "let"     : [ "ibr.bytes.read=first(sum#io.bytes.read,io.bytes.read)" ],
-         "select"  : [ "sum(ibr.bytes.read) as \"Bytes read\" unit Byte" ]
-       },
-       { "level"   : "cross", "select":
-         [ "avg(sum#ibr.bytes.read) as \"Avg read\"   unit Byte",
-           "sum(sum#ibr.bytes.read) as \"Total read\" unit Byte"
-         ]
-       }
-     ]
-    },
-    {
-     "name"        : "io.bytes",
-     "description" : "Report I/O bytes written and read",
-     "type"        : "bool",
-     "category"    : "metric",
-     "inherit"     : [ "io.bytes.read", "io.bytes.written" ]
-    },
-    {
-     "name"        : "io.read.bandwidth",
-     "description" : "Report I/O read bandwidth",
-     "type"        : "bool",
-     "category"    : "metric",
-     "services"    : [ "io" ],
-     "query"  :
-     [
-      { "level"    : "local",
-        "group by" : "io.region",
-        "let"      :
-         [
-           "irb.bytes.read=first(sum#io.bytes.read,io.bytes.read)",
-           "irb.time.ns=first(sum#time.duration.ns,time.duration.ns)"
-         ],
-        "select"   :
-         [
-          "io.region as I/O",
-          "ratio(irb.bytes.read,irb.time.ns,8e3) as \"Read Mbit/s\" unit Mb/s"
-         ]
-      },
-      { "level": "cross", "select":
-       [
-        "avg(ratio#irb.bytes_read/irb.time.ns) as \"Avg read Mbit/s\" unit Mb/s",
-        "max(ratio#irb.bytes_read/irb.time.ns) as \"Max read Mbit/s\" unit Mb/s"
-       ]
-      }
-     ]
-    },
-    {
-     "name"        : "io.write.bandwidth",
-     "description" : "Report I/O write bandwidth",
-     "type"        : "bool",
-     "category"    : "metric",
-     "services"    : [ "io" ],
-     "query"  :
-     [
-      { "level"    : "local",
-        "group by" : "io.region",
-        "let"      :
-         [
-           "iwb.bytes.written=first(sum#io.bytes.written,io.bytes.written)",
-           "iwb.time.ns=first(sum#time.duration.ns,time.duration.ns)"
-         ],
-        "select"   :
-         [
-          "io.region as I/O",
-          "ratio(iwb.bytes.written,iwb.time.ns,8e3) as \"Write Mbit/s\" unit Mb/s"
-         ]
-      },
-      { "level": "cross", "select":
-       [
-        "avg(ratio#iwb.bytes.written/iwb.time) as \"Avg write Mbit/s\" unit Mb/s",
-        "max(ratio#iwb.bytes.written/iwb.time) as \"Max write Mbit/s\" unit Mb/s"
-       ]
-      }
-     ]
-    },
-    {
-     "name"        : "umpire.totals",
-     "description" : "Report umpire allocation statistics (all allocators combined)",
-     "type"        : "bool",
-     "category"    : "metric",
-     "services"    : [ "umpire" ],
-     "config"      : { "CALI_UMPIRE_PER_ALLOCATOR_STATISTICS": "false" },
-     "query"  :
-     [
-       { "level"   : "local",
-         "let"     :
-           [ "umpt.size.bytes=first(max#umpire.total.size,umpire.total.size)",
-             "umpt.count=first(max#umpire.total.count,umpire.total.count)",
-             "umpt.hwm.bytes=first(max#umpire.total.hwm,umpire.total.hwm)",
-             "umpt.size=scale(umpt.size.bytes,1e-6)",
-             "umpt.hwm=scale(umpt.hwm.bytes,1e-6)"
-           ],
-         "select"  :
-           [ "inclusive_max(umpt.size)  as \"Ump MB (Total)\" unit MB",
-             "inclusive_max(umpt.count) as \"Ump allocs (Total)\"",
-             "inclusive_max(umpt.hwm)   as \"Ump HWM (Total)\""
-           ]
-       },
-       { "level"   : "cross",
-         "select"  :
-           [ "avg(imax#umpt.size)  as \"Ump MB (avg)\" unit MB",
-             "max(imax#umpt.size)  as \"Ump MB (max)\" unit MB",
-             "avg(imax#umpt.count) as \"Ump allocs (avg)\"",
-             "max(imax#umpt.count) as \"Ump allocs (max)\"",
-             "max(imax#umpt.hwm)   as \"Ump HWM (max)\""
-           ]
-       }
-     ]
-    },
-    {
-     "name"        : "umpire.allocators",
-     "description" : "Report umpire allocation statistics per allocator",
-     "type"        : "bool",
-     "category"    : "metric",
-     "services"    : [ "umpire" ],
-     "config"      : { "CALI_UMPIRE_PER_ALLOCATOR_STATISTICS": "true" },
-     "query"  :
-     [
-       { "level"   : "local",
-         "let"     :
-           [ "ump.size.bytes=first(max#umpire.alloc.current.size,umpire.alloc.current.size)",
-             "ump.hwm.bytes=first(max#umpire.alloc.highwatermark,umpire.alloc.highwatermark)",
-             "ump.count=first(max#umpire.alloc.count,umpire.alloc.count)",
-             "ump.size=scale(ump.size.bytes,1e-6)",
-             "ump.hwm=scale(ump.hwm.bytes,1e-6)"
-           ],
-         "select"  :
-           [ "umpire.alloc.name as Allocator",
-             "inclusive_max(ump.size)  as \"Alloc MB\"  unit MB",
-             "inclusive_max(ump.hwm)   as \"Alloc HWM\" unit MB",
-             "inclusive_max(ump.count) as \"Num allocs\""
-           ],
-         "group by": "umpire.alloc.name"
-       },
-       { "level"   : "cross",
-         "select"  :
-           [ "umpire.alloc.name   as Allocator",
-             "avg(imax#ump.size)  as \"Alloc MB (avg)\"  unit MB",
-             "max(imax#ump.size)  as \"Alloc MB (max)\"  unit MB",
-             "avg(imax#ump.hwm)   as \"Alloc HWM (avg)\" unit MB",
-             "max(imax#ump.hwm)   as \"Alloc HWM (max)\" unit MB",
-             "avg(imax#ump.count) as \"Num allocs (avg)\"",
-             "max(imax#ump.count) as \"Num allocs (max)\""
-           ],
-         "group by": "umpire.alloc.name"
-       }
-     ]
-    },
-    {
-     "name"        : "umpire.filter",
-     "description" : "Names of Umpire allocators to track",
-     "type"        : "string",
-     "category"    : "metric",
-     "config"      : { "CALI_UMPIRE_ALLOCATOR_FILTER": "{}" }
-    },
-    {
-     "name"        : "mem.pages",
-     "description" : "Memory pages used via /proc/self/statm",
-     "type"        : "bool",
-     "category"    : "metric",
-     "services"    : [ "memstat" ],
-     "query"  :
-     [
-       { "level"   : "local",
-         "let"     :
-           [ "mem.vmsize = first(max#memstat.vmsize,memstat.vmsize)",
-             "mem.vmrss = first(max#memstat.vmrss,memstat.vmrss)",
-             "mem.data = first(max#memstat.data,memstat.data)"
-           ],
-         "select"  :
-           [
-            "max(mem.vmsize) as VmSize unit pages",
-            "max(mem.vmrss) as VmRSS unit pages",
-            "max(mem.data) as Data unit pages"
-           ]
-       },
-       { "level"   : "cross",
-         "select"  :
-           [
-            "max(max#mem.vmsize) as \"VmSize (max)\" unit pages",
-            "max(max#mem.vmrss) as \"VmRSS (max)\" unit pages",
-            "max(max#mem.data) as \"Data (max)\" unit pages"
-           ]
-       }
-     ]
-    },
-    {
-     "name"        : "mem.highwatermark",
-     "description" : "Report memory high-water mark",
-     "type"        : "bool",
-     "category"    : "metric",
-     "services"    : [ "alloc", "sysalloc" ],
-     "config"      : { "CALI_ALLOC_TRACK_ALLOCATIONS": "false", "CALI_ALLOC_RECORD_HIGHWATERMARK": "true" },
-     "query"  :
-     [
-       { "level"   : "local",
-         "let"     :
-           [ "mem.highwatermark.bytes = first(max#alloc.region.highwatermark,alloc.region.highwatermark)",
-             "mem.highwatermark = scale(mem.highwatermark.bytes,1e-6)"
-           ],
-         "select"  : [ "max(mem.highwatermark) as \"Allocated MB\" unit MB" ]
-       },
-       { "level"   : "cross",
-         "select"  : [ "max(max#mem.highwatermark) as \"Allocated MB\" unit MB" ]
-       }
-     ]
-    },
-    {
-     "name"        : "mem.read.bandwidth",
-     "description" : "Record memory read bandwidth using the Performance Co-pilot API",
-     "type"        : "bool",
-     "category"    : "metric",
-     "services"    : [ "pcp.memory" ],
-     "query"  :
-     [
-       { "level"   : "local",
-         "let"     : [ "mrb.time=first(pcp.time.duration,sum#pcp.time.duration)" ],
-         "select"  : [ "ratio(mem.bytes.read,mrb.time,1e-6) as \"MB/s (r)\" unit MB/s" ]
-       },
-       { "level"   : "cross", "select":
-        [
-         "avg(ratio#mem.bytes.read/mrb.time) as \"Avg MemBW (r) (MB/s)\"   unit MB/s",
-         "max(ratio#mem.bytes.read/mrb.time) as \"Max MemBW (r) (MB/s)\"   unit MB/s",
-         "sum(ratio#mem.bytes.read/mrb.time) as \"Total MemBW (r) (MB/s)\" unit MB/s"
-        ]
-       }
-     ]
-    },
-    {
-     "name"        : "mem.write.bandwidth",
-     "description" : "Record memory write bandwidth using the Performance Co-pilot API",
-     "type"        : "bool",
-     "category"    : "metric",
-     "services"    : [ "pcp.memory" ],
-     "query"  :
-     [
-       { "level"   : "local",
-         "let"     : [ "mwb.time=first(pcp.time.duration,sum#pcp.time.duration)" ],
-         "select"  : [ "ratio(mem.bytes.written,mwb.time,1e-6) as \"MB/s (w)\" unit MB/s" ]
-       },
-       { "level"   : "cross", "select":
-        [
-         "avg(ratio#mem.bytes.written/mwb.time) as \"Avg MemBW (w) (MB/s)\"   unit MB/s",
-         "max(ratio#mem.bytes.written/mwb.time) as \"Max MemBW (w) (MB/s)\"   unit MB/s",
-         "sum(ratio#mem.bytes.written/mwb.time) as \"Total MemBW (w) (MB/s)\" unit MB/s",
-        ]
-       }
-     ]
-    },
-    {
-     "name"        : "mem.bandwidth",
-     "description" : "Record memory bandwidth using the Performance Co-pilot API",
-     "type"        : "bool",
-     "category"    : "metric",
-     "inherit"     : [ "mem.read.bandwidth", "mem.write.bandwidth" ],
-    },
-    {
-     "name"        : "topdown.toplevel",
-     "description" : "Top-down analysis for Intel CPUs (top level)",
-     "type"        : "bool",
-     "category"    : "metric",
-     "services"    : [ "topdown" ],
-     "config"      : { "CALI_TOPDOWN_LEVEL": "top" },
-     "query"  :
-     [
-      { "level": "local", "select":
-       [
-        "any(topdown.retiring) as \"Retiring\"",
-        "any(topdown.backend_bound) as \"Backend bound\"",
-        "any(topdown.frontend_bound) as \"Frontend bound\"",
-        "any(topdown.bad_speculation) as \"Bad speculation\""
-       ]
-      },
-      { "level": "cross", "select":
-       [
-        "any(any#topdown.retiring) as \"Retiring\"",
-        "any(any#topdown.backend_bound) as \"Backend bound\"",
-        "any(any#topdown.frontend_bound) as \"Frontend bound\"",
-        "any(any#topdown.bad_speculation) as \"Bad speculation\""
-       ]
-      }
-     ]
-    },
-    {
-     "name"        : "topdown.all",
-     "description" : "Top-down analysis for Intel CPUs (all levels)",
-     "type"        : "bool",
-     "category"    : "metric",
-     "services"    : [ "topdown" ],
-     "config"      : { "CALI_TOPDOWN_LEVEL": "all" },
-     "query"  :
-     [
-      { "level": "local", "select":
-       [
-        "any(topdown.retiring) as \"Retiring\"",
-        "any(topdown.backend_bound) as \"Backend bound\"",
-        "any(topdown.frontend_bound) as \"Frontend bound\"",
-        "any(topdown.bad_speculation) as \"Bad speculation\"",
-        "any(topdown.branch_mispredict) as \"Branch mispredict\"",
-        "any(topdown.machine_clears) as \"Machine clears\"",
-        "any(topdown.frontend_latency) as \"Frontend latency\"",
-        "any(topdown.frontend_bandwidth) as \"Frontend bandwidth\"",
-        "any(topdown.memory_bound) as \"Memory bound\"",
-        "any(topdown.core_bound) as \"Core bound\"",
-        "any(topdown.ext_mem_bound) as \"External Memory\"",
-        "any(topdown.l1_bound) as \"L1 bound\"",
-        "any(topdown.l2_bound) as \"L2 bound\"",
-        "any(topdown.l3_bound) as \"L3 bound\""
-       ]
-      },
-      { "level": "cross", "select":
-       [
-        "any(any#topdown.retiring) as \"Retiring\"",
-        "any(any#topdown.backend_bound) as \"Backend bound\"",
-        "any(any#topdown.frontend_bound) as \"Frontend bound\"",
-        "any(any#topdown.bad_speculation) as \"Bad speculation\"",
-        "any(any#topdown.branch_mispredict) as \"Branch mispredict\"",
-        "any(any#topdown.machine_clears) as \"Machine clears\"",
-        "any(any#topdown.frontend_latency) as \"Frontend latency\"",
-        "any(any#topdown.frontend_bandwidth) as \"Frontend bandwidth\"",
-        "any(any#topdown.memory_bound) as \"Memory bound\"",
-        "any(any#topdown.core_bound) as \"Core bound\"",
-        "any(any#topdown.ext_mem_bound) as \"External Memory\"",
-        "any(any#topdown.l1_bound) as \"L1 bound\"",
-        "any(any#topdown.l2_bound) as \"L2 bound\"",
-        "any(any#topdown.l3_bound) as \"L3 bound\""
-       ]
-      }
-     ]
-    },
-    {
-     "name"        : "topdown-counters.toplevel",
-     "description" : "Raw counter values for Intel top-down analysis (top level)",
-     "type"        : "bool",
-     "category"    : "metric",
-     "services"    : [ "papi" ],
-     "config"      :
-     {
-       "CALI_PAPI_COUNTERS":
-         "CPU_CLK_THREAD_UNHALTED:THREAD_P,UOPS_RETIRED:RETIRE_SLOTS,UOPS_ISSUED:ANY,INT_MISC:RECOVERY_CYCLES,IDQ_UOPS_NOT_DELIVERED:CORE"
-     },
-     "query"  :
-     [
-      { "level": "local", "select":
-       [
-        "inclusive_sum(sum#papi.CPU_CLK_THREAD_UNHALTED:THREAD_P) as cpu_clk_thread_unhalted:thread_p",
-        "inclusive_sum(sum#papi.UOPS_RETIRED:RETIRE_SLOTS) as uops_retired:retire_slots",
-        "inclusive_sum(sum#papi.UOPS_ISSUED:ANY) as uops_issued:any",
-        "inclusive_sum(sum#papi.INT_MISC:RECOVERY_CYCLES) as int_misc:recovery_cycles",
-        "inclusive_sum(sum#papi.IDQ_UOPS_NOT_DELIVERED:CORE) as idq_uops_note_delivered:core"
-       ]
-      },
-      { "level": "cross", "select":
-       [
-        "sum(inclusive#sum#papi.CPU_CLK_THREAD_UNHALTED:THREAD_P) as cpu_clk_thread_unhalted:thread_p",
-        "sum(inclusive#sum#papi.UOPS_RETIRED:RETIRE_SLOTS) as uops_retired:retire_slots",
-        "sum(inclusive#sum#papi.UOPS_ISSUED:ANY) as uops_issued:any",
-        "sum(inclusive#sum#papi.INT_MISC:RECOVERY_CYCLES) as int_misc:recovery_cycles",
-        "sum(inclusive#sum#papi.IDQ_UOPS_NOT_DELIVERED:CORE) as idq_uops_note_delivered:core"
-       ]
-      }
-     ]
-    },
-    {
-     "name"        : "topdown-counters.all",
-     "description" : "Raw counter values for Intel top-down analysis (all levels)",
-     "type"        : "bool",
-     "category"    : "metric",
-     "services"    : [ "papi" ],
-     "config"      :
-     {
-       "CALI_PAPI_COUNTERS":
-         "BR_MISP_RETIRED:ALL_BRANCHES
-          ,CPU_CLK_THREAD_UNHALTED:THREAD_P
-          ,CYCLE_ACTIVITY:CYCLES_NO_EXECUTE
-          ,CYCLE_ACTIVITY:STALLS_L1D_PENDING
-          ,CYCLE_ACTIVITY:STALLS_L2_PENDING
-          ,CYCLE_ACTIVITY:STALLS_LDM_PENDING
-          ,IDQ_UOPS_NOT_DELIVERED:CORE
-          ,IDQ_UOPS_NOT_DELIVERED:CYCLES_0_UOPS_DELIV_CORE
-          ,INT_MISC:RECOVERY_CYCLES
-          ,MACHINE_CLEARS:COUNT
-          ,MEM_LOAD_UOPS_RETIRED:L3_HIT
-          ,MEM_LOAD_UOPS_RETIRED:L3_MISS
-          ,UOPS_EXECUTED:CORE_CYCLES_GE_1
-          ,UOPS_EXECUTED:CORE_CYCLES_GE_2
-          ,UOPS_ISSUED:ANY
-          ,UOPS_RETIRED:RETIRE_SLOTS"
-     },
-     "query"  :
-     [
-      { "level": "local", "select":
-       [
-        "inclusive_sum(sum#papi.BR_MISP_RETIRED:ALL_BRANCHES) as br_misp_retired:all_branches",
-        "inclusive_sum(sum#papi.CPU_CLK_THREAD_UNHALTED:THREAD_P) as cpu_clk_thread_unhalted:thread_p",
-        "inclusive_sum(sum#papi.CYCLE_ACTIVITY:CYCLES_NO_EXECUTE) as cycle_activity:cycles_no_execute",
-        "inclusive_sum(sum#papi.CYCLE_ACTIVITY:STALLS_L1D_PENDING) as cycle_activity:stalls_l1d_pending",
-        "inclusive_sum(sum#papi.CYCLE_ACTIVITY:STALLS_L2_PENDING) as cycle_activity:stalls_l2_pending",
-        "inclusive_sum(sum#papi.CYCLE_ACTIVITY:STALLS_LDM_PENDING) as cycle_activity:stalls_ldm_pending",
-        "inclusive_sum(sum#papi.IDQ_UOPS_NOT_DELIVERED:CORE) as idq_uops_note_delivered:core",
-        "inclusive_sum(sum#papi.IDQ_UOPS_NOT_DELIVERED:CYCLES_0_UOPS_DELIV_CORE) as idq_uops_note_delivered:cycles_0_uops_deliv_core",
-        "inclusive_sum(sum#papi.INT_MISC:RECOVERY_CYCLES) as int_misc:recovery_cycles",
-        "inclusive_sum(sum#papi.MACHINE_CLEARS:COUNT) as machine_clears:count",
-        "inclusive_sum(sum#papi.MEM_LOAD_UOPS_RETIRED:L3_HIT) as mem_load_uops_retired:l3_hit",
-        "inclusive_sum(sum#papi.MEM_LOAD_UOPS_RETIRED:L3_MISS) as mem_load_uops_retired:l3_miss",
-        "inclusive_sum(sum#papi.UOPS_EXECUTED:CORE_CYCLES_GE_1) as uops_executed:core_cycles_ge_1",
-        "inclusive_sum(sum#papi.UOPS_EXECUTED:CORE_CYCLES_GE_2) as uops_executed:core_cycles_ge_2",
-        "inclusive_sum(sum#papi.UOPS_ISSUED:ANY) as uops_issued:any",
-        "inclusive_sum(sum#papi.UOPS_RETIRED:RETIRE_SLOTS) as uops_retired:retire_slots"
-       ]
-      },
-      { "level": "cross", "select":
-       [
-        "sum(inclusive#sum#papi.BR_MISP_RETIRED:ALL_BRANCHES) as br_misp_retired:all_branches",
-        "sum(inclusive#sum#papi.CPU_CLK_THREAD_UNHALTED:THREAD_P) as cpu_clk_thread_unhalted:thread_p",
-        "sum(inclusive#sum#papi.CYCLE_ACTIVITY:CYCLES_NO_EXECUTE) as cycle_activity:cycles_no_execute",
-        "sum(inclusive#sum#papi.CYCLE_ACTIVITY:STALLS_L1D_PENDING) as cycle_activity:stalls_l1d_pending",
-        "sum(inclusive#sum#papi.CYCLE_ACTIVITY:STALLS_L2_PENDING) as cycle_activity:stalls_l2_pending",
-        "sum(inclusive#sum#papi.CYCLE_ACTIVITY:STALLS_LDM_PENDING) as cycle_activity:stalls_ldm_pending",
-        "sum(inclusive#sum#papi.IDQ_UOPS_NOT_DELIVERED:CORE) as idq_uops_note_delivered:core",
-        "sum(inclusive#sum#papi.IDQ_UOPS_NOT_DELIVERED:CYCLES_0_UOPS_DELIV_CORE) as idq_uops_note_delivered:cycles_0_uops_deliv_core",
-        "sum(inclusive#sum#papi.INT_MISC:RECOVERY_CYCLES) as int_misc:recovery_cycles",
-        "sum(inclusive#sum#papi.MACHINE_CLEARS:COUNT) as machine_clears:count",
-        "sum(inclusive#sum#papi.MEM_LOAD_UOPS_RETIRED:L3_HIT) as mem_load_uops_retired:l3_hit",
-        "sum(inclusive#sum#papi.MEM_LOAD_UOPS_RETIRED:L3_MISS) as mem_load_uops_retired:l3_miss",
-        "sum(inclusive#sum#papi.UOPS_EXECUTED:CORE_CYCLES_GE_1) as uops_executed:core_cycles_ge_1",
-        "sum(inclusive#sum#papi.UOPS_EXECUTED:CORE_CYCLES_GE_2) as uops_executed:core_cycles_ge_2",
-        "sum(inclusive#sum#papi.UOPS_ISSUED:ANY) as uops_issued:any",
-        "sum(inclusive#sum#papi.UOPS_RETIRED:RETIRE_SLOTS) as uops_retired:retire_slots"
-       ]
-      }
-     ]
-    },
-    {
-     "name"        : "output",
-     "description" : "Output location ('stdout', 'stderr', or filename)",
-     "type"        : "string",
-     "category"    : "output"
-    },
-    {
-     "name"        : "adiak.import_categories",
-     "services"    : [ "adiak_import" ],
-     "description" : "Adiak import categories. Comma-separated list of integers.",
-     "type"        : "string",
-     "category"    : "adiak"
-    },
-    {
-     "name"        : "max_column_width",
-     "type"        : "int",
-     "description" : "Maximum column width in the tree display",
-     "category"    : "treeformatter"
-    },
-    {
-     "name"        : "print.metadata",
-     "type"        : "bool",
-     "description" : "Print program metadata (Caliper globals and Adiak data)",
-     "category"    : "treeformatter"
-    },
-    {
-     "name"        : "order_as_visited",
-     "type"        : "bool",
-     "description" : "Print tree nodes in the original visit order",
-     "category"    : "treeformatter",
-     "query"       :
-     [
-      { "level":     "local",
-        "let":       [ "o_a_v.slot=first(aggregate.slot)" ],
-        "aggregate": [ "min(o_a_v.slot)" ],
-        "order by":  [ "min#o_a_v.slot"  ]
-      },
-      { "level":     "cross",
-        "aggregate": [ "min(min#o_a_v.slot)" ],
-        "order by":  [ "min#min#o_a_v.slot"  ]
-      }
-     ]
-    }
+     "rs.count=first(sum#region.count,region.count)",
+     "rs.min=scale(min#time.inclusive.duration.ns,1e-9)",
+     "rs.max=scale(max#time.inclusive.duration.ns,1e-9)",
+     "rs.sum=scale(sum#time.inclusive.duration.ns,1e-9)"
+    ],
+    "aggregate": [ "sum(rs.sum)" ],
+    "select":
+    [
+     "sum(rs.count) as Visits unit count",
+     "min(rs.min) as \"Min time/visit\" unit sec",
+     "ratio(rs.sum,rs.count) as \"Avg time/visit\" unit sec",
+     "max(rs.max) as \"Max time/visit\" unit sec"
     ]
+  },
+  { "level": "cross", "select":
+    [
+     "sum(sum#rs.count) as Visits unit count",
+     "min(min#rs.min) as \"Min time/visit\" unit sec",
+     "ratio(sum#rs.sum,sum#rs.count) as \"Avg time/visit\" unit sec",
+     "max(max#rs.max) as \"Max time/visit\" unit sec"
+    ]
+  }
+ ]
+},{
+ "name"        : "loop.stats",
+ "description" : "Loop iteration count and time statistics",
+ "type"        : "bool",
+ "category"    : "metric",
+ "services"    : [ "loop_statistics" ],
+ "query"  :
+ [
+  { "level"   : "local",
+    "let"     :
+    [
+     "ls.min=scale(min#iter.duration.ns,1e-9)",
+     "ls.avg=scale(avg#iter.duration.ns,1e-9)",
+     "ls.max=scale(max#iter.duration.ns,1e-9)"
+    ],
+    "select"  :
+    [
+     "max(max#iter.count) as \"Iterations\" unit count",
+     "min(ls.min) as \"Time/iter (min)\" unit sec",
+     "avg(ls.avg) as \"Time/iter (avg)\" unit sec",
+     "max(ls.max) as \"Time/iter (max)\" unit sec"
+    ]
+  },
+  { "level"   : "cross", "select":
+   [
+    "max(max#max#iter.count) as \"Iterations\" unit count",
+    "min(min#ls.min) as \"Time/iter (min)\" unit sec",
+    "avg(avg#ls.avg) as \"Time/iter (avg)\" unit sec",
+    "max(max#ls.max) as \"Time/iter (max)\" unit sec"
+   ]
+  }
+ ]
+},{
+ "name"        : "node.order",
+ "description" : "Report order in which regions first appeared",
+ "type"        : "bool",
+ "category"    : "metric",
+ "query"  :
+ [
+  { "level": "local", "select": [ "min(aggregate.slot) as \"Node order\"" ] },
+  { "level": "cross", "select": [ "min(min#aggregate.slot) as \"Node order\"" ] }
+ ]
+},{
+ "name"        : "output",
+ "description" : "Output location ('stdout', 'stderr', or filename)",
+ "type"        : "string",
+ "category"    : "output"
+},{
+ "name"        : "adiak.import_categories",
+ "services"    : [ "adiak_import" ],
+ "description" : "Adiak import categories. Comma-separated list of integers.",
+ "type"        : "string",
+ "category"    : "adiak"
+},{
+ "name"        : "max_column_width",
+ "type"        : "int",
+ "description" : "Maximum column width in the tree display",
+ "category"    : "treeformatter"
+},{
+ "name"        : "print.metadata",
+ "type"        : "bool",
+ "description" : "Print program metadata (Caliper globals and Adiak data)",
+ "category"    : "treeformatter"
+},{
+ "name"        : "order_as_visited",
+ "type"        : "bool",
+ "description" : "Print tree nodes in the original visit order",
+ "category"    : "treeformatter",
+ "query"       :
+ [
+  { "level":     "local",
+    "let":       [ "o_a_v.slot=first(aggregate.slot)" ],
+    "aggregate": [ "min(o_a_v.slot)" ],
+    "order by":  [ "min#o_a_v.slot"  ]
+  },
+  { "level":     "cross",
+    "aggregate": [ "min(min#o_a_v.slot)" ],
+    "order by":  [ "min#min#o_a_v.slot"  ]
+  }
+ ]
+}
+]
+)json";
+
+const char* builtin_mpi_option_specs = R"json(
+[
+{
+ "name"        : "profile.mpi",
+ "type"        : "bool",
+ "description" : "Profile MPI functions",
+ "category"    : "region",
+ "services"    : [ "mpi" ],
+ "config": { "CALI_MPI_BLACKLIST": "MPI_Comm_rank,MPI_Comm_size,MPI_Wtick,MPI_Wtime" }
+},
+{
+ "name"        : "mpi.include",
+ "type"        : "string",
+ "description" : "Only instrument these MPI functions.",
+ "category"    : "region",
+ "config"      : { "CALI_MPI_WHITELIST": "{}" }
+},
+{
+ "name"        : "mpi.exclude",
+ "type"        : "string",
+ "description" : "Do not instrument these MPI functions.",
+ "category"    : "region",
+ "config"      : { "CALI_MPI_BLACKLIST": "{}" }
+},
+{
+ "name"       : "mpi.message.size",
+ "description": "MPI message size",
+ "type"       : "bool",
+ "category"   : "metric",
+ "services"   : [ "mpi" ],
+ "config"     : { "CALI_MPI_MSG_TRACING": "true", "CALI_MPI_BLACKLIST": "MPI_Wtime,MPI_Comm_rank,MPI_Comm_size" },
+ "query"      :
+ [
+  { "level"   : "local",
+    "let"     : [
+      "mpimsg.min=first(min#mpi.msg.size,mpi.msg.size)",
+      "mpimsg.avg=first(avg#mpi.msg.size,mpi.msg.size)",
+      "mpimsg.max=first(max#mpi.msg.size,mpi.msg.size)"
+    ],
+    "select"  : [
+      "min(mpimsg.min) as \"Msg size (min)\" unit Byte",
+      "avg(mpimsg.avg) as \"Msg size (avg)\" unit Byte",
+      "max(mpimsg.max) as \"Msg size (max)\" unit Byte"
+    ]
+  },
+  { "level"   : "cross",
+    "select"  : [
+      "min(min#mpimsg.min) as \"Msg size (min)\" unit Byte",
+      "avg(avg#mpimsg.avg) as \"Msg size (avg)\" unit Byte",
+      "max(max#mpimsg.max) as \"Msg size (max)\" unit Byte"
+    ]
+  }
+ ]
+},
+{
+ "name"       : "mpi.message.count",
+ "description": "Number of MPI send/recv/collective operations",
+ "type"       : "bool",
+ "category"   : "metric",
+ "services"   : [ "mpi" ],
+ "config"     : { "CALI_MPI_MSG_TRACING": "true", "CALI_MPI_BLACKLIST": "MPI_Wtime,MPI_Comm_rank,MPI_Comm_size" },
+ "query"      :
+ [
+  { "level"   : "local",
+    "let"     : [
+      "mpicount.recv=first(sum#mpi.recv.count,mpi.recv.count)",
+      "mpicount.send=first(sum#mpi.send.count,mpi.send.count)",
+      "mpicount.coll=first(sum#mpi.coll.count,mpi.coll.count)"
+    ],
+    "select"  : [
+      "sum(mpicount.send) as \"Msgs sent\"   unit count",
+      "sum(mpicount.recv) as \"Msgs recvd\"  unit count",
+      "sum(mpicount.coll) as \"Collectives\" unit count"
+    ]
+  },
+  { "level"   : "cross",
+    "select"  : [
+      "avg(sum#mpicount.send) as \"Msgs sent (avg)\"   unit count",
+      "max(sum#mpicount.send) as \"Msgs sent (max)\"   unit count",
+      "avg(sum#mpicount.recv) as \"Msgs recvd (avg)\"  unit count",
+      "max(sum#mpicount.recv) as \"Msgs recvd (max)\"  unit count",
+      "max(sum#mpicount.coll) as \"Collectives (max)\" unit count"
+    ]
+  }
+ ]
+},
+{
+ "name"        : "comm.stats",
+ "description" : "MPI message statistics in marked communication regions",
+ "type"        : "bool",
+ "category"    : "metric",
+ "services"    : [ "mpi" ],
+ "config"      : { "CALI_MPI_MSG_PATTERN": "true", "CALI_MPI_BLACKLIST": "MPI_Wtime,MPI_Comm_rank,MPI_Comm_size" },
+ "query"       :
+ [
+  { "level"    : "local",
+    "select"   :
+    [
+      "min(min#total.send.count) as \"Sends (min)\"",
+      "max(max#total.send.count) as \"Sends (max)\"",
+      "sum(sum#total.send.count) as \"Sends (total)\"",
+      "min(min#total.recv.count) as \"Recvs (min)\"",
+      "max(max#total.recv.count) as \"Recvs (max)\"",
+      "sum(sum#total.recv.count) as \"Recvs (total)\"",
+      "min(min#total.dest.ranks) as \"Dst ranks (min)\"",
+      "max(max#total.dest.ranks) as \"Dst ranks (max)\"",
+      "avg(avg#total.dest.ranks) as \"Dst ranks (avg)\"",
+      "min(min#total.src.ranks)  as \"Src ranks (min)\"",
+      "max(max#total.src.ranks)  as \"Src ranks (max)\"",
+      "avg(avg#total.src.ranks)  as \"Src ranks (avg)\"",
+      "max(max#total.coll.count) as \"Collectives (max)\"",
+      "min(min#mpi.send.size) as \"Bytes sent (min)\"",
+      "max(max#mpi.send.size) as \"Bytes sent (max)\"",
+      "sum(sum#mpi.send.size) as \"Bytes sent (total)\"",
+      "min(min#mpi.recv.size) as \"Bytes recv (min)\"",
+      "max(max#mpi.recv.size) as \"Bytes recv (max)\"",
+      "sum(sum#mpi.recv.size) as \"Bytes recv (total)\""
+    ]
+  },
+  { "level"    : "cross",
+    "select"   :
+    [
+      "min(min#min#total.send.count) as \"Sends (min)\"",
+      "max(max#max#total.send.count) as \"Sends (max)\"",
+      "sum(sum#sum#total.send.count) as \"Sends (total)\"",
+      "min(min#min#total.recv.count) as \"Recvs (min)\"",
+      "max(max#max#total.recv.count) as \"Recvs (max)\"",
+      "sum(sum#sum#total.recv.count) as \"Recvs (total)\"",
+      "min(min#min#total.dest.ranks) as \"Dst ranks (min)\"",
+      "max(max#max#total.dest.ranks) as \"Dst ranks (max)\"",
+      "avg(avg#avg#total.dest.ranks) as \"Dst ranks (avg)\"",
+      "min(min#min#total.src.ranks)  as \"Src ranks (min)\"",
+      "max(max#max#total.src.ranks)  as \"Src ranks (max)\"",
+      "avg(avg#avg#total.src.ranks)  as \"Src ranks (avg)\"",
+      "max(max#max#total.coll.count) as \"Coll (max)\"",
+      "min(min#min#mpi.send.size) as \"Bytes sent (min)\"",
+      "max(max#max#mpi.send.size) as \"Bytes sent (max)\"",
+      "sum(sum#sum#mpi.send.size) as \"Bytes sent (total)\"",
+      "min(min#min#mpi.recv.size) as \"Bytes recv (min)\"",
+      "max(max#max#mpi.recv.size) as \"Bytes recv (max)\"",
+      "sum(sum#sum#mpi.recv.size) as \"Bytes recv (total)\""
+    ]
+  }
+ ]
+}
+]
+)json";
+
+const char* builtin_gotcha_option_specs = R"json(
+[
+{
+ "name"        : "main_thread_only",
+ "type"        : "bool",
+ "description" : "Only include measurements from the main thread in results.",
+ "category"    : "region",
+ "services"    : [ "pthread" ],
+ "query"       : [ { "level": "local", "where": "pthread.is_master=true" } ]
+},{
+  "name"        : "io.bytes.written",
+  "description" : "Report I/O bytes written",
+  "type"        : "bool",
+  "category"    : "metric",
+  "services"    : [ "io" ],
+  "query"  :
+  [
+    { "level"   : "local",
+      "let"     : [ "ibw.bytes.written=first(sum#io.bytes.written,io.bytes.written)" ],
+      "select"  : [ "sum(ibw.bytes.written) as \"Bytes written\" unit Byte" ]
+    },
+    { "level"   : "cross", "select":
+      [ "avg(sum#ibw.bytes.written) as \"Avg written\" unit Byte",
+        "sum(sum#ibw.bytes.written) as \"Total written\" unit Byte"
+      ]
+    }
+  ]
+},{
+ "name"        : "io.bytes.read",
+ "description" : "Report I/O bytes read",
+ "type"        : "bool",
+ "category"    : "metric",
+ "services"    : [ "io" ],
+ "query"  :
+ [
+  { "level"   : "local",
+    "let"     : [ "ibr.bytes.read=first(sum#io.bytes.read,io.bytes.read)" ],
+    "select"  : [ "sum(ibr.bytes.read) as \"Bytes read\" unit Byte" ]
+  },
+  { "level"   : "cross", "select":
+    [ "avg(sum#ibr.bytes.read) as \"Avg read\"   unit Byte",
+      "sum(sum#ibr.bytes.read) as \"Total read\" unit Byte"
+    ]
+  }
+ ]
+},{
+ "name"        : "io.bytes",
+ "description" : "Report I/O bytes written and read",
+ "type"        : "bool",
+ "category"    : "metric",
+ "inherit"     : [ "io.bytes.read", "io.bytes.written" ]
+},{
+ "name"        : "io.read.bandwidth",
+ "description" : "Report I/O read bandwidth",
+ "type"        : "bool",
+ "category"    : "metric",
+ "services"    : [ "io" ],
+ "query"  :
+ [
+  { "level"    : "local",
+    "group by" : "io.region",
+    "let"      :
+      [
+        "irb.bytes.read=first(sum#io.bytes.read,io.bytes.read)",
+        "irb.time.ns=first(sum#time.duration.ns,time.duration.ns)"
+      ],
+    "select"   :
+      [
+      "io.region as I/O",
+      "ratio(irb.bytes.read,irb.time.ns,8e3) as \"Read Mbit/s\" unit Mb/s"
+      ]
+  },
+  { "level": "cross", "select":
+    [
+    "avg(ratio#irb.bytes_read/irb.time.ns) as \"Avg read Mbit/s\" unit Mb/s",
+    "max(ratio#irb.bytes_read/irb.time.ns) as \"Max read Mbit/s\" unit Mb/s"
+    ]
+  }
+ ]
+},{
+ "name"        : "io.write.bandwidth",
+ "description" : "Report I/O write bandwidth",
+ "type"        : "bool",
+ "category"    : "metric",
+ "services"    : [ "io" ],
+ "query"  :
+ [
+  { "level"    : "local",
+    "group by" : "io.region",
+    "let"      :
+    [
+     "iwb.bytes.written=first(sum#io.bytes.written,io.bytes.written)",
+     "iwb.time.ns=first(sum#time.duration.ns,time.duration.ns)"
+    ],
+    "select"   :
+    [
+     "io.region as I/O",
+     "ratio(iwb.bytes.written,iwb.time.ns,8e3) as \"Write Mbit/s\" unit Mb/s"
+    ]
+  },
+  { "level": "cross", "select":
+    [
+     "avg(ratio#iwb.bytes.written/iwb.time) as \"Avg write Mbit/s\" unit Mb/s",
+     "max(ratio#iwb.bytes.written/iwb.time) as \"Max write Mbit/s\" unit Mb/s"
+    ]
+  }
+ ]
+},{
+ "name"        : "mem.highwatermark",
+ "description" : "Report memory high-water mark",
+ "type"        : "bool",
+ "category"    : "metric",
+ "services"    : [ "alloc", "sysalloc" ],
+ "config"      : { "CALI_ALLOC_TRACK_ALLOCATIONS": "false", "CALI_ALLOC_RECORD_HIGHWATERMARK": "true" },
+ "query":
+ [
+  { "level"  : "local",
+    "let"    :
+    [ "mem.highwatermark.bytes = first(max#alloc.region.highwatermark,alloc.region.highwatermark)",
+      "mem.highwatermark = scale(mem.highwatermark.bytes,1e-6)"
+    ],
+    "select" : [ "max(mem.highwatermark) as \"Allocated MB\" unit MB" ]
+  },
+  { "level": "cross", "select": [ "max(max#mem.highwatermark) as \"Allocated MB\" unit MB" ] }
+ ]
+},{
+ "name"        : "mem.pages",
+ "description" : "Memory pages used via /proc/self/statm",
+ "type"        : "bool",
+ "category"    : "metric",
+ "services"    : [ "memstat" ],
+ "query"  :
+ [
+  { "level"   : "local",
+    "let"     :
+    [ "mem.vmsize = first(max#memstat.vmsize,memstat.vmsize)",
+      "mem.vmrss = first(max#memstat.vmrss,memstat.vmrss)",
+      "mem.data = first(max#memstat.data,memstat.data)"
+    ],
+    "select"  :
+    [
+     "max(mem.vmsize) as VmSize unit pages",
+     "max(mem.vmrss) as VmRSS unit pages",
+     "max(mem.data) as Data unit pages"
+    ]
+  },
+  { "level"   : "cross",
+    "select"  :
+    [
+     "max(max#mem.vmsize) as \"VmSize (max)\" unit pages",
+     "max(max#mem.vmrss) as \"VmRSS (max)\" unit pages",
+     "max(max#mem.data) as \"Data (max)\" unit pages"
+    ]
+  }
+ ]
+}
+]
+)json";
+
+const char* builtin_cuda_option_specs = R"json(
+[
+{
+  "name"        : "profile.cuda",
+  "type"        : "bool",
+  "description" : "Profile CUDA API functions",
+  "category"    : "region",
+  "services"    : [ "cupti" ]
+},
+{
+  "name"        : "cuda.memcpy",
+  "description" : "Report MB copied between host and device with cudaMemcpy",
+  "type"        : "bool",
+  "category"    : "cuptitrace.metric",
+  "query"  :
+  [
+    { "level"   : "local",
+      "let"     :
+      [
+      "cuda.memcpy.dtoh=scale(cupti.memcpy.bytes,1e-6) if cupti.memcpy.kind=DtoH",
+      "cuda.memcpy.htod=scale(cupti.memcpy.bytes,1e-6) if cupti.memcpy.kind=HtoD"
+      ],
+      "select"  :
+      [
+      "sum(cuda.memcpy.htod) as \"Copy CPU->GPU\" unit MB",
+      "sum(cuda.memcpy.dtoh) as \"Copy GPU->CPU\" unit MB"
+      ]
+    },
+    { "level"   : "cross", "select":
+      [
+        "avg(sum#cuda.memcpy.htod) as \"Copy CPU->GPU (avg)\" unit MB",
+        "max(sum#cuda.memcpy.htod) as \"Copy CPU->GPU (max)\" unit MB",
+        "avg(sum#cuda.memcpy.dtoh) as \"Copy GPU->CPU (avg)\" unit MB",
+        "max(sum#cuda.memcpy.dtoh) as \"Copy GPU->CPU (max)\" unit MB"
+      ]
+    }
+  ]
+},
+{
+  "name"        : "cuda.gputime",
+  "description" : "Report GPU time in CUDA activities",
+  "type"        : "bool",
+  "category"    : "metric",
+  "services"    : [ "cuptitrace" ],
+  "query"  :
+  [
+    { "level"   : "local",
+      "select"  :
+      [
+      "inclusive_scale(cupti.activity.duration,1e-9) as \"GPU time (I)\" unit sec",
+      ]
+    },
+    { "level"   : "cross", "select":
+      [
+        "avg(iscale#cupti.activity.duration) as \"Avg GPU time/rank\" unit sec",
+        "min(iscale#cupti.activity.duration) as \"Min GPU time/rank\" unit sec",
+        "max(iscale#cupti.activity.duration) as \"Max GPU time/rank\" unit sec",
+        "sum(iscale#cupti.activity.duration) as \"Total GPU time\" unit sec"
+      ]
+    }
+  ]
+}
+]
+)json";
+
+const char* builtin_rocm_option_specs = R"json(
+[
+{
+ "name"        : "profile.hip",
+ "type"        : "bool",
+ "description" : "Profile HIP API functions",
+ "category"    : "region",
+ "services"    : [ "roctracer" ],
+ "config"      : { "CALI_ROCTRACER_TRACE_ACTIVITIES": "false" }
+},
+{
+ "name"        : "rocm.gputime",
+ "description" : "Report GPU time in AMD ROCm activities",
+ "type"        : "bool",
+ "category"    : "metric",
+ "services"    : [ "roctracer" ],
+ "config"      : { "CALI_ROCTRACER_TRACE_ACTIVITIES": "true", "CALI_ROCTRACER_RECORD_KERNEL_NAMES": "false" },
+ "query"  :
+ [
+  { "level"   : "local",
+    "select"  : [ "inclusive_scale(sum#rocm.activity.duration,1e-9) as \"GPU time (I)\" unit sec" ]
+  },
+  { "level"   : "cross",
+    "select"  :
+    [
+     "avg(iscale#sum#rocm.activity.duration) as \"Avg GPU time/rank\" unit sec",
+     "min(iscale#sum#rocm.activity.duration) as \"Min GPU time/rank\" unit sec",
+     "max(iscale#sum#rocm.activity.duration) as \"Max GPU time/rank\" unit sec",
+     "sum(iscale#sum#rocm.activity.duration) as \"Total GPU time\" unit sec"
+    ]
+  }
+ ]
+}
+]
+)json";
+
+const char* builtin_openmp_option_specs = R"json(
+[
+{
+ "name"        : "openmp.times",
+ "description" : "Report time spent in OpenMP work and barrier regions",
+ "type"        : "bool",
+ "category"    : "metric",
+ "services"    : [ "ompt", "timestamp" ],
+ "query"  :
+ [
+  { "level"   : "local",
+    "let"     :
+    [
+     "t.omp.ns=first(sum#time.duration.ns,time.duration.ns)",
+     "t.omp.work=scale(t.omp.ns,1e-9) if omp.work",
+     "t.omp.sync=scale(t.omp.ns,1e-9) if omp.sync",
+     "t.omp.total=first(t.omp.work,t.omp.sync)"
+     ],
+     "select"  :
+     [ "sum(t.omp.work) as \"Time (work)\"    unit sec",
+       "sum(t.omp.sync) as \"Time (barrier)\" unit sec"
+     ]
+   },
+   { "level"   : "cross", "select":
+     [ "avg(sum#t.omp.work) as \"Time (work) (avg)\" unit sec",
+       "avg(sum#t.omp.sync) as \"Time (barrier) (avg)\" unit sec",
+       "sum(sum#t.omp.work) as \"Time (work) (total)\" unit sec",
+       "sum(sum#t.omp.sync) as \"Time (barrier) (total)\" unit sec"
+     ]
+   }
+ ]
+},
+{
+ "name"        : "openmp.efficiency",
+ "description" : "Compute OpenMP efficiency metrics",
+ "type"        : "bool",
+ "category"    : "metric",
+ "inherit"     : [ "openmp.times" ],
+ "query"  :
+ [
+  { "level"   : "local",
+    "select"  :
+    [ "inclusive_ratio(t.omp.work,t.omp.total,100.0) as \"Work %\"    unit percent",
+      "inclusive_ratio(t.omp.sync,t.omp.total,100.0) as \"Barrier %\" unit percent"
+    ]
+  },
+  { "level"   : "cross", "select":
+    [ "min(iratio#t.omp.work/t.omp.total) as \"Work % (min)\" unit percent",
+      "avg(iratio#t.omp.work/t.omp.total) as \"Work % (avg)\" unit percent",
+      "avg(iratio#t.omp.sync/t.omp.total) as \"Barrier % (avg)\" unit percent",
+      "max(iratio#t.omp.sync/t.omp.total) as \"Barrier % (max)\" unit percent"
+    ]
+  }
+ ]
+},
+{
+ "name"        : "openmp.threads",
+ "description" : "Show OpenMP threads",
+ "type"        : "bool",
+ "category"    : "metric",
+ "services"    : [ "ompt" ],
+ "query"  :
+ [
+  { "level"   : "local",
+    "let"     : [ "n.omp.threads=first(omp.num.threads)" ],
+    "group by": "omp.thread.id,omp.thread.type",
+    "select"  :
+    [ "max(n.omp.threads) as \"#Threads\"",
+      "omp.thread.id as \"Thread\""
+    ]
+  },
+  { "level"   : "cross",
+    "group by": "omp.thread.id,omp.thread.type",
+    "select"  :
+    [ "max(max#n.omp.threads) as \"#Threads\"",
+      "omp.thread.id as Thread"
+    ]
+  }
+ ]
+}
+]
+)json";
+
+const char* builtin_libdw_option_specs = R"json(
+[
+{
+ "name"        : "source.module",
+ "type"        : "bool",
+ "category"    : "sampling",
+ "description" : "Report source module (.so/.exe)",
+ "services"    : [ "symbollookup" ],
+ "config"      : { "CALI_SYMBOLLOOKUP_LOOKUP_MODULE": "true" },
+ "query":
+ [
+  { "level": "local", "group by": "module#cali.sampler.pc",
+    "select": [ "module#cali.sampler.pc as \"Module\"" ]
+  },
+  { "level": "cross", "group by": "module#cali.sampler.pc",
+    "select": [ "module#cali.sampler.pc as \"Module\"" ]
+  }
+ ]
+},
+{
+ "name"        : "source.function",
+ "type"        : "bool",
+ "category"    : "sampling",
+ "description" : "Report source function symbol names",
+ "services"    : [ "symbollookup" ],
+ "config"      : { "CALI_SYMBOLLOOKUP_LOOKUP_FUNCTION": "true" },
+ "query":
+ [
+  { "level": "local", "group by": "source.function#cali.sampler.pc",
+    "select": [ "source.function#cali.sampler.pc as \"Function\"" ]
+  },
+  { "level": "cross", "group by": "source.function#cali.sampler.pc",
+    "select": [ "source.function#cali.sampler.pc as \"Function\"" ]
+  }
+ ]
+},
+{
+ "name"        : "source.location",
+ "type"        : "bool",
+ "category"    : "sampling",
+ "description" : "Report source location (file+line)",
+ "services"    : [ "symbollookup" ],
+ "config"      : { "CALI_SYMBOLLOOKUP_LOOKUP_SOURCELOC": "true" },
+ "query":
+ [
+  { "level": "local", "group by": "sourceloc#cali.sampler.pc",
+    "select": [ "sourceloc#cali.sampler.pc as \"Source\"" ]
+  },
+  { "level": "cross", "group by": "sourceloc#cali.sampler.pc",
+    "select": [ "sourceloc#cali.sampler.pc as \"Source\"" ]
+  }
+ ]
+}
+]
+)json";
+
+const char* builtin_umpire_option_specs = R"json(
+[
+{
+ "name"        : "umpire.totals",
+ "description" : "Report umpire allocation statistics (all allocators combined)",
+ "type"        : "bool",
+ "category"    : "metric",
+ "services"    : [ "umpire" ],
+ "config"      : { "CALI_UMPIRE_PER_ALLOCATOR_STATISTICS": "false" },
+ "query"  :
+ [
+  { "level"   : "local",
+    "let"     :
+    [ "umpt.size.bytes=first(max#umpire.total.size,umpire.total.size)",
+      "umpt.count=first(max#umpire.total.count,umpire.total.count)",
+      "umpt.hwm.bytes=first(max#umpire.total.hwm,umpire.total.hwm)",
+      "umpt.size=scale(umpt.size.bytes,1e-6)",
+      "umpt.hwm=scale(umpt.hwm.bytes,1e-6)"
+    ],
+    "select"  :
+    [ "inclusive_max(umpt.size)  as \"Ump MB (Total)\" unit MB",
+      "inclusive_max(umpt.count) as \"Ump allocs (Total)\"",
+      "inclusive_max(umpt.hwm)   as \"Ump HWM (Total)\""
+    ]
+  },
+  { "level"   : "cross",
+    "select"  :
+    [ "avg(imax#umpt.size)  as \"Ump MB (avg)\" unit MB",
+      "max(imax#umpt.size)  as \"Ump MB (max)\" unit MB",
+      "avg(imax#umpt.count) as \"Ump allocs (avg)\"",
+      "max(imax#umpt.count) as \"Ump allocs (max)\"",
+      "max(imax#umpt.hwm)   as \"Ump HWM (max)\""
+    ]
+  }
+ ]
+},
+{
+ "name"        : "umpire.allocators",
+ "description" : "Report umpire allocation statistics per allocator",
+ "type"        : "bool",
+ "category"    : "metric",
+ "services"    : [ "umpire" ],
+ "config"      : { "CALI_UMPIRE_PER_ALLOCATOR_STATISTICS": "true" },
+ "query"  :
+ [
+  { "level"   : "local",
+    "let"     :
+    [ "ump.size.bytes=first(max#umpire.alloc.current.size,umpire.alloc.current.size)",
+      "ump.hwm.bytes=first(max#umpire.alloc.highwatermark,umpire.alloc.highwatermark)",
+      "ump.count=first(max#umpire.alloc.count,umpire.alloc.count)",
+      "ump.size=scale(ump.size.bytes,1e-6)",
+      "ump.hwm=scale(ump.hwm.bytes,1e-6)"
+     ],
+    "select"  :
+    [ "umpire.alloc.name as Allocator",
+      "inclusive_max(ump.size)  as \"Alloc MB\"  unit MB",
+      "inclusive_max(ump.hwm)   as \"Alloc HWM\" unit MB",
+      "inclusive_max(ump.count) as \"Num allocs\""
+    ],
+    "group by": "umpire.alloc.name"
+  },
+  { "level"   : "cross",
+    "select"  :
+    [ "umpire.alloc.name   as Allocator",
+      "avg(imax#ump.size)  as \"Alloc MB (avg)\"  unit MB",
+      "max(imax#ump.size)  as \"Alloc MB (max)\"  unit MB",
+      "avg(imax#ump.hwm)   as \"Alloc HWM (avg)\" unit MB",
+      "max(imax#ump.hwm)   as \"Alloc HWM (max)\" unit MB",
+      "avg(imax#ump.count) as \"Num allocs (avg)\"",
+      "max(imax#ump.count) as \"Num allocs (max)\""
+    ],
+    "group by": "umpire.alloc.name"
+  }
+ ]
+},
+{
+ "name"        : "umpire.filter",
+ "description" : "Names of Umpire allocators to track",
+ "type"        : "string",
+ "category"    : "metric",
+ "config"      : { "CALI_UMPIRE_ALLOCATOR_FILTER": "{}" }
+}
+]
+)json";
+
+const char* builtin_pcp_option_specs = R"json(
+[
+{
+  "name"        : "mem.read.bandwidth",
+  "description" : "Record memory read bandwidth using the Performance Co-pilot API",
+  "type"        : "bool",
+  "category"    : "metric",
+  "services"    : [ "pcp.memory" ],
+  "query"  :
+  [
+    { "level"   : "local",
+      "let"     : [ "mrb.time=first(pcp.time.duration,sum#pcp.time.duration)" ],
+      "select"  : [ "ratio(mem.bytes.read,mrb.time,1e-6) as \"MB/s (r)\" unit MB/s" ]
+    },
+    { "level"   : "cross", "select":
+    [
+      "avg(ratio#mem.bytes.read/mrb.time) as \"Avg MemBW (r) (MB/s)\"   unit MB/s",
+      "max(ratio#mem.bytes.read/mrb.time) as \"Max MemBW (r) (MB/s)\"   unit MB/s",
+      "sum(ratio#mem.bytes.read/mrb.time) as \"Total MemBW (r) (MB/s)\" unit MB/s"
+    ]
+    }
+  ]
+},
+{
+  "name"        : "mem.write.bandwidth",
+  "description" : "Record memory write bandwidth using the Performance Co-pilot API",
+  "type"        : "bool",
+  "category"    : "metric",
+  "services"    : [ "pcp.memory" ],
+  "query"  :
+  [
+    { "level"   : "local",
+      "let"     : [ "mwb.time=first(pcp.time.duration,sum#pcp.time.duration)" ],
+      "select"  : [ "ratio(mem.bytes.written,mwb.time,1e-6) as \"MB/s (w)\" unit MB/s" ]
+    },
+    { "level"   : "cross", "select":
+    [
+      "avg(ratio#mem.bytes.written/mwb.time) as \"Avg MemBW (w) (MB/s)\"   unit MB/s",
+      "max(ratio#mem.bytes.written/mwb.time) as \"Max MemBW (w) (MB/s)\"   unit MB/s",
+      "sum(ratio#mem.bytes.written/mwb.time) as \"Total MemBW (w) (MB/s)\" unit MB/s",
+    ]
+    }
+  ]
+},
+{
+  "name"        : "mem.bandwidth",
+  "description" : "Record memory bandwidth using the Performance Co-pilot API",
+  "type"        : "bool",
+  "category"    : "metric",
+  "inherit"     : [ "mem.read.bandwidth", "mem.write.bandwidth" ],
+}
+]
+)json";
+
+const char* builtin_papi_option_specs = R"json(
+[
+{
+ "name"        : "topdown.toplevel",
+ "description" : "Top-down analysis for Intel CPUs (top level)",
+ "type"        : "bool",
+ "category"    : "metric",
+ "services"    : [ "topdown" ],
+ "config"      : { "CALI_TOPDOWN_LEVEL": "top" },
+ "query"  :
+ [
+  { "level": "local", "select":
+   [
+    "any(topdown.retiring) as \"Retiring\"",
+    "any(topdown.backend_bound) as \"Backend bound\"",
+    "any(topdown.frontend_bound) as \"Frontend bound\"",
+    "any(topdown.bad_speculation) as \"Bad speculation\""
+   ]
+  },
+  { "level": "cross", "select":
+   [
+    "any(any#topdown.retiring) as \"Retiring\"",
+    "any(any#topdown.backend_bound) as \"Backend bound\"",
+    "any(any#topdown.frontend_bound) as \"Frontend bound\"",
+    "any(any#topdown.bad_speculation) as \"Bad speculation\""
+   ]
+  }
+ ]
+},
+{
+ "name"        : "topdown.all",
+ "description" : "Top-down analysis for Intel CPUs (all levels)",
+ "type"        : "bool",
+ "category"    : "metric",
+ "services"    : [ "topdown" ],
+ "config"      : { "CALI_TOPDOWN_LEVEL": "all" },
+ "query"  :
+ [
+  { "level": "local", "select":
+   [
+    "any(topdown.retiring) as \"Retiring\"",
+    "any(topdown.backend_bound) as \"Backend bound\"",
+    "any(topdown.frontend_bound) as \"Frontend bound\"",
+    "any(topdown.bad_speculation) as \"Bad speculation\"",
+    "any(topdown.branch_mispredict) as \"Branch mispredict\"",
+    "any(topdown.machine_clears) as \"Machine clears\"",
+    "any(topdown.frontend_latency) as \"Frontend latency\"",
+    "any(topdown.frontend_bandwidth) as \"Frontend bandwidth\"",
+    "any(topdown.memory_bound) as \"Memory bound\"",
+    "any(topdown.core_bound) as \"Core bound\"",
+    "any(topdown.ext_mem_bound) as \"External Memory\"",
+    "any(topdown.l1_bound) as \"L1 bound\"",
+    "any(topdown.l2_bound) as \"L2 bound\"",
+    "any(topdown.l3_bound) as \"L3 bound\""
+   ]
+  },
+  { "level": "cross", "select":
+   [
+    "any(any#topdown.retiring) as \"Retiring\"",
+    "any(any#topdown.backend_bound) as \"Backend bound\"",
+    "any(any#topdown.frontend_bound) as \"Frontend bound\"",
+    "any(any#topdown.bad_speculation) as \"Bad speculation\"",
+    "any(any#topdown.branch_mispredict) as \"Branch mispredict\"",
+    "any(any#topdown.machine_clears) as \"Machine clears\"",
+    "any(any#topdown.frontend_latency) as \"Frontend latency\"",
+    "any(any#topdown.frontend_bandwidth) as \"Frontend bandwidth\"",
+    "any(any#topdown.memory_bound) as \"Memory bound\"",
+    "any(any#topdown.core_bound) as \"Core bound\"",
+    "any(any#topdown.ext_mem_bound) as \"External Memory\"",
+    "any(any#topdown.l1_bound) as \"L1 bound\"",
+    "any(any#topdown.l2_bound) as \"L2 bound\"",
+    "any(any#topdown.l3_bound) as \"L3 bound\""
+   ]
+  }
+ ]
+}
+]
+)json";
+
+const char* builtin_kokkos_option_specs = R"json(
+[
+{
+ "name"        : "profile.kokkos",
+ "type"        : "bool",
+ "description" : "Profile Kokkos functions",
+ "category"    : "region",
+ "services"    : [ "kokkostime" ]
+}
+]
 )json";
 
 } // namespace cali

--- a/src/services/adiak/AdiakImport.cpp
+++ b/src/services/adiak/AdiakImport.cpp
@@ -278,16 +278,18 @@ void nameval_cb(
 }
 
 const char* spec = R"json(
-    {   "name"        : "adiak_import",
-        "description" : "Import program run metadata from Adiak",
-        "config"      : [
-            { "name"        : "categories",
-              "type"        : "string",
-              "description" : "List of Adiak categories to import",
-              "value"       : "2,3"
-            }
-        ]
-    }
+{
+"name"        : "adiak_import",
+"description" : "Import program run metadata from Adiak",
+"config"      :
+[
+{
+ "name": "categories",
+ "type": "string",
+ "description": "List of Adiak categories to import",
+ "value": "2,3"
+}
+]}
 )json";
 
 void register_adiak_import(Caliper* c, Channel* channel)

--- a/src/services/aggregate/Aggregate.cpp
+++ b/src/services/aggregate/Aggregate.cpp
@@ -421,14 +421,17 @@ public:
 }; // class Aggregate
 
 const char* Aggregate::s_spec = R"json(
-{   "name"        : "aggregate",
-    "description" : "Aggregate snapshots at runtime",
-    "config" : [
-      { "name"        : "key",
-        "description" : "Attributes in the aggregation key (i.e., group by)",
-        "type"        : "string"
-      }
-    ]
+{
+ "name"        : "aggregate",
+ "description" : "Aggregate snapshots at runtime",
+ "config" :
+ [
+  {
+   "name"        : "key",
+   "description" : "Attributes in the aggregation key (i.e., group by)",
+   "type"        : "string"
+  }
+ ]
 }
 )json";
 

--- a/src/services/alloc/AllocService.cpp
+++ b/src/services/alloc/AllocService.cpp
@@ -504,30 +504,33 @@ public:
 };
 
 const char* AllocService::s_spec = R"json(
-{   "name" : "alloc",
-    "description" : "Track user-defined memory allocations",
-    "config" : [
-        {   "name"        : "resolve_addresses",
-            "type"        : "bool",
-            "description" : "Resolve memory addresses in snapshots",
-            "value"       : "false"
-        },
-        {   "name"        : "track_allocations",
-            "type"        : "bool",
-            "description" : "Record snapshots for annotated memory regions",
-            "value"       : "true"
-        },
-        {   "name"        : "record_active_mem",
-            "type"        : "bool",
-            "description" : "Record the active allocated memory at each snapshot",
-            "value"       : "false"
-        },
-        {   "name"        : "record_highwatermark",
-            "type"        : "bool",
-            "description" : "Record the high water mark of allocated memory at each snapshot",
-            "value"       : "false"
-        }
-    ]
+{
+ "name" : "alloc",
+ "description" : "Track user-defined memory allocations",
+ "config" :
+ [
+  {
+   "name"        : "resolve_addresses",
+   "type"        : "bool",
+   "description" : "Resolve memory addresses in snapshots",
+   "value"       : "false"
+  },{
+   "name"        : "track_allocations",
+   "type"        : "bool",
+   "description" : "Record snapshots for annotated memory regions",
+   "value"       : "true"
+  },{
+   "name"        : "record_active_mem",
+   "type"        : "bool",
+   "description" : "Record the active allocated memory at each snapshot",
+   "value"       : "false"
+  },{
+   "name"        : "record_highwatermark",
+   "type"        : "bool",
+   "description" : "Record the high water mark of allocated memory at each snapshot",
+   "value"       : "false"
+  }
+ ]
 }
 )json";
 

--- a/src/services/callpath/Callpath.cpp
+++ b/src/services/callpath/Callpath.cpp
@@ -237,30 +237,33 @@ public:
 }; // class Callpath
 
 const char* Callpath::s_spec = R"json(
-{   "name"        : "callpath",
-    "description" : "Record call stack at each snapshot",
-    "config"      : [
-        { "name"        : "use_name",
-          "type"        : "bool",
-          "description" : "Record function names",
-          "value"       : "false"
-        },
-        { "name"        : "use_address",
-          "type"        : "bool",
-          "description" : "Record function addresses",
-          "value"       : "true"
-        },
-        { "name"        : "skip_frames",
-          "type"        : "uint",
-          "description" : "Skip this number of stack frames",
-          "value"       : "0"
-        },
-        { "name"        : "skip_internal",
-          "type"        : "bool",
-          "description" : "Skip internal (inside Caliper library) stack frames",
-          "value"       : "true"
-        }
-    ]
+{
+ "name"        : "callpath",
+ "description" : "Record call stack at each snapshot",
+ "config"      :
+ [
+  {
+   "name": "use_name",
+   "type": "bool",
+   "description": "Record function names",
+   "value": "false"
+  },{
+   "name": "use_address",
+   "type": "bool",
+   "description": "Record function addresses",
+   "value": "true"
+  },{
+   "name": "skip_frames",
+   "type": "uint",
+   "description": "Skip this number of stack frames",
+   "value": "0"
+  },{
+   "name": "skip_internal",
+   "type": "bool",
+   "description": "Skip internal (inside Caliper library) stack frames",
+   "value": "true"
+  }
+ ]
 }
 )json";
 

--- a/src/services/event/EventTrigger.cpp
+++ b/src/services/event/EventTrigger.cpp
@@ -368,38 +368,40 @@ public:
 };
 
 const char* EventTrigger::s_spec = R"json(
-    {   "name"        : "event",
-        "description" : "Trigger snapshots for Caliper region begin and end events",
-        "config"      :
-        [
-            { "name"        : "trigger",
-              "type"        : "stringlist",
-              "description" : "List of attributes that trigger measurements (optional)"
-            },
-            { "name"        : "region_level",
-              "type"        : "string",
-              "description" : "Minimum region level that triggers snapshots",
-              "value"       : "0"
-            },
-            { "name"        : "enable_snapshot_info",
-              "type"        : "bool",
-              "description" : "If true, add begin/end attributes at each event. Increases overhead.",
-              "value"       : "True"
-            },
-            { "name"        : "include_regions",
-              "type"        : "string",
-              "description" : "Region filter to specify regions that will trigger snapshots"
-            },
-            { "name"        : "exclude_regions",
-              "type"        : "string",
-              "description" : "Region filter to specify regions that won't trigger snapshots"
-            },
-            { "name"        : "include_branches",
-              "type"        : "string",
-              "description" : "Region filter to specify a branch"
-            }
-        ]
-    }
+{
+ "name"        : "event",
+ "description" : "Trigger snapshots for Caliper region begin and end events",
+ "config"      :
+ [
+  {
+   "name": "trigger",
+   "type": "stringlist",
+   "description": "List of attributes that trigger measurements (optional)"
+  },{
+   "name": "region_level",
+   "type": "string",
+   "description": "Minimum region level that triggers snapshots",
+   "value": "0"
+  },{
+   "name": "enable_snapshot_info",
+   "type": "bool",
+   "description": "If true, add begin/end attributes at each event. Increases overhead.",
+   "value": "True"
+  },{
+   "name": "include_regions",
+   "type": "string",
+   "description": "Region filter to specify regions that will trigger snapshots"
+  },{
+   "name": "exclude_regions",
+   "type": "string",
+   "description": "Region filter to specify regions that won't trigger snapshots"
+  },{
+   "name": "include_branches",
+   "type": "string",
+   "description": "Region filter to specify a branch"
+  }
+ ]
+}
 )json";
 
 } // namespace

--- a/src/services/monitor/LoopMonitor.cpp
+++ b/src/services/monitor/LoopMonitor.cpp
@@ -170,25 +170,27 @@ public:
 };
 
 const char* LoopMonitor::s_spec = R"json(
-{   "name"        : "loop_monitor",
-    "description" : "Trigger snapshots on loop iterations",
-    "config"      : [
-        {   "name"        : "iteration_interval",
-            "description" : "Trigger snapshots every N iterations",
-            "type"        : "int",
-            "value"       : "0"
-        },
-        {   "name"        : "time_interval",
-            "description" : "Trigger snapshots every t seconds",
-            "type"        : "double",
-            "value"       : "0.0"
-        },
-        {   "name"        : "target_loops",
-            "description" : "List of loops to instrument",
-            "type"        : "string"
-        }
-    ]
-}
+{
+"name"        : "loop_monitor",
+"description" : "Trigger snapshots on loop iterations",
+"config"      :
+[
+ {
+  "name": "iteration_interval",
+  "type": "int",
+  "description": "Trigger snapshots every N iterations",
+  "value": "0"
+ },{
+  "name": "time_interval",
+  "description": "Trigger snapshots every t seconds",
+  "type": "double",
+  "value": "0.0"
+ },{
+  "name": "target_loops",
+  "description": "List of loops to instrument",
+  "type": "string"
+ }
+]}
 )json";
 
 } // namespace

--- a/src/services/mpireport/MpiReport.cpp
+++ b/src/services/mpireport/MpiReport.cpp
@@ -139,34 +139,36 @@ public:
 };
 
 const char* MpiReport::s_spec = R"json(
-{   "name": "mpireport",
-    "description": "Aggregate data across MPI ranks and write output using CalQL query",
-    "config": [
-        {   "name": "filename",
-            "description": "File name for report stream",
-            "type": "string",
-            "value": "stdout"
-        },
-        {   "name": "append",
-            "description": "Append to file instead of overwriting",
-            "type": "bool",
-            "value": "false"
-        },
-        {   "name": "config",
-            "description": "CalQL query for cross-process aggregation and formatting",
-            "type": "string"
-        },
-        {   "name": "local_config",
-            "description": "CalQL query for process-local aggregation step",
-            "type": "string"
-        },
-        {   "name": "write_on_finalize",
-            "description": "Write output at MPI_Finalize",
-            "type": "bool",
-            "value": "true"
-        }
-    ]
-}
+{
+"name": "mpireport",
+"description": "Aggregate data across MPI ranks and write output using CalQL query",
+"config":
+[
+ {
+  "name": "filename",
+  "description": "File name for report stream",
+  "type": "string",
+  "value": "stdout"
+ },{
+  "name": "append",
+  "description": "Append to file instead of overwriting",
+  "type": "bool",
+  "value": "false"
+ },{
+  "name": "config",
+  "description": "CalQL query for cross-process aggregation and formatting",
+  "type": "string"
+ },{
+  "name": "local_config",
+  "description": "CalQL query for process-local aggregation step",
+  "type": "string"
+ },{
+  "name": "write_on_finalize",
+  "description": "Write output at MPI_Finalize",
+  "type": "bool",
+  "value": "true"
+ }
+]}
 )json";
 
 } // namespace

--- a/src/services/papi/Papi.cpp
+++ b/src/services/papi/Papi.cpp
@@ -481,21 +481,22 @@ public:
 int PapiService::s_num_instances = 0;
 
 const char* PapiService::s_spec = R"json(
-{   "name": "papi",
-    "description": "Record PAPI counters",
-    "config": [
-        {   "name": "counters",
-            "description": "List of PAPI events to record",
-            "type": "string"
-        },
-        {
-            "name": "enable_multiplexing",
-            "description": "Always enable multiplexing",
-            "type": "bool",
-            "value": "False"
-        }
-    ]
-}
+{
+"name": "papi",
+"description": "Record PAPI counters",
+"config":
+[
+ {
+  "name": "counters",
+  "description": "List of PAPI events to record",
+  "type": "string"
+ },{
+  "name": "enable_multiplexing",
+  "description": "Always enable multiplexing",
+  "type": "bool",
+  "value": "False"
+ }
+]}
 )json";
 
 } // namespace

--- a/src/services/recorder/Recorder.cpp
+++ b/src/services/recorder/Recorder.cpp
@@ -30,19 +30,21 @@ namespace
 {
 
 const char* spec = R"json(
-    {   "name"        : "recorder",
-        "description" : "Write records into .cali file",
-        "config"      : [
-            { "name"        : "filename",
-              "type"        : "string",
-              "description" : "Stream or file name. If empty, auto-generate file."
-            },
-            { "name"        : "directory",
-              "type"        : "string",
-              "description" : "Directory to write .cali files to."
-            }
-        ]
-    }
+{
+"name"        : "recorder",
+"description" : "Write records into .cali file",
+"config"      :
+[
+ {
+  "name": "filename",
+  "type": "string",
+  "description": "Stream or file name. If empty, auto-generate file."
+ },{
+  "name": "directory",
+  "type": "string",
+  "description": "Directory to write .cali files to."
+ }
+]}
 )json";
 
 void write_output_cb(Caliper* c, Channel* chn, SnapshotView flush_info)

--- a/src/services/report/Report.cpp
+++ b/src/services/report/Report.cpp
@@ -99,25 +99,27 @@ public:
 };
 
 const char* Report::s_spec = R"json(
-{   "name": "report",
-    "description": "Write output using CalQL query",
-    "config": [
-        {   "name": "filename",
-            "description": "File name for report stream",
-            "type": "string",
-            "value": "stdout"
-        },
-        {   "name": "append",
-            "description": "Append to file instead of overwriting",
-            "type": "bool",
-            "value": "false"
-        },
-        {   "name": "config",
-            "description": "CalQL query to generate report",
-            "type": "string"
-        }
-    ]
-}
+{
+"name"        : "report",
+"description" : "Write output using CalQL query",
+"config"      :
+[
+ {
+  "name": "filename",
+  "type": "string",
+  "description": "File name for report stream",
+  "value": "stdout"
+ },{
+  "name": "append",
+  "type": "bool",
+  "description": "Append to file instead of overwriting",
+  "value": "false"
+ },{
+  "name": "config",
+  "type": "string"
+  "description": "CalQL query to generate report",
+ }
+]}
 )json";
 
 } // namespace

--- a/src/services/sampler/Sampler.cpp
+++ b/src/services/sampler/Sampler.cpp
@@ -51,16 +51,18 @@ int n_processed_samples = 0;
 Channel channel;
 
 const char* spec = R"json(
-{   "name": "sampler",
-    "description": "Trigger snapshots via sampling timer",
-    "config": [
-        { "name": "frequency",
-          "description": "Sampling frequency in Hz",
-          "type": "int",
-          "value": "50"
-        }
-    ]
-}
+{
+"name": "sampler",
+"description": "Trigger snapshots via sampling timer",
+"config":
+[
+ {
+  "name": "frequency",
+  "description": "Sampling frequency in Hz",
+  "type": "int",
+  "value": "50"
+ }
+]}
 )json";
 
 void on_prof(int sig, siginfo_t* info, void* context)

--- a/src/services/symbollookup/SymbolLookup.cpp
+++ b/src/services/symbollookup/SymbolLookup.cpp
@@ -299,40 +299,41 @@ public:
 
 const char* SymbolLookup::s_spec = R"json(
 {
-    "name": "symbollookup",
-    "description": "Perform symbol name lookup for source code address attributes",
-    "config": [
-        {   "name": "attributes",
-            "description": "List of address attributes for which to perform symbol lookup",
-            "type": "string"
-        },
-        {   "name": "lookup_functions",
-            "description": "Perform function name lookup",
-            "type": "bool",
-            "value": "true"
-        },
-        {   "name": "lookup_sourceloc",
-            "description": "Perform source location lookup (source file name + line number)",
-            "type": "bool",
-            "value": "true"
-        },
-        {   "name": "lookup_file",
-            "description": "Perform source file name lookup",
-            "type": "bool",
-            "value": "false"
-        },
-        {   "name": "lookup_line",
-            "description": "Perform source line lookup",
-            "type": "bool",
-            "value": "false"
-        },
-        {   "name": "lookup_module",
-            "description": "Perform module lookup",
-            "type": "bool",
-            "value": "true"
-        }
-    ]
-}
+"name"        : "symbollookup",
+"description" : "Perform symbol name lookup for source code address attributes",
+"config":
+[
+ {
+  "name": "attributes",
+  "description": "List of address attributes for which to perform symbol lookup",
+  "type": "string"
+ },{
+  "name": "lookup_functions",
+  "description": "Perform function name lookup",
+  "type": "bool",
+  "value": "true"
+ },{
+  "name": "lookup_sourceloc",
+  "description": "Perform source location lookup (source file name + line number)",
+  "type": "bool",
+  "value": "true"
+ },{
+  "name": "lookup_file",
+  "description": "Perform source file name lookup",
+  "type": "bool",
+  "value": "false"
+ },{
+  "name": "lookup_line",
+  "description": "Perform source line lookup",
+  "type": "bool",
+  "value": "false"
+ },{
+  "name": "lookup_module",
+  "description": "Perform module lookup",
+  "type": "bool",
+  "value": "true"
+ }
+]}
 )json";
 
 } // namespace

--- a/src/services/textlog/TextLog.cpp
+++ b/src/services/textlog/TextLog.cpp
@@ -186,24 +186,26 @@ public:
 }; // TextLogService
 
 const char* TextLogService::s_spec = R"json(
-{   "name": "textlog",
-    "description": "Write runtime output for (some) snapshots",
-    "config": [
-        {   "name": "trigger",
-            "type": "string",
-            "description": "List of attributes for which to write text log entries",
-        },
-        {   "name": "formatstring",
-            "description": "Format string for the text log output",
-            "type": "string"
-        },
-        {   "name": "filename",
-            "type": "string",
-            "description": "File or stream to write to",
-            "value": "stdout"
-        }
-    ]
-}
+{
+"name": "textlog",
+"description": "Write runtime output for (some) snapshots",
+"config":
+[
+ {
+  "name": "trigger",
+  "type": "string",
+  "description": "List of attributes for which to write text log entries",
+ },{
+  "name": "formatstring",
+  "description": "Format string for the text log output",
+  "type": "string"
+ },{
+  "name": "filename",
+  "type": "string",
+  "description": "File or stream to write to",
+  "value": "stdout"
+ }
+]}
 )json";
 
 } // namespace

--- a/src/services/timer/Timer.cpp
+++ b/src/services/timer/Timer.cpp
@@ -224,21 +224,24 @@ public:
 }; // class TimerService
 
 const char* TimerService::s_spec = R"json(
-{   "name": "timer",
-    "description": "Record timestamps and time durations",
-    "config": [
-        {   "name": "inclusive_duration",
-            "description": "Record inclusive duration of begin/end regions",
-            "type": "bool",
-            "value": "false"
-        }
-    ]
-}
+{
+"name": "timer",
+"description": "Record timestamps and time durations",
+"config":
+[
+ {
+  "name": "inclusive_duration",
+  "type": "bool",
+  "description": "Record inclusive duration of begin/end regions",
+  "value": "false"
+ }
+]}
 )json";
 
 const char* timestamp_spec = R"json(
-{   "name": "timestamp",
-    "description": "Deprecated name for 'timer' service"
+{
+"name": "timestamp",
+"description": "Deprecated name for 'timer' service"
 }
 )json";
 

--- a/src/services/trace/Trace.cpp
+++ b/src/services/trace/Trace.cpp
@@ -345,21 +345,23 @@ public:
 }; // class Trace
 
 const char* Trace::s_spec = R"json(
-{   "name": "trace",
-    "description": "Store snapshots in trace buffer",
-    "config": [
-        {   "name": "buffer_size",
-            "description": "Size of initial per-thread trace buffer in MiB",
-            "type": "uint",
-            "value": "2"
-        },
-        {   "name": "buffer_policy",
-            "description": "What to do when the buffer is full ('flush', 'stop', 'grow')",
-            "type": "string",
-            "value": "grow"
-        }
-    ]
-}
+{
+"name": "trace",
+"description": "Store snapshots in trace buffer",
+"config":
+[
+ {
+  "name": "buffer_size",
+  "description": "Size of initial per-thread trace buffer in MiB",
+  "type": "uint",
+  "value": "2"
+ },{
+  "name": "buffer_policy",
+  "description": "What to do when the buffer is full ('flush', 'stop', 'grow')",
+  "type": "string",
+  "value": "grow"
+ }
+]}
 )json";
 
 } // namespace

--- a/src/services/umpire/UmpireStatistics.cpp
+++ b/src/services/umpire/UmpireStatistics.cpp
@@ -228,26 +228,27 @@ public:
 };
 
 const char* UmpireService::s_spec = R"json(
-{   "name"        : "umpire",
-    "description" : "Record Umpire memory manager statistics",
-    "config"      :
-    [
-        {   "name"        : "per_allocator_statistics",
-            "description" : "Include statistics for each Umpire allocator",
-            "type"        : "bool",
-            "value"       : "false"
-        },
-        {   "name"        : "allocator_filter",
-            "description" : "Umpire allocators to track",
-            "type"        : "string"
-        },
-        {   "name"        : "record_highwatermarks",
-            "description" : "Record high-watermarks as global attributes",
-            "type"        : "bool",
-            "value"       : "true"
-        }
-    ]
-}
+{
+"name"        : "umpire",
+"description" : "Record Umpire memory manager statistics",
+"config"      :
+[
+ {
+  "name": "per_allocator_statistics",
+  "type": "bool",
+  "description": "Include statistics for each Umpire allocator",
+  "value": "false"
+ },{
+  "name": "allocator_filter",
+  "type": "string"
+  "description": "Umpire allocators to track",
+ },{
+  "name": "record_highwatermarks",
+  "type": "bool",
+  "description": "Record high-watermarks as global attributes",
+  "value": "true"
+ }
+]}
 )json";
 
 } // namespace


### PR DESCRIPTION
Splits up the long ConfigManager option spec string. Should fit with MSVC's 16KiB string literal size limit now. Also generally shortens the service and config recipe strings by removing whitespace.