### PR TITLE
Properly escape backslashes in Python strings

### DIFF
--- a/test/ci_app_tests/test_json.py
+++ b/test/ci_app_tests/test_json.py
@@ -63,7 +63,7 @@ class CaliperJSONTest(unittest.TestCase):
 
         target_cmd = [ './ci_test_macros' ]
         query_cmd  = [ '../../src/tools/cali-query/cali-query',
-                       '-q', 'SELECT count(),sum(time.inclusive.duration.ns),loop,iteration#main\ loop group by loop,iteration#main\ loop format json-split' ]
+                       '-q', 'SELECT count(),sum(time.inclusive.duration.ns),loop,iteration#main\\ loop group by loop,iteration#main\\ loop format json-split' ]
 
         caliper_config = {
             'CALI_CONFIG_PROFILE'    : 'serial-trace',

--- a/test/ci_app_tests/test_loopreport.py
+++ b/test/ci_app_tests/test_loopreport.py
@@ -115,7 +115,7 @@ class CaliperLoopReportTest(unittest.TestCase):
     """ Loop statistics option """
     def test_loop_stats(self):
         target_cmd = [ './ci_test_macros', '10', 'spot,loop.stats,output=stdout' ]
-        query_cmd  = [ '../../src/tools/cali-query/cali-query', '-q', 'let r=leaf() select * where r=main\ loop format json' ]
+        query_cmd  = [ '../../src/tools/cali-query/cali-query', '-q', 'let r=leaf() select * where r=main\\ loop format json' ]
 
         obj = json.loads( cat.run_test_with_query(target_cmd, query_cmd, None) )
 

--- a/test/ci_app_tests/test_monitor.py
+++ b/test/ci_app_tests/test_monitor.py
@@ -14,7 +14,7 @@ class CaliperTestMonitor(unittest.TestCase):
         caliper_config = {
             'CALI_SERVICES_ENABLE'   : 'loop_monitor,trace,report',
             'CALI_LOOP_MONITOR_ITERATION_INTERVAL' : '5',
-            'CALI_REPORT_CONFIG'     : 'select * where iteration#main\ loop format expand',
+            'CALI_REPORT_CONFIG'     : 'select * where iteration#main\\ loop format expand',
             'CALI_REPORT_FILENAME'   : 'stdout',
             'CALI_LOG_VERBOSITY'     : '0'
         }

--- a/test/ci_app_tests/test_report.py
+++ b/test/ci_app_tests/test_report.py
@@ -52,7 +52,7 @@ class CaliperReportTest(unittest.TestCase):
 
         caliper_config = {
             'CALI_SERVICES_ENABLE'   : 'event,trace,report',
-            'CALI_REPORT_CONFIG'     : 'select *,count() group by path,iteration#main\ loop format expand',
+            'CALI_REPORT_CONFIG'     : 'select *,count() group by path,iteration#main\\ loop format expand',
             'CALI_LOG_VERBOSITY'     : '0'
         }
 
@@ -97,7 +97,7 @@ class CaliperReportTest(unittest.TestCase):
 
         caliper_config = {
             'CALI_SERVICES_ENABLE'   : 'event,trace,report',
-            'CALI_REPORT_CONFIG'     : 'select *,count() as my\\ count\\ alias group by path,iteration#main\ loop format expand',
+            'CALI_REPORT_CONFIG'     : 'select *,count() as my\\ count\\ alias group by path,iteration#main\\ loop format expand',
             'CALI_LOG_VERBOSITY'     : '0'
         }
 

--- a/test/ci_app_tests/test_textlog.py
+++ b/test/ci_app_tests/test_textlog.py
@@ -12,7 +12,7 @@ class CaliperTextlogTest(unittest.TestCase):
 
         caliper_config = {
             'CALI_SERVICES_ENABLE'      : 'event,textlog',
-            'CALI_TEXTLOG_TRIGGER'      : 'iteration#main\ loop',
+            'CALI_TEXTLOG_TRIGGER'      : 'iteration#main\\ loop',
             'CALI_TEXTLOG_FORMATSTRING' : '%region% iteration: %[2]iteration#main loop%',
             'CALI_LOG_VERBOSITY'        : '0',
         }


### PR DESCRIPTION
Strings in some of our test code didn't escape backslashes properly, which causes a syntax error in Python 3.12.