### PR TITLE
Use ROCM_PATH to look for roctracer/roctx. Fixes #637

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -380,7 +380,7 @@ if (WITH_ROCTX OR WITH_ROCM)
     list(APPEND CALIPER_EXTERNAL_LIBS ${ROCTX_LIBRARIES})
   else()
     message(WARNING "RocTX support requested but ROCm was not found!\n"
-      "Set ROCM_PREFIX to installation path and re-run cmake.")
+      "Set ROCM_PATH to installation path and re-run cmake.")
   endif()
 endif()
 
@@ -392,7 +392,7 @@ if (WITH_ROCTRACER OR WITH_ROCM)
     list(APPEND CALIPER_EXTERNAL_LIBS ${ROCTRACER_LIBRARIES})
   else()
     message(WARNING "RocTracer support requested but ROCm was not found!\n"
-      "Set ROCM_PREFIX to installation path and re-run cmake.")
+      "Set ROCM_PATH to installation path and re-run cmake.")
   endif()
 endif()
 

--- a/cmake/FindRocTX.cmake
+++ b/cmake/FindRocTX.cmake
@@ -1,17 +1,17 @@
 # Find RocTX libraries/headers
 
-find_path(ROCM_ROOT_DIR
+find_path(ROCM_PATH
   NAMES include/roctracer/roctx.h
 )
 
 find_library(ROCTX_LIBRARIES
   NAMES roctx64
-  HINTS ${ROCM_ROOT_DIR}/lib
+  HINTS ${ROCM_PATH}/lib
 )
 
 find_path(ROCTX_INCLUDE_DIRS
   NAMES roctx.h
-  HINTS ${ROCM_ROOT_DIR}/include/roctracer
+  HINTS ${ROCM_PATH}/include/roctracer
 )
 
 include(FindPackageHandleStandardArgs)

--- a/cmake/FindRoctracer.cmake
+++ b/cmake/FindRoctracer.cmake
@@ -1,38 +1,38 @@
 # Find ROCTracer libraries/headers
 
-find_path(ROCM_ROOT_DIR
+find_path(ROCM_PATH
   NAMES include/roctracer/roctracer.h
 )
 
 find_library(ROCTRACER_LIBROCTRACER
   NAMES roctracer64
-  HINTS ${ROCM_ROOT_DIR}/lib
+  HINTS ${ROCM_PATH}/lib
 )
 find_library(ROCTRACER_LIBHSARUNTIME
   NAMES hsa-runtime64
-  HINTS ${ROCM_ROOT_DIR}/lib
+  HINTS ${ROCM_PATH}/lib
 )
 find_library(ROCTRACER_LIBHSAKMT
   NAMES hsakmt
-  HINTS ${ROCM_ROOT_DIR}/lib
+  HINTS ${ROCM_PATH}/lib
 )
 find_library(ROCTRACER_LIBHSAKMT
   NAMES hsakmt
-  HINTS ${ROCM_ROOT_DIR}/lib
+  HINTS ${ROCM_PATH}/lib
 )
 find_library(ROCTRACER_AMDHIP64
   NAMES amdhip64
-  HINTS ${ROCM_ROOT_DIR}/lib
+  HINTS ${ROCM_PATH}/lib
 )
 
 find_path(ROCTRACER_INCLUDE_DIR
   NAMES roctracer.h
-  HINTS ${ROCM_ROOT_DIR}/include/roctracer
+  HINTS ${ROCM_PATH}/include/roctracer
 )
 
 find_path(HIP_INCLUDE_DIR
   NAMES hip/hip_runtime.h
-  HINTS ${ROCM_ROOT_DIR}/include)
+  HINTS ${ROCM_PATH}/include)
 
 set(ROCTRACER_INCLUDE_DIRS 
   ${ROCTRACER_INCLUDE_DIR}


### PR DESCRIPTION
Use the default `ROCM_PATH` variable instead of `ROCM_ROOT_DIR`. Fixes #637 