### PR TITLE
Refactor channel args in callback functions

### DIFF
--- a/include/caliper/AnnotationBinding.h
+++ b/include/caliper/AnnotationBinding.h
@@ -89,8 +89,8 @@ class AnnotationBinding
     /// User code should instead use on_mark_attribute(),
     /// on_begin(), and on_end().
 
-    void begin_cb(Caliper*, Channel*, const Attribute&, const Variant&);
-    void end_cb(Caliper*, Channel*, const Attribute&, const Variant&);
+    void begin_cb(Caliper*, const Attribute&, const Variant&);
+    void end_cb(Caliper*, const Attribute&, const Variant&);
 
     static bool is_subscription_attribute(const Attribute& attr);
 
@@ -109,13 +109,13 @@ protected:
     /// \param c     Caliper instance
     /// \param attr  Attribute on which the %Caliper begin event was invoked.
     /// \param value The annotation name/value.
-    virtual void on_begin(Caliper* c, Channel* chn, const Attribute& attr, const Variant& value) {}
+    virtual void on_begin(Caliper* c, const Attribute& attr, const Variant& value) {}
 
     /// \brief Callback for an annotation end event
     /// \param c     Caliper instance
     /// \param attr  Attribute on which the %Caliper end event was invoked.
     /// \param value The annotation name/value.
-    virtual void on_end(Caliper* c, Channel* chn, const Attribute& attr, const Variant& value) {}
+    virtual void on_end(Caliper* c, const Attribute& attr, const Variant& value) {}
 
     /// \brief Initialization callback. Invoked after the %Caliper
     ///   initialization completed.
@@ -159,13 +159,13 @@ public:
             binding->check_attribute(c, attr);
         });
         chn->events().pre_begin_evt.connect(
-            [binding](Caliper* c, Channel* chn, const Attribute& attr, const Variant& value) {
-                binding->begin_cb(c, chn, attr, value);
+            [binding](Caliper* c, ChannelBody*, const Attribute& attr, const Variant& value) {
+                binding->begin_cb(c, attr, value);
             }
         );
         chn->events().pre_end_evt.connect(
-            [binding](Caliper* c, Channel* chn, const Attribute& attr, const Variant& value) {
-                binding->end_cb(c, chn, attr, value);
+            [binding](Caliper* c, ChannelBody*, const Attribute& attr, const Variant& value) {
+                binding->end_cb(c, attr, value);
             }
         );
         chn->events().finish_evt.connect([binding](Caliper* c, Channel* chn) {

--- a/include/caliper/AnnotationBinding.h
+++ b/include/caliper/AnnotationBinding.h
@@ -74,8 +74,10 @@ class AnnotationBinding
     std::unique_ptr<RegionFilter> m_filter;
     std::vector<std::string> m_trigger_attr_names;
 
-    void mark_attribute(Caliper*, Channel*, const Attribute&);
-    void check_attribute(Caliper*, Channel*, const Attribute&);
+    std::string m_channel_name;
+
+    void mark_attribute(Caliper*, const Attribute&);
+    void check_attribute(Caliper*, const Attribute&);
 
     void base_pre_initialize(Caliper*, Channel*);
     void base_post_initialize(Caliper*, Channel*);
@@ -100,9 +102,8 @@ protected:
     /// annotation binding is found.
     ///
     /// \param c    The %Caliper instance
-    /// \param chn  The channel instance
     /// \param attr The attribute being marked
-    virtual void on_mark_attribute(Caliper* c, Channel* chn, const Attribute& attr) {}
+    virtual void on_mark_attribute(Caliper* c, const Attribute& attr) {}
 
     /// \brief Callback for an annotation begin event
     /// \param c     Caliper instance
@@ -150,12 +151,12 @@ public:
         binding->initialize(c, chn);
         binding->base_post_initialize(c, chn);
 
-        chn->events().create_attr_evt.connect([binding](Caliper* c, Channel* chn, const Attribute& attr) {
+        chn->events().create_attr_evt.connect([binding](Caliper* c, const Attribute& attr) {
             if (!is_subscription_attribute(attr))
-                binding->check_attribute(c, chn, attr);
+                binding->check_attribute(c, attr);
         });
-        chn->events().subscribe_attribute.connect([binding](Caliper* c, Channel* chn, const Attribute& attr) {
-            binding->check_attribute(c, chn, attr);
+        chn->events().subscribe_attribute.connect([binding](Caliper* c, const Attribute& attr) {
+            binding->check_attribute(c, attr);
         });
         chn->events().pre_begin_evt.connect(
             [binding](Caliper* c, Channel* chn, const Attribute& attr, const Variant& value) {

--- a/include/caliper/Caliper.h
+++ b/include/caliper/Caliper.h
@@ -60,13 +60,12 @@ public:
         typedef util::callback<void(Caliper*, Channel*, const Attribute&)>                 attribute_cbvec;
         typedef util::callback<void(Caliper*, Channel*, const Attribute&, const Variant&)> update_cbvec;
         typedef util::callback<void(Caliper*, Channel*)>                                   caliper_cbvec;
+        typedef util::callback<void(Caliper*, Channel*, SnapshotView)>                     event_cbvec;
 
-        typedef util::callback<void(Caliper*, Channel*, SnapshotView)>                   event_cbvec;
-        typedef util::callback<void(Caliper*, Channel*, SnapshotView, SnapshotBuilder&)> snapshot_cbvec;
-        typedef util::callback<void(Caliper*, Channel*, SnapshotView, SnapshotView)>     process_snapshot_cbvec;
-        typedef util::callback<void(Caliper*, Channel*, std::vector<Entry>&)>            edit_snapshot_cbvec;
-
-        typedef util::callback<void(Caliper*, Channel*, SnapshotView, SnapshotFlushFn)> flush_cbvec;
+        typedef util::callback<void(Caliper*, SnapshotView, SnapshotBuilder&)> snapshot_cbvec;
+        typedef util::callback<void(Caliper*, SnapshotView, SnapshotView)>     process_snapshot_cbvec;
+        typedef util::callback<void(Caliper*, std::vector<Entry>&)>            edit_snapshot_cbvec;
+        typedef util::callback<void(Caliper*, SnapshotView, SnapshotFlushFn)>  flush_cbvec;
 
         typedef util::callback<
             void(Caliper*, Channel*, const void*, const char*, size_t, size_t, const size_t*, size_t, const Attribute*, const Variant*)>

--- a/include/caliper/Caliper.h
+++ b/include/caliper/Caliper.h
@@ -344,7 +344,7 @@ public:
     /// snapshot entry before processing the record. This allows for an optimization
     /// when creating event trigger info entries where we replace the context entry
     /// with an augmented entry from \a trigger_info.
-    void push_snapshot_replace(Channel* channel, SnapshotView trigger_info, Entry target);
+    void push_snapshot_replace(Channel* channel, SnapshotView trigger_info, const Entry& target);
 
     /// \brief Return context data from blackboards.
     ///

--- a/include/caliper/Caliper.h
+++ b/include/caliper/Caliper.h
@@ -57,7 +57,8 @@ public:
 
     /// \brief Holds the %Caliper callbacks for a channel.
     struct Events {
-        typedef util::callback<void(Caliper*, Channel*, const Attribute&)>                 attribute_cbvec;
+        typedef util::callback<void(Caliper*, const Attribute&)> attribute_cbvec;
+
         typedef util::callback<void(Caliper*, Channel*, const Attribute&, const Variant&)> update_cbvec;
         typedef util::callback<void(Caliper*, Channel*)>                                   caliper_cbvec;
         typedef util::callback<void(Caliper*, Channel*, SnapshotView)>                     event_cbvec;

--- a/include/caliper/Caliper.h
+++ b/include/caliper/Caliper.h
@@ -32,12 +32,20 @@ class RuntimeConfig;
 ///   snapshot buffers.
 typedef std::function<void(CaliperMetadataAccessInterface&, const std::vector<cali::Entry>&)> SnapshotFlushFn;
 
+/// \brief %Channel implementation details.
+///
+///   Maintains data (callback tables etc.) associated with a %Caliper
+/// measurement configuration. While ChannelBody pointers can be safely
+/// passed through the %Caliper API and callback functions, any code that
+/// needs to store a channel reference should make a copy of the
+/// original Channel object to properly manage lifetime.
+struct ChannelBody;
+
 /// \brief Maintain a single data collection configuration with
 ///    callbacks and associated measurement data.
 class Channel
 {
-    struct ChannelImpl;
-    std::shared_ptr<ChannelImpl> mP;
+    std::shared_ptr<ChannelBody> mP;
 
     Channel(cali_id_t id, const char* name, const RuntimeConfig& cfg);
 
@@ -59,9 +67,10 @@ public:
     struct Events {
         typedef util::callback<void(Caliper*, const Attribute&)> attribute_cbvec;
 
-        typedef util::callback<void(Caliper*, Channel*, const Attribute&, const Variant&)> update_cbvec;
-        typedef util::callback<void(Caliper*, Channel*)>                                   caliper_cbvec;
-        typedef util::callback<void(Caliper*, Channel*, SnapshotView)>                     event_cbvec;
+        typedef util::callback<void(Caliper*, Channel*)> caliper_cbvec;
+
+        typedef util::callback<void(Caliper*, ChannelBody*, const Attribute&, const Variant&)> update_cbvec;
+        typedef util::callback<void(Caliper*, ChannelBody*, SnapshotView)>                     event_cbvec;
 
         typedef util::callback<void(Caliper*, SnapshotView, SnapshotBuilder&)> snapshot_cbvec;
         typedef util::callback<void(Caliper*, SnapshotView, SnapshotView)>     process_snapshot_cbvec;
@@ -69,9 +78,9 @@ public:
         typedef util::callback<void(Caliper*, SnapshotView, SnapshotFlushFn)>  flush_cbvec;
 
         typedef util::callback<
-            void(Caliper*, Channel*, const void*, const char*, size_t, size_t, const size_t*, size_t, const Attribute*, const Variant*)>
+            void(Caliper*, ChannelBody*, const void*, const char*, size_t, size_t, const size_t*, size_t, const Attribute*, const Variant*)>
                                                                       track_mem_cbvec;
-        typedef util::callback<void(Caliper*, Channel*, const void*)> untrack_mem_cbvec;
+        typedef util::callback<void(Caliper*, ChannelBody*, const void*)> untrack_mem_cbvec;
 
         /// \brief Invoked when a new attribute has been created.
         attribute_cbvec create_attr_evt;
@@ -152,6 +161,8 @@ public:
         /// in the given channel.
         attribute_cbvec subscribe_attribute;
     };
+
+    ChannelBody* body() { return mP.get(); }
 
     /// \brief Access the callback vectors to register callbacks for this channel.
     Events& events();
@@ -337,7 +348,7 @@ public:
     /// \param trigger_info A caller-provided list of attributes that is passed
     ///   to the snapshot and process_snapshot callbacks, and added to the
     ///   returned snapshot record.
-    void push_snapshot(Channel* channel, SnapshotView trigger_info);
+    void push_snapshot(ChannelBody* chB, SnapshotView trigger_info);
 
     /// \brief Specialized snapshot trigger function which replaces a given blackboard entry.
     ///
@@ -345,7 +356,7 @@ public:
     /// snapshot entry before processing the record. This allows for an optimization
     /// when creating event trigger info entries where we replace the context entry
     /// with an augmented entry from \a trigger_info.
-    void push_snapshot_replace(Channel* channel, SnapshotView trigger_info, const Entry& target);
+    void push_snapshot_replace(ChannelBody* chB, SnapshotView trigger_info, const Entry& target);
 
     /// \brief Return context data from blackboards.
     ///
@@ -378,7 +389,7 @@ public:
     /// \param trigger_info A caller-provided record that is passed to the
     ///   snapshot callback, and added to the returned snapshot record.
     /// \param rec The snapshot record buffer to update.
-    void pull_snapshot(Channel* channel, SnapshotView trigger_info, SnapshotBuilder& rec);
+    void pull_snapshot(ChannelBody* chB, SnapshotView trigger_info, SnapshotBuilder& rec);
 
     // --- Flush and I/O API
 
@@ -388,7 +399,7 @@ public:
 
     /// \brief Flush aggregation/trace buffer contents into the \a proc_fn
     ///   processing function.
-    void flush(Channel* channel, SnapshotView flush_info, SnapshotFlushFn proc_fn);
+    void flush(ChannelBody* chB, SnapshotView flush_info, SnapshotFlushFn proc_fn);
 
     /// \brief Flush snapshot buffer contents on \a channel into the registered
     ///   output services.
@@ -399,7 +410,7 @@ public:
     ///
     /// \param channel The channel to flush
     /// \param input_flush_info User-provided flush context information
-    void flush_and_write(Channel* channel, SnapshotView flush_info);
+    void flush_and_write(ChannelBody* chB, SnapshotView flush_info);
 
     /// \brief Clear snapshot buffers on \a channel
     ///
@@ -426,12 +437,12 @@ public:
     ///
     /// This function is signal safe.
     ///
-    /// \param channel Designated channel
+    /// \param chB  Designated channel
     /// \param attr Attribute key
     /// \param data Value to set
     ///
     /// \sa begin(const Attribute&, const Variant&)
-    void begin(Channel* channel, const Attribute& attr, const Variant& data);
+    void begin(ChannelBody* chB, const Attribute& attr, const Variant& data);
 
     /// \brief Pop/remove top-most entry with given attribute from
     ///   the channel blackboard.
@@ -444,7 +455,7 @@ public:
     /// \param attr Attribute key.
     ///
     /// \sa end(const Attribute&)
-    void end(Channel* channel, const Attribute& attr);
+    void end(ChannelBody* chB, const Attribute& attr);
 
     /// \brief Set attribute:value pair on the channel blackboard.
     ///
@@ -459,14 +470,14 @@ public:
     /// \param attr Attribute key
     /// \param data Value to set
     /// \sa set(const Attribute&, const Variant&)
-    void set(Channel* channel, const Attribute& attr, const Variant& data);
+    void set(ChannelBody* chB, const Attribute& attr, const Variant& data);
 
     /// \}
     /// \name Memory region tracking (single channel)
     /// \{
 
     void memory_region_begin(
-        Channel*         chn,
+        ChannelBody*     chB,
         const void*      ptr,
         const char*      label,
         size_t           elem_size,
@@ -476,7 +487,7 @@ public:
         const Attribute* extra_attr = nullptr,
         const Variant*   extra_val  = nullptr
     );
-    void memory_region_end(Channel* chn, const void* ptr);
+    void memory_region_end(ChannelBody* chB, const void* ptr);
 
     /// \}
     /// \name Blackboard access
@@ -513,7 +524,7 @@ public:
     ///
     /// \return The top-most entry on the blackboard for the given attribute key.
     ///   An empty Entry object if this attribute is not set.
-    Entry get(Channel* channel, const Attribute& attr);
+    Entry get(ChannelBody* chB, const Attribute& attr);
 
     /// \brief Retrieve the current top-most entry in \a attr's blackboard slot
     ///
@@ -530,10 +541,8 @@ public:
     /// \sa get_globals(Channel*)
     std::vector<Entry> get_globals();
 
-    /// \brief Return all global attributes for \a channel
-    ///
-    ///
-    std::vector<Entry> get_globals(const Channel& channel);
+    /// \brief Return all global attributes for \a chB
+    std::vector<Entry> get_globals(const ChannelBody* chB);
 
     /// \}
     /// \name Explicit snapshot record manipulation

--- a/include/caliper/Caliper.h
+++ b/include/caliper/Caliper.h
@@ -338,6 +338,14 @@ public:
     ///   returned snapshot record.
     void push_snapshot(Channel* channel, SnapshotView trigger_info);
 
+    /// \brief Specialized snapshot trigger function which replaces a given blackboard entry.
+    ///
+    /// Internal-use snapshot trigger function which removes a given blackboard
+    /// snapshot entry before processing the record. This allows for an optimization
+    /// when creating event trigger info entries where we replace the context entry
+    /// with an augmented entry from \a trigger_info.
+    void push_snapshot_replace(Channel* channel, SnapshotView trigger_info, Entry target);
+
     /// \brief Return context data from blackboards.
     ///
     /// This function updates the caller-provided snapshot record builder
@@ -505,6 +513,14 @@ public:
     /// \return The top-most entry on the blackboard for the given attribute key.
     ///   An empty Entry object if this attribute is not set.
     Entry get(Channel* channel, const Attribute& attr);
+
+    /// \brief Retrieve the current top-most entry in \a attr's blackboard slot
+    ///
+    /// A special-purpose function which retrieves the current top-most entry in
+    /// \a attr's blackboard slot. This is not necessarily \a attr itself because
+    /// reference attributes typically share a single slot. Usually
+    /// \ref Caliper::get(const Attribute) should be used instead.
+    Entry get_blackboard_entry(const Attribute& attr);
 
     /// \brief Retrieve the current path entry from the blackboard.
     Entry get_path_node();

--- a/include/caliper/ChannelController.h
+++ b/include/caliper/ChannelController.h
@@ -18,6 +18,8 @@ namespace cali
 class Caliper;
 class Channel;
 
+struct ChannelBody;
+
 typedef std::map<std::string, std::string> config_map_t;
 typedef std::map<std::string, std::string> info_map_t;
 
@@ -65,6 +67,8 @@ public:
 
     /// \brief Return the underlying %Caliper channel object.
     Channel channel();
+    /// \brief Return the underlying channel body pointer
+    ChannelBody* channel_body();
 
     /// \brief Create and activate the %Caliper channel,
     ///   or reactivate a stopped %Caliper channel.
@@ -75,6 +79,8 @@ public:
 
     /// \brief Returns true if channel exists and is active, false otherwise.
     bool is_active() const;
+    /// \brief Returns true if the channel is instantiated
+    bool is_instantiated() const;
 
     /// \brief Returns the name of the underlying channel
     std::string name() const;

--- a/include/caliper/SnapshotRecord.h
+++ b/include/caliper/SnapshotRecord.h
@@ -88,12 +88,13 @@ public:
     size_t skipped() const { return m_skipped; }
 
     void remove(const Entry& e) {
-        if (m_len > 0)
-            --m_len;
         size_t pos = 0;
-        for ( ; pos < m_len; ++pos)
-            if (e == m_data[pos])
+        for ( ; pos < m_len; ++pos) {
+            if (e == m_data[pos]) {
+                --m_len;
                 break;
+            }
+        }
         for ( ; pos < m_len; ++pos)
             m_data[pos] = m_data[pos+1];
     }

--- a/include/caliper/SnapshotRecord.h
+++ b/include/caliper/SnapshotRecord.h
@@ -87,6 +87,17 @@ public:
     size_t size() const { return m_len; }
     size_t skipped() const { return m_skipped; }
 
+    void remove(const Entry& e) {
+        if (m_len > 0)
+            --m_len;
+        size_t pos = 0;
+        for ( ; pos < m_len; ++pos)
+            if (e == m_data[pos])
+                break;
+        for ( ; pos < m_len; ++pos)
+            m_data[pos] = m_data[pos+1];
+    }
+
     void append(const Entry& e)
     {
         if (m_len < m_capacity)

--- a/include/caliper/SnapshotRecord.h
+++ b/include/caliper/SnapshotRecord.h
@@ -87,7 +87,8 @@ public:
     size_t size() const { return m_len; }
     size_t skipped() const { return m_skipped; }
 
-    void remove(const Entry& e) {
+    void remove(const Entry& e)
+    {
         size_t pos = 0;
         for ( ; pos < m_len; ++pos) {
             if (e == m_data[pos]) {

--- a/include/caliper/cali-mpi.h
+++ b/include/caliper/cali-mpi.h
@@ -20,10 +20,10 @@ namespace cali
 
 class Aggregator;
 class Caliper;
-class Channel;
 class CaliperMetadataDB;
 class OutputStream;
 
+struct ChannelBody;
 struct QuerySpec;
 
 /**
@@ -54,7 +54,7 @@ void aggregate_over_mpi(CaliperMetadataDB& db, Aggregator& a, MPI_Comm comm);
 void collective_flush(
     OutputStream&    stream,
     Caliper&         c,
-    Channel&         channel,
+    ChannelBody*     chB,
     SnapshotView     flush_info,
     const QuerySpec& local_query,
     const QuerySpec& cross_query,

--- a/src/caliper/AnnotationBinding.cpp
+++ b/src/caliper/AnnotationBinding.cpp
@@ -75,7 +75,7 @@ bool AnnotationBinding::is_subscription_attribute(const Attribute& attr)
 AnnotationBinding::~AnnotationBinding()
 {}
 
-void AnnotationBinding::mark_attribute(Caliper* c, Channel* chn, const Attribute& attr)
+void AnnotationBinding::mark_attribute(Caliper* c, const Attribute& attr)
 {
     // Add the binding marker for this attribute
 
@@ -84,13 +84,13 @@ void AnnotationBinding::mark_attribute(Caliper* c, Channel* chn, const Attribute
 
     // Invoke derived functions
 
-    on_mark_attribute(c, chn, attr);
+    on_mark_attribute(c, attr);
 
     Log(2).stream() << "Adding " << this->service_tag() << " bindings for attribute \"" << attr.name() << "\" in "
-                    << chn->name() << " channel" << std::endl;
+                    << m_channel_name << " channel" << std::endl;
 }
 
-void AnnotationBinding::check_attribute(Caliper* c, Channel* chn, const Attribute& attr)
+void AnnotationBinding::check_attribute(Caliper* c, const Attribute& attr)
 {
     int prop = attr.properties();
 
@@ -107,7 +107,7 @@ void AnnotationBinding::check_attribute(Caliper* c, Channel* chn, const Attribut
             return;
     }
 
-    mark_attribute(c, chn, attr);
+    mark_attribute(c, attr);
 }
 
 void AnnotationBinding::begin_cb(Caliper* c, Channel* chn, const Attribute& attr, const Variant& value)
@@ -132,6 +132,8 @@ void AnnotationBinding::end_cb(Caliper* c, Channel* chn, const Attribute& attr, 
 
 void AnnotationBinding::base_pre_initialize(Caliper* c, Channel* chn)
 {
+    m_channel_name = chn->name();
+
     const char* tag     = service_tag();
     std::string cfgname = std::string(tag) + "_binding";
 
@@ -168,7 +170,7 @@ void AnnotationBinding::base_post_initialize(Caliper* c, Channel* chn)
 
     for (const Attribute& attr : attributes)
         if (!attr.skip_events() && !is_subscription_attribute(attr))
-            check_attribute(c, chn, attr);
+            check_attribute(c, attr);
 }
 
 AnnotationBinding::AnnotationBinding()

--- a/src/caliper/AnnotationBinding.cpp
+++ b/src/caliper/AnnotationBinding.cpp
@@ -110,24 +110,24 @@ void AnnotationBinding::check_attribute(Caliper* c, const Attribute& attr)
     mark_attribute(c, attr);
 }
 
-void AnnotationBinding::begin_cb(Caliper* c, Channel* chn, const Attribute& attr, const Variant& value)
+void AnnotationBinding::begin_cb(Caliper* c, const Attribute& attr, const Variant& value)
 {
     if (!::has_marker(attr, m_marker_attr))
         return;
     if (m_filter && !m_filter->pass(value))
         return;
 
-    this->on_begin(c, chn, attr, value);
+    this->on_begin(c, attr, value);
 }
 
-void AnnotationBinding::end_cb(Caliper* c, Channel* chn, const Attribute& attr, const Variant& value)
+void AnnotationBinding::end_cb(Caliper* c, const Attribute& attr, const Variant& value)
 {
     if (!::has_marker(attr, m_marker_attr))
         return;
     if (m_filter && !m_filter->pass(value))
         return;
 
-    this->on_end(c, chn, attr, value);
+    this->on_end(c, attr, value);
 }
 
 void AnnotationBinding::base_pre_initialize(Caliper* c, Channel* chn)

--- a/src/caliper/Caliper.cpp
+++ b/src/caliper/Caliper.cpp
@@ -889,7 +889,7 @@ void Caliper::push_snapshot(Channel* channel, SnapshotView trigger_info)
     channel->mP->events.process_snapshot(this, trigger_info, sT->snapshot.view());
 }
 
-void Caliper::push_snapshot_replace(Channel* channel, SnapshotView trigger_info, Entry target)
+void Caliper::push_snapshot_replace(Channel* channel, SnapshotView trigger_info, const Entry& target)
 {
     std::lock_guard<::siglock> g(sT->lock);
 

--- a/src/caliper/Caliper.cpp
+++ b/src/caliper/Caliper.cpp
@@ -751,7 +751,7 @@ Attribute Caliper::create_attribute(
     Attribute attr = Attribute::make_attribute(node);
 
     for (auto& channel : sG->all_channels)
-        channel.mP->events.create_attr_evt(this, &channel, attr);
+        channel.mP->events.create_attr_evt(this, attr);
 
     return attr;
 }

--- a/src/caliper/ChannelController.cpp
+++ b/src/caliper/ChannelController.cpp
@@ -43,7 +43,7 @@ void add_channel_metadata(Caliper& c, Channel& channel, const info_map_t& metada
             CALI_ATTR_GLOBAL | CALI_ATTR_SKIP_EVENTS | CALI_ATTR_UNALIGNED
         );
 
-        c.set(&channel, attr, Variant(entry.second.c_str()));
+        c.set(channel.body(), attr, Variant(entry.second.c_str()));
     }
 }
 
@@ -52,6 +52,11 @@ void add_channel_metadata(Caliper& c, Channel& channel, const info_map_t& metada
 Channel ChannelController::channel()
 {
     return mP->channel;
+}
+
+ChannelBody* ChannelController::channel_body()
+{
+    return mP->channel.body();
 }
 
 config_map_t& ChannelController::config()
@@ -119,11 +124,16 @@ bool ChannelController::is_active() const
     return mP->channel && mP->channel.is_active();
 }
 
+bool ChannelController::is_instantiated() const
+{
+    return mP && mP->channel;
+}
+
 void ChannelController::flush()
 {
     Channel chn = channel();
     if (chn)
-        Caliper().flush_and_write(&chn, SnapshotView());
+        Caliper().flush_and_write(chn.body(), SnapshotView());
 }
 
 std::string ChannelController::name() const

--- a/src/caliper/CollectiveOutputChannel.cpp
+++ b/src/caliper/CollectiveOutputChannel.cpp
@@ -76,9 +76,7 @@ public:
 
     void collective_flush(OutputStream& stream, MPI_Comm comm) override
     {
-        Channel chn = m_channel->channel();
-
-        if (!chn)
+        if (!m_channel->is_instantiated())
             return;
 
         QuerySpec cross_spec;
@@ -107,7 +105,7 @@ public:
         }
 
         Caliper c;
-        cali::collective_flush(stream, c, chn, SnapshotView(), local_spec, cross_spec, comm);
+        cali::collective_flush(stream, c, m_channel->channel_body(), SnapshotView(), local_spec, cross_spec, comm);
     }
 
     void collective_flush(MPI_Comm comm) override

--- a/src/caliper/RegionProfile.cpp
+++ b/src/caliper/RegionProfile.cpp
@@ -42,7 +42,7 @@ RegionProfile::region_profile_t RegionProfile::exclusive_region_times(const std:
     FlatExclusiveRegionProfile rp(c, "sum#time.duration.ns", region_type.c_str());
 
     if (chn)
-        c.flush(&chn, SnapshotView(), rp);
+        c.flush(chn.body(), SnapshotView(), rp);
     else
         Log(1).stream() << "RegionProfile::exclusive_region_times(): channel is not enabled" << std::endl;
 
@@ -64,7 +64,7 @@ RegionProfile::region_profile_t RegionProfile::inclusive_region_times(const std:
     FlatInclusiveRegionProfile rp(c, "sum#time.duration.ns", region_type.c_str());
 
     if (chn)
-        c.flush(&chn, SnapshotView(), rp);
+        c.flush(chn.body(), SnapshotView(), rp);
     else
         Log(1).stream() << "RegionProfile::inclusive_region_times(): channel is not enabled" << std::endl;
 

--- a/src/caliper/builtin_configmanager.cpp
+++ b/src/caliper/builtin_configmanager.cpp
@@ -77,13 +77,13 @@ void init_builtin_configmanager(Caliper* c)
 
     mgr.start();
 
-    channel.events().write_output_evt.connect([mgr, flag_attr](Caliper* c, Channel* channel, SnapshotView) mutable {
-        if (c->get(channel, flag_attr).value().to_bool() == true)
+    channel.events().write_output_evt.connect([mgr, flag_attr](Caliper* c, ChannelBody* chB, SnapshotView) mutable {
+        if (c->get(chB, flag_attr).value().to_bool() == true)
             return;
 
         mgr.flush();
 
-        c->set(channel, flag_attr, Variant(true));
+        c->set(chB, flag_attr, Variant(true));
     });
 
     Log(1).stream() << "Registered builtin ConfigManager" << std::endl;

--- a/src/caliper/cali.cpp
+++ b/src/caliper/cali.cpp
@@ -144,7 +144,7 @@ void cali_push_snapshot(
 
     for (auto& channel : c.get_all_channels())
         if (channel.is_active())
-            c.push_snapshot(&channel, trigger_info.view());
+            c.push_snapshot(channel.body(), trigger_info.view());
 }
 
 void cali_channel_push_snapshot(
@@ -173,7 +173,7 @@ void cali_channel_push_snapshot(
     Channel channel = c.get_channel(chn_id);
 
     if (channel && channel.is_active())
-        c.push_snapshot(&channel, trigger_info.view());
+        c.push_snapshot(channel.body(), trigger_info.view());
 }
 
 size_t cali_channel_pull_snapshot(cali_id_t chn_id, int /* scopes */, size_t len, unsigned char* buf)
@@ -187,7 +187,7 @@ size_t cali_channel_pull_snapshot(cali_id_t chn_id, int /* scopes */, size_t len
     Channel                           channel = c.get_channel(chn_id);
 
     if (channel)
-        c.pull_snapshot(&channel, SnapshotView(), snapshot.builder());
+        c.pull_snapshot(channel.body(), SnapshotView(), snapshot.builder());
     else
         Log(0).stream() << "cali_channel_pull_snapshot(): invalid channel id " << chn_id << std::endl;
 
@@ -346,7 +346,7 @@ cali_variant_t cali_channel_get(cali_id_t chn_id, cali_id_t attr_id)
     if (!c || !channel)
         return cali_make_empty_variant();
 
-    return c.get(&channel, c.get_attribute(attr_id)).value().c_variant();
+    return c.get(channel.body(), c.get_attribute(attr_id)).value().c_variant();
 }
 
 const char* cali_get_current_region_or(const char* alt)
@@ -713,7 +713,7 @@ void cali_flush(int flush_opts)
     Channel channel = c.get_channel(0); // channel 0 should be the default channel
 
     if (channel) {
-        c.flush_and_write(&channel, SnapshotView());
+        c.flush_and_write(channel.body(), SnapshotView());
 
         if (flush_opts & CALI_FLUSH_CLEAR_BUFFERS)
             c.clear(&channel);
@@ -725,7 +725,7 @@ void cali_channel_flush(cali_id_t chn_id, int flush_opts)
     Caliper c;
     Channel channel = c.get_channel(chn_id);
 
-    c.flush_and_write(&channel, SnapshotView());
+    c.flush_and_write(channel.body(), SnapshotView());
 
     if (flush_opts & CALI_FLUSH_CLEAR_BUFFERS)
         c.clear(&channel);
@@ -820,7 +820,7 @@ void write_report_for_query(cali_id_t chn_id, const char* query, int flush_opts,
 
     QueryProcessor queryP(spec, stream);
 
-    c.flush(&channel, SnapshotView(), [&queryP](CaliperMetadataAccessInterface& db, const std::vector<Entry>& rec) {
+    c.flush(channel.body(), SnapshotView(), [&queryP](CaliperMetadataAccessInterface& db, const std::vector<Entry>& rec) {
         queryP.process_record(db, rec);
     });
 

--- a/src/caliper/collective_flush.cpp
+++ b/src/caliper/collective_flush.cpp
@@ -26,7 +26,7 @@ namespace cali
 void collective_flush(
     OutputStream&    stream,
     Caliper&         c,
-    Channel&         channel,
+    ChannelBody*     chB,
     SnapshotView     flush_info,
     const QuerySpec& local_query,
     const QuerySpec& cross_query,
@@ -49,7 +49,7 @@ void collective_flush(
 
     // flush this rank's caliper data into local aggregator
     c.flush(
-        &channel,
+        chB,
         flush_info,
         [&db,
          &local_agg,
@@ -88,7 +88,7 @@ void collective_flush(
     //   create a formatter and print it out
     if (rank == 0) {
         // import globals from runtime Caliper object
-        db.import_globals(c, c.get_globals(channel));
+        db.import_globals(c, c.get_globals(chB));
 
         QuerySpec spec = cross_query;
 

--- a/src/caliper/controllers/LoopReportController.cpp
+++ b/src/caliper/controllers/LoopReportController.cpp
@@ -68,9 +68,8 @@ class LoopReportController : public cali::internal::CustomOutputController
         Preprocessor   prp(spec);
         Aggregator     agg(spec);
 
-        Channel chn(channel());
         c.flush(
-            &chn,
+            channel_body(),
             SnapshotView(),
             [&db, &filter, &prp, &agg](CaliperMetadataAccessInterface& in_db, const EntryList& rec) {
                 EntryList mrec = prp.process(db, db.merge_snapshot(in_db, rec));

--- a/src/caliper/mpi_flush.cpp
+++ b/src/caliper/mpi_flush.cpp
@@ -22,7 +22,7 @@ namespace
 void mpiflush_init(Caliper* c, Channel* channel)
 {
     mpiwrap_get_events(channel)->mpi_finalize_evt.connect([](Caliper* c, Channel* channel) {
-        c->flush_and_write(channel, SnapshotView());
+        c->flush_and_write(channel->body(), SnapshotView());
     });
 
     Log(1).stream() << channel->name() << ": Registered mpiflush service" << std::endl;

--- a/src/caliper/test/test_channel_api.cpp
+++ b/src/caliper/test/test_channel_api.cpp
@@ -22,18 +22,18 @@ TEST(ChannelAPITest, MultiChannel)
 
     c.begin(attr_global, Variant(42));
 
-    c.begin(&chn_a, attr_local, Variant(1144));
-    c.begin(&chn_b, attr_local, Variant(4411));
+    c.begin(chn_a.body(), attr_local, Variant(1144));
+    c.begin(chn_b.body(), attr_local, Variant(4411));
 
     EXPECT_EQ(c.get(attr_global).value().to_int(), 42);
     EXPECT_EQ(c.get(attr_global).value().to_int(), 42);
-    EXPECT_EQ(c.get(&chn_a, attr_local).value().to_int(), 1144);
-    EXPECT_EQ(c.get(&chn_b, attr_local).value().to_int(), 4411);
+    EXPECT_EQ(c.get(chn_a.body(), attr_local).value().to_int(), 1144);
+    EXPECT_EQ(c.get(chn_b.body(), attr_local).value().to_int(), 4411);
 
     EXPECT_EQ(c.get(attr_global).value().to_int(), 42);
 
-    c.end(&chn_b, attr_local);
-    c.end(&chn_a, attr_local);
+    c.end(chn_b.body(), attr_local);
+    c.end(chn_a.body(), attr_local);
 
     c.delete_channel(chn_a);
 

--- a/src/caliper/test/test_postprocess_snapshot.cpp
+++ b/src/caliper/test/test_postprocess_snapshot.cpp
@@ -45,7 +45,7 @@ TEST(PostprocessSnapshotTest, PostprocessSnapshot)
 
     std::vector<std::vector<Entry>> output;
 
-    c.flush(&channel, SnapshotView(), [&output](CaliperMetadataAccessInterface& db, const std::vector<Entry>& rec) {
+    c.flush(channel.body(), SnapshotView(), [&output](CaliperMetadataAccessInterface& db, const std::vector<Entry>& rec) {
         output.push_back(rec);
     });
 

--- a/src/caliper/test/test_postprocess_snapshot.cpp
+++ b/src/caliper/test/test_postprocess_snapshot.cpp
@@ -11,7 +11,7 @@ using namespace cali;
 namespace
 {
 
-void flush_cb(Caliper* c, Channel*, SnapshotView, SnapshotFlushFn flush_fn)
+void flush_cb(Caliper* c, SnapshotView, SnapshotFlushFn flush_fn)
 {
     Attribute snapshot_attr = c->create_attribute("tps.snapshot.val", CALI_TYPE_INT, CALI_ATTR_ASVALUE);
 
@@ -21,7 +21,7 @@ void flush_cb(Caliper* c, Channel*, SnapshotView, SnapshotFlushFn flush_fn)
     flush_fn(*c, rec);
 }
 
-void postprocess_snapshot_cb(Caliper* c, Channel*, std::vector<Entry>& rec)
+void postprocess_snapshot_cb(Caliper* c, std::vector<Entry>& rec)
 {
     Attribute val_attr  = c->create_attribute("tps.postprocess.val", CALI_TYPE_INT, CALI_ATTR_ASVALUE);
     Attribute node_attr = c->create_attribute("tps.postprocess.node", CALI_TYPE_INT, CALI_ATTR_DEFAULT);

--- a/src/services/adiak/AdiakExport.cpp
+++ b/src/services/adiak/AdiakExport.cpp
@@ -19,14 +19,12 @@ using namespace cali;
 namespace
 {
 
-std::map<cali_id_t, std::vector<Variant>> get_caliper_globals(Caliper* c, Channel* chn)
+std::map<cali_id_t, std::vector<Variant>> get_caliper_globals(Caliper* c, ChannelBody* chB)
 {
     std::map<cali_id_t, std::vector<Variant>> ret;
-    auto                                      globals = c->get_globals(*chn);
 
     // expand globals
-
-    for (const Entry& e : globals) {
+    for (const Entry& e : c->get_globals(chB)) {
         if (e.is_reference()) {
             for (const Node* node = e.node(); node; node = node->parent())
                 ret[node->attribute()].push_back(node->data());
@@ -38,9 +36,9 @@ std::map<cali_id_t, std::vector<Variant>> get_caliper_globals(Caliper* c, Channe
     return ret;
 }
 
-void export_globals_to_adiak(Caliper* c, Channel* chn)
+void export_globals_to_adiak(Caliper* c, ChannelBody* chB)
 {
-    auto globals_map = get_caliper_globals(c, chn);
+    auto globals_map = get_caliper_globals(c, chB);
 
     for (auto p : globals_map) {
         if (p.second.empty())
@@ -91,7 +89,7 @@ void export_globals_to_adiak(Caliper* c, Channel* chn)
 
 void register_adiak_export(Caliper* c, Channel* chn)
 {
-    chn->events().pre_flush_evt.connect([](Caliper* c, Channel* chn, SnapshotView) { export_globals_to_adiak(c, chn); }
+    chn->events().pre_flush_evt.connect([](Caliper* c, ChannelBody* chB, SnapshotView) { export_globals_to_adiak(c, chB); }
     );
 
     Log(1).stream() << chn->name() << ": Registered adiak_export service" << std::endl;

--- a/src/services/adiak/AdiakImport.cpp
+++ b/src/services/adiak/AdiakImport.cpp
@@ -135,7 +135,7 @@ std::ostream& recursive_unpack(std::ostream& os, adiak_value_t* val, adiak_datat
 }
 
 void set_val(
-    Channel&          channel,
+    ChannelBody*      chB,
     const char*       name,
     const Variant&    val,
     adiak_datatype_t* type,
@@ -157,12 +157,12 @@ void set_val(
     Attribute attr =
         c.create_attribute(name, val.type(), CALI_ATTR_GLOBAL | CALI_ATTR_SKIP_EVENTS, 3, meta_attr, v_metavals);
 
-    c.set(&channel, attr, val);
+    c.set(chB, attr, val);
 }
 
 struct nameval_usr_args_t {
-    Channel channel;
-    int     count;
+    ChannelBody* chB;
+    int          count;
 };
 
 void nameval_cb(
@@ -176,9 +176,7 @@ void nameval_cb(
 {
     nameval_usr_args_t* args = static_cast<nameval_usr_args_t*>(usr_args);
 
-    Channel channel = args->channel;
-
-    if (!channel)
+    if (!args->chB)
         return;
     if (category == adiak_control)
         return;
@@ -198,20 +196,20 @@ void nameval_cb(
             return;
         }
     case adiak_long:
-        set_val(channel, name, Variant(static_cast<int>(val->v_long)), t, category, subcategory);
+        set_val(args->chB, name, Variant(static_cast<int>(val->v_long)), t, category, subcategory);
         ++args->count;
         break;
     case adiak_int:
-        set_val(channel, name, Variant(val->v_int), t, category, subcategory);
+        set_val(args->chB, name, Variant(val->v_int), t, category, subcategory);
         ++args->count;
         break;
     case adiak_ulong:
-        set_val(channel, name, Variant(static_cast<uint64_t>(val->v_long)), t, category, subcategory);
+        set_val(args->chB, name, Variant(static_cast<uint64_t>(val->v_long)), t, category, subcategory);
         ++args->count;
         break;
 #ifdef ADIAK_HAVE_LONGLONG
     case adiak_longlong:
-        set_val(channel, name, Variant(cali_make_variant_from_int64(val->v_longlong)), t, category, subcategory);
+        set_val(args->chB, name, Variant(cali_make_variant_from_int64(val->v_longlong)), t, category, subcategory);
         ++args->count;
         break;
     case adiak_ulonglong:
@@ -227,21 +225,21 @@ void nameval_cb(
         break;
 #endif
     case adiak_uint:
-        set_val(channel, name, Variant(static_cast<uint64_t>(val->v_int)), t, category, subcategory);
+        set_val(args->chB, name, Variant(static_cast<uint64_t>(val->v_int)), t, category, subcategory);
         ++args->count;
         break;
     case adiak_double:
-        set_val(channel, name, Variant(val->v_double), t, category, subcategory);
+        set_val(args->chB, name, Variant(val->v_double), t, category, subcategory);
         ++args->count;
         break;
     case adiak_date:
-        set_val(channel, name, Variant(static_cast<uint64_t>(val->v_long)), t, category, subcategory);
+        set_val(args->chB, name, Variant(static_cast<uint64_t>(val->v_long)), t, category, subcategory);
         ++args->count;
         break;
     case adiak_timeval:
         {
             struct timeval* tval = static_cast<struct timeval*>(val->v_ptr);
-            set_val(channel, name, Variant(tval->tv_sec + tval->tv_usec / 1000000.0), t, category, subcategory);
+            set_val(args->chB, name, Variant(tval->tv_sec + tval->tv_usec / 1000000.0), t, category, subcategory);
             ++args->count;
             break;
         }
@@ -268,7 +266,7 @@ void nameval_cb(
             recursive_unpack(os, val, t);
             std::string str = os.str();
 
-            set_val(channel, name, Variant(CALI_TYPE_STRING, str.c_str(), str.length() + 1), t, category, subcategory);
+            set_val(args->chB, name, Variant(CALI_TYPE_STRING, str.c_str(), str.length() + 1), t, category, subcategory);
             ++args->count;
             break;
         }
@@ -305,8 +303,8 @@ void register_adiak_import(Caliper* c, Channel* channel)
     meta_attr[2] =
         c->create_attribute("adiak.subcategory", CALI_TYPE_STRING, CALI_ATTR_DEFAULT | CALI_ATTR_SKIP_EVENTS);
 
-    channel->events().pre_flush_evt.connect([categories](Caliper*, Channel* channel, SnapshotView) {
-        nameval_usr_args_t args { *channel, 0 };
+    channel->events().pre_flush_evt.connect([categories](Caliper*, ChannelBody* chB, SnapshotView) {
+        nameval_usr_args_t args { chB, 0 };
 
         for (int category : categories)
             adiak_list_namevals(1, static_cast<adiak_category_t>(category), nameval_cb, &args);

--- a/src/services/adiak/AdiakImport.cpp
+++ b/src/services/adiak/AdiakImport.cpp
@@ -214,7 +214,7 @@ void nameval_cb(
         break;
     case adiak_ulonglong:
         set_val(
-            channel,
+            args->chB,
             name,
             Variant(cali_make_variant_from_uint(static_cast<uint64_t>(val->v_longlong))),
             t,
@@ -248,7 +248,7 @@ void nameval_cb(
     case adiak_catstring:
     case adiak_path:
         set_val(
-            channel,
+            args->chB,
             name,
             Variant(CALI_TYPE_STRING, val->v_ptr, strlen(static_cast<const char*>(val->v_ptr))),
             t,
@@ -303,16 +303,18 @@ void register_adiak_import(Caliper* c, Channel* channel)
     meta_attr[2] =
         c->create_attribute("adiak.subcategory", CALI_TYPE_STRING, CALI_ATTR_DEFAULT | CALI_ATTR_SKIP_EVENTS);
 
-    channel->events().pre_flush_evt.connect([categories](Caliper*, ChannelBody* chB, SnapshotView) {
+    std::string channel_name = channel->name();
+
+    channel->events().pre_flush_evt.connect([categories,channel_name](Caliper*, ChannelBody* chB, SnapshotView) {
         nameval_usr_args_t args { chB, 0 };
 
         for (int category : categories)
             adiak_list_namevals(1, static_cast<adiak_category_t>(category), nameval_cb, &args);
 
-        Log(1).stream() << channel->name() << ": adiak_import: Imported " << args.count << " adiak values" << std::endl;
+        Log(1).stream() << channel_name << ": adiak_import: Imported " << args.count << " adiak values" << std::endl;
     });
 
-    Log(1).stream() << channel->name() << ": Registered adiak_import service" << std::endl;
+    Log(1).stream() << channel_name << ": Registered adiak_import service" << std::endl;
 }
 
 } // namespace

--- a/src/services/adiak/test/test_adiak.cpp
+++ b/src/services/adiak/test/test_adiak.cpp
@@ -49,9 +49,10 @@ TEST(AdiakServiceTest, AdiakImport)
     adiak::value("import.vec", vec);
 
     Caliper c;
-    Channel chn = c.get_channel(import_chn_id);
+    Channel channel = c.get_channel(import_chn_id);
+    ChannelBody* chB = channel.body();
 
-    chn.events().pre_flush_evt(&c, &chn, SnapshotView());
+    channel.events().pre_flush_evt(&c, chB, SnapshotView());
 
     Attribute int_attr = c.get_attribute("import.int");
     Attribute str_attr = c.get_attribute("import.str");
@@ -69,9 +70,9 @@ TEST(AdiakServiceTest, AdiakImport)
     EXPECT_EQ(str_attr.get(adk_type_attr).to_string(), std::string("string"));
     EXPECT_EQ(vec_attr.get(adk_type_attr).to_string(), std::string("list of int"));
 
-    EXPECT_EQ(c.get(&chn, int_attr).value().to_int(), 42);
-    EXPECT_EQ(c.get(&chn, str_attr).value().to_string(), std::string("import"));
-    EXPECT_EQ(c.get(&chn, vec_attr).value().to_string(), std::string("{1,4,16}"));
+    EXPECT_EQ(c.get(chB, int_attr).value().to_int(), 42);
+    EXPECT_EQ(c.get(chB, str_attr).value().to_string(), std::string("import"));
+    EXPECT_EQ(c.get(chB, vec_attr).value().to_string(), std::string("{1,4,16}"));
 }
 
 #ifdef ADIAK_HAVE_LONGLONG
@@ -89,9 +90,10 @@ TEST(AdiakServiceTest, AdiakImportLonglong)
     adiak::value("import.vec", vec);
 
     Caliper c;
-    Channel chn = c.get_channel(import_chn_id);
+    Channel channel = c.get_channel(import_chn_id);
+    ChannelBody* chB = channel.body();
 
-    chn.events().pre_flush_evt(&c, &chn, SnapshotView());
+    channel.events().pre_flush_evt(&c, chB, SnapshotView());
 
     Attribute i64_attr = c.get_attribute("import.i64");
     Attribute vec_attr = c.get_attribute("import.vec");
@@ -106,8 +108,8 @@ TEST(AdiakServiceTest, AdiakImportLonglong)
     EXPECT_EQ(i64_attr.get(adk_type_attr).to_string(), std::string("long long"));
     EXPECT_EQ(vec_attr.get(adk_type_attr).to_string(), std::string("list of int"));
 
-    EXPECT_EQ(c.get(&chn, i64_attr).value().to_int64(), llv);
-    EXPECT_EQ(c.get(&chn, vec_attr).value().to_string(), std::string("{1,4,281474976710570}"));
+    EXPECT_EQ(c.get(chB, i64_attr).value().to_int64(), llv);
+    EXPECT_EQ(c.get(chB, vec_attr).value().to_string(), std::string("{1,4,281474976710570}"));
 }
 #endif
 
@@ -124,9 +126,10 @@ TEST(AdiakServiceTest, AdiakImportCategoryFilter)
     adiak_namevalue("do.import.2", static_cast<adiak_category_t>(12345), "import.category", "%s", "hi");
 
     Caliper c;
-    Channel chn = c.get_channel(import_chn_id);
+    Channel channel = c.get_channel(import_chn_id);
+    ChannelBody* chB = channel.body();
 
-    chn.events().pre_flush_evt(&c, &chn, SnapshotView());
+    channel.events().pre_flush_evt(&c, chB, SnapshotView());
 
     Attribute do_import_attr_1   = c.get_attribute("do.import.1");
     Attribute do_import_attr_2   = c.get_attribute("do.import.2");
@@ -147,8 +150,8 @@ TEST(AdiakServiceTest, AdiakImportCategoryFilter)
     EXPECT_EQ(do_import_attr_1.get(adk_caty_attr).to_int(), 424242);
     EXPECT_EQ(do_import_attr_1.get(adk_scat_attr).to_string(), std::string("import.category"));
 
-    EXPECT_EQ(c.get(&chn, do_import_attr_1).value().to_int(), 42);
-    EXPECT_EQ(c.get(&chn, do_import_attr_2).value().to_string(), std::string("hi"));
+    EXPECT_EQ(c.get(chB, do_import_attr_1).value().to_int(), 42);
+    EXPECT_EQ(c.get(chB, do_import_attr_2).value().to_string(), std::string("hi"));
 }
 
 TEST(AdiakServiceTest, AdiakExport)
@@ -159,9 +162,9 @@ TEST(AdiakServiceTest, AdiakExport)
     cali_set_global_string_byname("export.str", "export");
 
     Caliper c;
-    Channel chn = c.get_channel(export_chn_id);
+    Channel channel = c.get_channel(export_chn_id);
 
-    chn.events().pre_flush_evt(&c, &chn, SnapshotView());
+    channel.events().pre_flush_evt(&c, channel.body(), SnapshotView());
 
     std::map<std::string, std::string> res;
 

--- a/src/services/aggregate/Aggregate.cpp
+++ b/src/services/aggregate/Aggregate.cpp
@@ -393,7 +393,7 @@ public:
     {
         Aggregate* instance = new Aggregate(c, chn);
 
-        chn->events().create_attr_evt.connect([instance](Caliper* c, Channel*, const Attribute& attr) {
+        chn->events().create_attr_evt.connect([instance](Caliper* c, const Attribute& attr) {
             instance->create_attribute_cb(c, attr);
         });
         chn->events().post_init_evt.connect([instance](Caliper* c, Channel* chn) { instance->post_init_cb(c, chn); });

--- a/src/services/aggregate/Aggregate.cpp
+++ b/src/services/aggregate/Aggregate.cpp
@@ -70,6 +70,8 @@ class Aggregate
 
     ConfigSet config;
 
+    std::string channel_name;
+
     ThreadDB*      tdb_list = nullptr;
     util::spinlock tdb_lock;
 
@@ -81,7 +83,7 @@ class Aggregate
 
     size_t num_dropped_snapshots;
 
-    ThreadDB* acquire_tdb(Caliper* c, Channel* chn, bool can_alloc)
+    inline ThreadDB* acquire_tdb(Caliper* c, bool can_alloc)
     {
         //   we store a pointer to the thread-local aggregation DB for this channel
         // on the thread's blackboard
@@ -155,13 +157,12 @@ class Aggregate
         info.slot_attr  = c->create_attribute("aggregate.slot", CALI_TYPE_UINT, prop);
     }
 
-    void flush_cb(Caliper* c, Channel* chn, SnapshotFlushFn proc_fn)
+    void flush_cb(Caliper* c, SnapshotFlushFn proc_fn)
     {
         ThreadDB* tdb = nullptr;
 
         {
             std::lock_guard<util::spinlock> g(tdb_lock);
-
             tdb = tdb_list;
         }
 
@@ -173,7 +174,7 @@ class Aggregate
             tdb->stopped.store(false);
         }
 
-        Log(1).stream() << chn->name() << ": Aggregate: flushed " << num_written << " snapshots." << std::endl;
+        Log(1).stream() << channel_name << ": Aggregate: flushed " << num_written << " snapshots." << std::endl;
     }
 
     void clear_cb(Caliper* c, Channel* chn)
@@ -238,9 +239,9 @@ class Aggregate
                             << " entries dropped because aggregation buffers are full!" << std::endl;
     }
 
-    void process_snapshot_cb(Caliper* c, Channel* chn, SnapshotView rec)
+    void process_snapshot_cb(Caliper* c, SnapshotView rec)
     {
-        ThreadDB* tdb = acquire_tdb(c, chn, !c->is_signal());
+        ThreadDB* tdb = acquire_tdb(c, !c->is_signal());
 
         if (tdb && !tdb->stopped.load())
             tdb->db.process_snapshot(c, rec, info);
@@ -282,7 +283,7 @@ class Aggregate
         init_aggregation_attributes(c);
 
         // Initialize master-thread aggregation DB
-        acquire_tdb(c, chn, true);
+        acquire_tdb(c, true);
     }
 
     void create_attribute_cb(Caliper* c, const Attribute& attr)
@@ -291,11 +292,11 @@ class Aggregate
         check_aggregation_attribute(c, attr);
     }
 
-    void create_thread_cb(Caliper* c, Channel* chn) { acquire_tdb(c, chn, true); }
+    void create_thread_cb(Caliper* c) { acquire_tdb(c, true); }
 
-    void release_thread_cb(Caliper* c, Channel* chn)
+    void release_thread_cb(Caliper* c)
     {
-        ThreadDB* tdb = acquire_tdb(c, chn, false);
+        ThreadDB* tdb = acquire_tdb(c, false);
 
         if (tdb)
             tdb->retired.store(true);
@@ -305,10 +306,10 @@ class Aggregate
     {
         // report attribute keys we haven't found
         for (const std::string& s : key_attribute_names)
-            Log(1).stream() << chn->name() << ": Aggregate: warning: key attribute \"" << s << "\" unused" << std::endl;
+            Log(1).stream() << channel_name << ": Aggregate: warning: key attribute \"" << s << "\" unused" << std::endl;
 
         if (num_dropped_snapshots > 0)
-            Log(1).stream() << chn->name() << ": Aggregate: dropped " << num_dropped_snapshots << " snapshots."
+            Log(1).stream() << channel_name << ": Aggregate: dropped " << num_dropped_snapshots << " snapshots."
                             << std::endl;
     }
 
@@ -348,7 +349,7 @@ class Aggregate
         }
     }
 
-    Aggregate(Caliper* c, Channel* chn) : num_dropped_snapshots(0)
+    Aggregate(Caliper* c, Channel* chn) : channel_name { chn->name() }, num_dropped_snapshots(0)
     {
         config = services::init_config_from_spec(chn->config(), s_spec);
 
@@ -397,16 +398,16 @@ public:
         });
         chn->events().post_init_evt.connect([instance](Caliper* c, Channel* chn) { instance->post_init_cb(c, chn); });
         chn->events().create_thread_evt.connect([instance](Caliper* c, Channel* chn) {
-            instance->create_thread_cb(c, chn);
+            instance->create_thread_cb(c);
         });
         chn->events().release_thread_evt.connect([instance](Caliper* c, Channel* chn) {
-            instance->release_thread_cb(c, chn);
+            instance->release_thread_cb(c);
         });
-        chn->events().process_snapshot.connect([instance](Caliper* c, Channel* chn, SnapshotView, SnapshotView rec) {
-            instance->process_snapshot_cb(c, chn, rec);
+        chn->events().process_snapshot.connect([instance](Caliper* c, SnapshotView, SnapshotView rec) {
+            instance->process_snapshot_cb(c, rec);
         });
-        chn->events().flush_evt.connect([instance](Caliper* c, Channel* chn, SnapshotView, SnapshotFlushFn proc_fn) {
-            instance->flush_cb(c, chn, proc_fn);
+        chn->events().flush_evt.connect([instance](Caliper* c, SnapshotView, SnapshotFlushFn proc_fn) {
+            instance->flush_cb(c, proc_fn);
         });
         chn->events().clear_evt.connect([instance](Caliper* c, Channel* chn) { instance->clear_cb(c, chn); });
         chn->events().finish_evt.connect([instance](Caliper* c, Channel* chn) {

--- a/src/services/aggregate/AggregationDB.cpp
+++ b/src/services/aggregate/AggregationDB.cpp
@@ -214,13 +214,11 @@ struct AggregationDB::AggregationDBImpl {
                 }
         } else {
             if (info.group_nested) {
-                // exploit that nested attributes have their own entry
-                for (const Entry& e : rec)
-                    if (e.is_reference() && c->get_attribute(e.node()->attribute()).is_nested()) {
-                        key.builder().append(e);
-                        hash += e.node()->id();
-                        break;
-                    }
+                Entry e = c->get_path_node();
+                if (!e.empty()) {
+                    key.builder().append(e);
+                    hash += e.node()->id();
+                }
             }
 
             Node* node = make_key_node(c, rec, info.ref_key_attrs);

--- a/src/services/alloc/AllocService.cpp
+++ b/src/services/alloc/AllocService.cpp
@@ -150,7 +150,7 @@ class AllocService
 
     void track_mem_snapshot(
         Caliper*       c,
-        Channel*       chn,
+        ChannelBody*   chB,
         cali::Node*    label_node,
         const Variant& v_size,
         const Variant& v_uid,
@@ -162,12 +162,12 @@ class AllocService
                          { alloc_addr_attr, v_addr },
                          { label_node } };
 
-        c->push_snapshot(chn, SnapshotView(4, data));
+        c->push_snapshot(chB, SnapshotView(4, data));
     }
 
     void track_mem_cb(
         Caliper*         c,
-        Channel*         chn,
+        ChannelBody*     chB,
         const void*      ptr,
         const char*      label,
         size_t           elem_size,
@@ -208,7 +208,7 @@ class AllocService
         if (g_track_allocations)
             track_mem_snapshot(
                 c,
-                chn,
+                chB,
                 info.alloc_label_node,
                 Variant(static_cast<int>(total_size)),
                 info.v_uid,
@@ -233,7 +233,7 @@ class AllocService
         }
     }
 
-    void untrack_mem_cb(Caliper* c, Channel* chn, const void* ptr)
+    void untrack_mem_cb(Caliper* c, ChannelBody* chB, const void* ptr)
     {
         AllocInfo info;
 
@@ -256,7 +256,7 @@ class AllocService
         if (g_track_allocations)
             track_mem_snapshot(
                 c,
-                chn,
+                chB,
                 info.free_label_node,
                 Variant(-static_cast<int>(info.total_size)),
                 info.v_uid,
@@ -470,7 +470,7 @@ public:
 
         chn->events().track_mem_evt.connect([instance](
                                                 Caliper*         c,
-                                                Channel*         chn,
+                                                ChannelBody*     chB,
                                                 const void*      ptr,
                                                 const char*      label,
                                                 size_t           elem_size,
@@ -480,10 +480,10 @@ public:
                                                 const Attribute* attrs,
                                                 const Variant*   vals
                                             ) {
-            instance->track_mem_cb(c, chn, ptr, label, elem_size, ndims, dims, n, attrs, vals);
+            instance->track_mem_cb(c, chB, ptr, label, elem_size, ndims, dims, n, attrs, vals);
         });
-        chn->events().untrack_mem_evt.connect([instance](Caliper* c, Channel* chn, const void* ptr) {
-            instance->untrack_mem_cb(c, chn, ptr);
+        chn->events().untrack_mem_evt.connect([instance](Caliper* c, ChannelBody* chB, const void* ptr) {
+            instance->untrack_mem_cb(c, chB, ptr);
         });
 
         if (instance->g_resolve_addresses || instance->g_record_active_mem || instance->g_record_highwatermark)

--- a/src/services/alloc/AllocService.cpp
+++ b/src/services/alloc/AllocService.cpp
@@ -377,7 +377,7 @@ class AllocService
         for (auto attr : address_attrs)
             make_address_attributes(c, attr);
 
-        chn->events().create_attr_evt.connect([this](Caliper* c, Channel* chn, const Attribute& attr) {
+        chn->events().create_attr_evt.connect([this](Caliper* c, const Attribute& attr) {
             this->create_attr_cb(c, attr);
         });
     }

--- a/src/services/alloc/AllocService.cpp
+++ b/src/services/alloc/AllocService.cpp
@@ -307,7 +307,7 @@ class AllocService
         }
     }
 
-    void record_highwatermark(Caliper* c, Channel* chn, SnapshotBuilder& rec)
+    void record_highwatermark(Caliper* c, SnapshotBuilder& rec)
     {
         uint64_t hwm = 0;
 
@@ -321,7 +321,7 @@ class AllocService
         rec.append(region_hwm_attr, Variant(hwm));
     }
 
-    void snapshot_cb(Caliper* c, Channel* chn, SnapshotView info, SnapshotBuilder& snapshot)
+    void snapshot_cb(Caliper* c, SnapshotView info, SnapshotBuilder& snapshot)
     {
         // Record currently active amount of allocated memory
         if (g_record_active_mem)
@@ -331,7 +331,7 @@ class AllocService
             resolve_addresses(c, info, snapshot);
 
         if (g_record_highwatermark)
-            record_highwatermark(c, chn, snapshot);
+            record_highwatermark(c, snapshot);
     }
 
     void make_address_attributes(Caliper* c, const Attribute& attr)
@@ -488,8 +488,8 @@ public:
 
         if (instance->g_resolve_addresses || instance->g_record_active_mem || instance->g_record_highwatermark)
             chn->events().snapshot.connect(
-                [instance](Caliper* c, Channel* chn, SnapshotView info, SnapshotBuilder& snapshot) {
-                    instance->snapshot_cb(c, chn, info, snapshot);
+                [instance](Caliper* c, SnapshotView info, SnapshotBuilder& snapshot) {
+                    instance->snapshot_cb(c, info, snapshot);
                 }
             );
 

--- a/src/services/alloc/AllocStatsService.cpp
+++ b/src/services/alloc/AllocStatsService.cpp
@@ -61,15 +61,11 @@ class AllocStatsService
 
     void track_mem_cb(
         Caliper*         c,
-        Channel*         chn,
         const void*      ptr,
         const char*      label,
         size_t           elem_size,
         size_t           ndims,
-        const size_t*    dims,
-        size_t           nextra,
-        const Attribute* extra_attrs,
-        const Variant*   extra_vals
+        const size_t*    dims
     )
     {
         uint64_t    size = std::accumulate(dims, dims + ndims, elem_size, std::multiplies<size_t>());
@@ -111,7 +107,7 @@ class AllocStatsService
         }
     }
 
-    void untrack_mem_cb(Caliper* c, Channel* chn, const void* ptr)
+    void untrack_mem_cb(Caliper* c, const void* ptr)
     {
         uint64_t addr = reinterpret_cast<uint64_t>(ptr);
         AllocInfo alloc_info { 0, nullptr };
@@ -217,7 +213,7 @@ public:
 
         chn->events().track_mem_evt.connect([instance](
                                                 Caliper*         c,
-                                                Channel*         chn,
+                                                ChannelBody*     chn,
                                                 const void*      ptr,
                                                 const char*      label,
                                                 size_t           elem_size,
@@ -227,10 +223,10 @@ public:
                                                 const Attribute* attrs,
                                                 const Variant*   vals
                                             ) {
-            instance->track_mem_cb(c, chn, ptr, label, elem_size, ndims, dims, n, attrs, vals);
+            instance->track_mem_cb(c, ptr, label, elem_size, ndims, dims);
         });
-        chn->events().untrack_mem_evt.connect([instance](Caliper* c, Channel* chn, const void* ptr) {
-            instance->untrack_mem_cb(c, chn, ptr);
+        chn->events().untrack_mem_evt.connect([instance](Caliper* c, ChannelBody* chB, const void* ptr) {
+            instance->untrack_mem_cb(c, ptr);
         });
         chn->events().flush_evt.connect([instance](Caliper* c, SnapshotView ctx, SnapshotFlushFn flush_fn){
             instance->flush_cb(c, ctx, flush_fn);

--- a/src/services/callpath/Callpath.cpp
+++ b/src/services/callpath/Callpath.cpp
@@ -53,7 +53,7 @@ class Callpath
     uintptr_t caliper_start_addr { 0 };
     uintptr_t caliper_end_addr { 0 };
 
-    void snapshot_cb(Caliper* c, Channel* chn, SnapshotView info, SnapshotBuilder& snapshot)
+    void snapshot_cb(Caliper* c, SnapshotView info, SnapshotBuilder& snapshot)
     {
         Variant v_addr[MAX_PATH];
         Variant v_name[MAX_PATH];
@@ -220,8 +220,8 @@ public:
 
         chn->events().post_init_evt.connect([instance](Caliper* c, Channel* chn) { instance->post_init_evt(c, chn); });
         chn->events().snapshot.connect(
-            [instance](Caliper* c, Channel* chn, SnapshotView info, SnapshotBuilder& snapshot) {
-                instance->snapshot_cb(c, chn, info, snapshot);
+            [instance](Caliper* c, SnapshotView info, SnapshotBuilder& snapshot) {
+                instance->snapshot_cb(c, info, snapshot);
             }
         );
         chn->events().finish_evt.connect([instance](Caliper* c, Channel* chn) { delete instance; });

--- a/src/services/cpuinfo/CpuInfo.cpp
+++ b/src/services/cpuinfo/CpuInfo.cpp
@@ -20,7 +20,7 @@ namespace
 Attribute cpu_attr;
 Attribute node_attr;
 
-void snapshot_cb(Caliper*, Channel*, SnapshotView, SnapshotBuilder& rec)
+void snapshot_cb(Caliper*, SnapshotView, SnapshotBuilder& rec)
 {
 #ifdef SYS_getcpu
     unsigned cpu = 0, node = 0;

--- a/src/services/craypat/CrayPAT.cpp
+++ b/src/services/craypat/CrayPAT.cpp
@@ -60,13 +60,13 @@ class CrayPATBinding : public AnnotationBinding
 
 public:
 
-    void on_begin(Caliper*, Channel*, const Attribute& attr, const Variant& value)
+    void on_begin(Caliper*, const Attribute& attr, const Variant& value)
     {
         if (attr.is_nested() && attr.type() == CALI_TYPE_STRING)
             PAT_region_push(static_cast<const char*>(value.data()));
     }
 
-    void on_end(Caliper*, Channel*, const Attribute& attr, const Variant& value)
+    void on_end(Caliper*, const Attribute& attr, const Variant& value)
     {
         if (attr.is_nested() && attr.type() == CALI_TYPE_STRING)
             PAT_region_pop(static_cast<const char*>(value.data()));

--- a/src/services/cupti/Cupti.cpp
+++ b/src/services/cupti/Cupti.cpp
@@ -312,7 +312,7 @@ class CuptiService
     void finish_cb(Caliper* c, Channel* chn)
     {
         if (Log::verbosity() >= 2) {
-            Log(2).stream() << chn->name() << ": Cupti: processed " << num_api_cb << " API callbacks, "
+        Log(2).stream() << chn->name() << ": Cupti: processed " << num_api_cb << " API callbacks, "
                             << num_resource_cb << " resource callbacks, " << num_sync_cb << " sync callbacks, "
                             << num_nvtx_cb << " nvtx callbacks (" << num_cb << " total)." << std::endl;
 
@@ -323,9 +323,9 @@ class CuptiService
 
     void subscribe_attributes(Caliper* c)
     {
-        channel->events().subscribe_attribute(c, cupti_info.runtime_attr);
-        channel->events().subscribe_attribute(c, cupti_info.driver_attr);
-        channel->events().subscribe_attribute(c, cupti_info.nvtx_range_attr);
+        channel.events().subscribe_attribute(c, cupti_info.runtime_attr);
+        channel.events().subscribe_attribute(c, cupti_info.driver_attr);
+        channel.events().subscribe_attribute(c, cupti_info.nvtx_range_attr);
     }
 
     void create_attributes(Caliper* c)

--- a/src/services/cupti/Cupti.cpp
+++ b/src/services/cupti/Cupti.cpp
@@ -118,7 +118,7 @@ class CuptiService
         Caliper                    c;
 
         c.make_record(4, attr, vals, trigger_info.builder());
-        c.push_snapshot(&channel, trigger_info.view());
+        c.push_snapshot(channel.body(), trigger_info.view());
     }
 
     void handle_context_event(CUcontext context, const Attribute& name_attr, const Variant& v_name)
@@ -140,7 +140,7 @@ class CuptiService
         Caliper                    c;
 
         c.make_record(3, attr, vals, trigger_info.builder());
-        c.push_snapshot(&channel, trigger_info.view());
+        c.push_snapshot(channel.body(), trigger_info.view());
     }
 
     void handle_resource(CUpti_CallbackIdResource cbid, CUpti_ResourceData* cbInfo)

--- a/src/services/cupti/Cupti.cpp
+++ b/src/services/cupti/Cupti.cpp
@@ -425,7 +425,7 @@ public:
             return;
 
         if (instance->event_sampling.is_enabled())
-            chn->events().snapshot.connect([instance](Caliper* c, Channel*, SnapshotView, SnapshotBuilder& rec) {
+            chn->events().snapshot.connect([instance](Caliper* c, SnapshotView, SnapshotBuilder& rec) {
                 instance->snapshot_cb(c, rec);
             });
 

--- a/src/services/cupti/Cupti.cpp
+++ b/src/services/cupti/Cupti.cpp
@@ -321,11 +321,11 @@ class CuptiService
         }
     }
 
-    void subscribe_attributes(Caliper* c, Channel* channel)
+    void subscribe_attributes(Caliper* c)
     {
-        channel->events().subscribe_attribute(c, channel, cupti_info.runtime_attr);
-        channel->events().subscribe_attribute(c, channel, cupti_info.driver_attr);
-        channel->events().subscribe_attribute(c, channel, cupti_info.nvtx_range_attr);
+        channel->events().subscribe_attribute(c, cupti_info.runtime_attr);
+        channel->events().subscribe_attribute(c, cupti_info.driver_attr);
+        channel->events().subscribe_attribute(c, cupti_info.nvtx_range_attr);
     }
 
     void create_attributes(Caliper* c)
@@ -430,7 +430,7 @@ public:
             });
 
         chn->events().post_init_evt.connect([instance](Caliper* c, Channel* channel) {
-            instance->subscribe_attributes(c, channel);
+            instance->subscribe_attributes(c);
         });
         chn->events().pre_finish_evt.connect([instance](Caliper*, Channel*) { instance->pre_finish_cb(); });
         chn->events().finish_evt.connect([instance](Caliper* c, Channel* chn) {

--- a/src/services/cupti/CuptiTrace.cpp
+++ b/src/services/cupti/CuptiTrace.cpp
@@ -866,7 +866,7 @@ class CuptiTraceService
             return;
 
         do_flush(c, SnapshotView(), [c, this](CaliperMetadataAccessInterface& db, const std::vector<Entry>& rec) {
-            c->push_snapshot(&channel, SnapshotView(rec.size(), rec.data()));
+            c->push_snapshot(channel.body(), SnapshotView(rec.size(), rec.data()));
         });
 
         clear_cb(c, &channel);
@@ -929,7 +929,7 @@ class CuptiTraceService
                             << " Triggering on " << attr_name << std::endl;
         } else {
             chn->events().flush_evt.connect([](Caliper* c, SnapshotView info, SnapshotFlushFn flush_fn) {
-                s_instance->flush_cb(c, chn, info, flush_fn);
+                s_instance->flush_cb(c, info, flush_fn);
             });
             chn->events().clear_evt.connect([](Caliper* c, Channel* chn) { s_instance->clear_cb(c, chn); });
         }

--- a/src/services/cupti/CuptiTrace.cpp
+++ b/src/services/cupti/CuptiTrace.cpp
@@ -687,7 +687,7 @@ class CuptiTraceService
         }
     }
 
-    void post_begin_cb(Caliper* c, Channel* chn, const Attribute& attr, const Variant& value)
+    void post_begin_cb(Caliper* c, ChannelBody* chB, const Attribute& attr, const Variant& value)
     {
         if (attr.is_nested()) {
             Entry e = c->get(attr);
@@ -702,7 +702,7 @@ class CuptiTraceService
         }
     }
 
-    void pre_end_cb(Caliper* c, Channel* chn, const Attribute& attr, const Variant& value)
+    void pre_end_cb(Caliper* c, ChannelBody* chB, const Attribute& attr, const Variant& value)
     {
         if (attr.is_nested()) {
             CUptiResult res = cuptiActivityPopExternalCorrelationId(CUPTI_EXTERNAL_CORRELATION_KIND_CUSTOM0, nullptr);
@@ -893,12 +893,12 @@ class CuptiTraceService
 
         if (config.get("correlate_context").to_bool()) {
             chn->events().post_begin_evt.connect(
-                [](Caliper* c, Channel* chn, const Attribute& attr, const Variant& value) {
-                    s_instance->post_begin_cb(c, chn, attr, value);
+                [](Caliper* c, ChannelBody* chB, const Attribute& attr, const Variant& value) {
+                    s_instance->post_begin_cb(c, chB, attr, value);
                 }
             );
-            chn->events().pre_end_evt.connect([](Caliper* c, Channel* chn, const Attribute& attr, const Variant& value
-                                              ) { s_instance->pre_end_cb(c, chn, attr, value); });
+            chn->events().pre_end_evt.connect([](Caliper* c, ChannelBody* chB, const Attribute& attr, const Variant& value
+                                              ) { s_instance->pre_end_cb(c, chB, attr, value); });
         }
 
         if (record_host_timestamp || record_host_duration) {

--- a/src/services/cupti/CuptiTrace.cpp
+++ b/src/services/cupti/CuptiTrace.cpp
@@ -130,6 +130,8 @@ class CuptiTraceService
 
     std::vector<std::string> flush_info_attributes;
 
+    Channel channel;
+
     static CuptiTraceService* s_instance;
 
     typedef std::unordered_map<uint32_t, uint64_t> correlation_id_map_t;
@@ -654,11 +656,10 @@ class CuptiTraceService
     // --- Caliper callbacks
     //
 
-    void flush_cb(Caliper* c, Channel* channel, SnapshotView flush_info, SnapshotFlushFn proc_fn)
+    void flush_cb(Caliper* c, SnapshotView flush_info, SnapshotFlushFn proc_fn)
     {
         size_t num_written = do_flush(c, flush_info, proc_fn);
-
-        Log(1).stream() << channel->name() << ": cuptitrace: Wrote " << num_written << " records." << std::endl;
+        Log(1).stream() << channel.name() << ": cuptitrace: Wrote " << num_written << " records." << std::endl;
     }
 
     void clear_cb(Caliper* c, Channel* chn)
@@ -841,7 +842,7 @@ class CuptiTraceService
             Log(0).stream() << "cuptitrace: selected activity \"" << s << "\" not found!" << std::endl;
     }
 
-    void snapshot_cb(Caliper* c, Channel* chn, const SnapshotView, SnapshotBuilder& snapshot)
+    void snapshot_cb(Caliper* c, const SnapshotView, SnapshotBuilder& snapshot)
     {
         uint64_t timestamp = 0;
         cuptiGetTimestamp(&timestamp);
@@ -855,7 +856,6 @@ class CuptiTraceService
 
     void snapshot_flush_activities_cb(
         Caliper*         c,
-        Channel*         channel,
         SnapshotView     trigger_info,
         SnapshotBuilder& snapshot
     )
@@ -865,11 +865,11 @@ class CuptiTraceService
         if (!flush_trigger_attr || trigger_info.get(flush_trigger_attr).empty())
             return;
 
-        do_flush(c, SnapshotView(), [c, channel](CaliperMetadataAccessInterface& db, const std::vector<Entry>& rec) {
-            c->push_snapshot(channel, SnapshotView(rec.size(), rec.data()));
+        do_flush(c, SnapshotView(), [c, this](CaliperMetadataAccessInterface& db, const std::vector<Entry>& rec) {
+            c->push_snapshot(&channel, SnapshotView(rec.size(), rec.data()));
         });
 
-        clear_cb(c, channel);
+        clear_cb(c, &channel);
 
         ++num_snapshot_flushes;
     }
@@ -904,8 +904,8 @@ class CuptiTraceService
         if (record_host_timestamp || record_host_duration) {
             c->set(timestamp_attr, cali_make_variant_from_uint(starttime));
 
-            chn->events().snapshot.connect([](Caliper* c, Channel* chn, SnapshotView info, SnapshotBuilder& rec) {
-                s_instance->snapshot_cb(c, chn, info, rec);
+            chn->events().snapshot.connect([](Caliper* c, SnapshotView info, SnapshotBuilder& rec) {
+                s_instance->snapshot_cb(c, info, rec);
             });
         }
 
@@ -921,14 +921,14 @@ class CuptiTraceService
                         s_instance->flush_trigger_attr = attr;
                 });
 
-            chn->events().snapshot.connect([](Caliper* c, Channel* channel, SnapshotView info, SnapshotBuilder& rec) {
-                s_instance->snapshot_flush_activities_cb(c, channel, info, rec);
+            chn->events().snapshot.connect([](Caliper* c, SnapshotView info, SnapshotBuilder& rec) {
+                s_instance->snapshot_flush_activities_cb(c, info, rec);
             });
 
             Log(1).stream() << chn->name() << ": cuptitrace: Using flush-on-snapshot mode."
                             << " Triggering on " << attr_name << std::endl;
         } else {
-            chn->events().flush_evt.connect([](Caliper* c, Channel* chn, SnapshotView info, SnapshotFlushFn flush_fn) {
+            chn->events().flush_evt.connect([](Caliper* c, SnapshotView info, SnapshotFlushFn flush_fn) {
                 s_instance->flush_cb(c, chn, info, flush_fn);
             });
             chn->events().clear_evt.connect([](Caliper* c, Channel* chn) { s_instance->clear_cb(c, chn); });
@@ -944,7 +944,7 @@ class CuptiTraceService
         Log(1).stream() << chn->name() << ": Registered cuptitrace service" << std::endl;
     }
 
-    CuptiTraceService(Caliper* c, Channel* chn)
+    CuptiTraceService(Caliper* c, Channel* chn) : channel { *chn }
     {
         Attribute unit_attr       = c->create_attribute("time.unit", CALI_TYPE_STRING, CALI_ATTR_SKIP_EVENTS);
         Attribute addr_class_attr = c->get_attribute("class.memoryaddress");

--- a/src/services/cupti/CuptiTrace.cpp
+++ b/src/services/cupti/CuptiTrace.cpp
@@ -916,7 +916,7 @@ class CuptiTraceService
             flush_trigger_attr    = c->get_attribute(attr_name);
 
             if (!flush_trigger_attr)
-                chn->events().create_attr_evt.connect([attr_name](Caliper* c, Channel*, const Attribute& attr) {
+                chn->events().create_attr_evt.connect([attr_name](Caliper* c, const Attribute& attr) {
                     if (attr.name() == attr_name)
                         s_instance->flush_trigger_attr = attr;
                 });

--- a/src/services/debug/Debug.cpp
+++ b/src/services/debug/Debug.cpp
@@ -28,22 +28,22 @@ void create_attr_cb(Caliper* c, const Attribute& attr)
     Log(1).stream() << "Event: create_attribute (attr=" << attr << ")" << endl;
 }
 
-void begin_cb(Caliper* c, Channel* chn, const Attribute& attr, const Variant& value)
+void begin_cb(Caliper* c, ChannelBody*, const Attribute& attr, const Variant& value)
 {
     lock_guard<mutex> lock(dbg_mutex);
-    Log(1).stream() << chn->name() << ": Event: pre_begin (" << attr.name() << "=" << value << ")" << endl;
+    Log(1).stream() << "Event: pre_begin (" << attr.name() << "=" << value << ")" << endl;
 }
 
-void end_cb(Caliper* c, Channel* chn, const Attribute& attr, const Variant& value)
+void end_cb(Caliper* c, ChannelBody*, const Attribute& attr, const Variant& value)
 {
     lock_guard<mutex> lock(dbg_mutex);
-    Log(1).stream() << chn->name() << ": Event: pre_end (" << attr.name() << "=" << value << ")" << endl;
+    Log(1).stream() << "Event: pre_end (" << attr.name() << "=" << value << ")" << endl;
 }
 
-void set_cb(Caliper* c, Channel* chn, const Attribute& attr, const Variant& value)
+void set_cb(Caliper* c, ChannelBody*, const Attribute& attr, const Variant& value)
 {
     lock_guard<mutex> lock(dbg_mutex);
-    Log(1).stream() << chn->name() << ": Event: pre_set (" << attr.name() << "=" << value << ")" << endl;
+    Log(1).stream() << "Event: pre_set (" << attr.name() << "=" << value << ")" << endl;
 }
 
 void create_thread_cb(Caliper* c, Channel* chn)
@@ -61,7 +61,7 @@ void release_thread_cb(Caliper* c, Channel* chn)
 void snapshot_cb(Caliper* c, SnapshotView, SnapshotBuilder&)
 {
     lock_guard<mutex> lock(dbg_mutex);
-    Log(1).stream() << ": Event: snapshot" << endl;
+    Log(1).stream() << "Event: snapshot" << endl;
 }
 
 std::ostream& print_snapshot_record(Caliper* c, std::ostream& os, SnapshotView rec)

--- a/src/services/debug/Debug.cpp
+++ b/src/services/debug/Debug.cpp
@@ -58,10 +58,10 @@ void release_thread_cb(Caliper* c, Channel* chn)
     Log(1).stream() << chn->name() << ": Event: release_thread" << endl;
 }
 
-void snapshot_cb(Caliper* c, Channel* chn, SnapshotView, SnapshotBuilder&)
+void snapshot_cb(Caliper* c, SnapshotView, SnapshotBuilder&)
 {
     lock_guard<mutex> lock(dbg_mutex);
-    Log(1).stream() << chn->name() << ": Event: snapshot" << endl;
+    Log(1).stream() << ": Event: snapshot" << endl;
 }
 
 std::ostream& print_snapshot_record(Caliper* c, std::ostream& os, SnapshotView rec)
@@ -80,11 +80,10 @@ std::ostream& print_snapshot_record(Caliper* c, std::ostream& os, SnapshotView r
     return (os << " }");
 }
 
-void process_snapshot_cb(Caliper* c, Channel* chn, SnapshotView, SnapshotView rec)
+void process_snapshot_cb(Caliper* c, SnapshotView, SnapshotView rec)
 {
     lock_guard<mutex> lock(dbg_mutex);
-
-    print_snapshot_record(c, Log(1).stream() << chn->name() << ": Event: process_snapshot: ", rec) << std::endl;
+    print_snapshot_record(c, Log(1).stream() << "Event: process_snapshot: ", rec) << std::endl;
 }
 
 void finish_cb(Caliper* c, Channel* chn)

--- a/src/services/debug/Debug.cpp
+++ b/src/services/debug/Debug.cpp
@@ -22,10 +22,10 @@ namespace
 
 mutex dbg_mutex;
 
-void create_attr_cb(Caliper* c, Channel* chn, const Attribute& attr)
+void create_attr_cb(Caliper* c, const Attribute& attr)
 {
     lock_guard<mutex> lock(dbg_mutex);
-    Log(1).stream() << chn->name() << ": Event: create_attribute (attr=" << attr << ")" << endl;
+    Log(1).stream() << "Event: create_attribute (attr=" << attr << ")" << endl;
 }
 
 void begin_cb(Caliper* c, Channel* chn, const Attribute& attr, const Variant& value)

--- a/src/services/event/AsyncEventTrigger.cpp
+++ b/src/services/event/AsyncEventTrigger.cpp
@@ -19,9 +19,9 @@ namespace
 
 void async_event_trigger_register(Caliper*, Channel* channel)
 {
-    channel->events().async_event.connect([](Caliper* c, Channel* chn, SnapshotView info){
+    channel->events().async_event.connect([](Caliper* c, ChannelBody* chB, SnapshotView info){
             if (!info.empty())
-                c->push_snapshot(chn, info);
+                c->push_snapshot(chB, info);
         });
 
     Log(1).stream() << channel->name() << ": registered async_event service\n";

--- a/src/services/event/EventTrigger.cpp
+++ b/src/services/event/EventTrigger.cpp
@@ -151,7 +151,7 @@ class EventTrigger
     // --- Callbacks
     //
 
-    void pre_begin_cb(Caliper* c, Channel* chn, const Attribute& attr, const Variant& value)
+    void pre_begin_cb(Caliper* c, ChannelBody* chB, const Attribute& attr, const Variant& value)
     {
         const Node* marker_node = find_marker(attr);
 
@@ -176,7 +176,7 @@ class EventTrigger
             // Construct the trigger info entry
             if (attr.store_as_value()) {
                 Entry info(begin_attr, value);
-                c->push_snapshot(chn, SnapshotView(info));
+                c->push_snapshot(chB, SnapshotView(info));
             } else {
                 //   As an optimization we attach the trigger info entries directly to their
                 // current context node. This drastically reduces the search space in the
@@ -188,14 +188,14 @@ class EventTrigger
                 // augmented entry in trigger_info.
                 Entry bb_entry = c->get_blackboard_entry(attr);
                 Entry info(c->make_tree_entry(begin_attr, value, bb_entry.empty() ? &event_root_node : bb_entry.node()));
-                c->push_snapshot_replace(chn, SnapshotView(info), bb_entry);
+                c->push_snapshot_replace(chB, SnapshotView(info), bb_entry);
             }
         } else {
-            c->push_snapshot(chn, SnapshotView());
+            c->push_snapshot(chB, SnapshotView());
         }
     }
 
-    void pre_set_cb(Caliper* c, Channel* chn, const Attribute& attr, const Variant& value)
+    void pre_set_cb(Caliper* c, ChannelBody* chB, const Attribute& attr, const Variant& value)
     {
         const Node* marker_node = find_marker(attr);
 
@@ -220,18 +220,18 @@ class EventTrigger
             // Construct the trigger info entry
             if (attr.store_as_value()) {
                 Entry info(set_attr, value);
-                c->push_snapshot(chn, SnapshotView(info));
+                c->push_snapshot(chB, SnapshotView(info));
             } else {
                 Entry bb_entry = c->get_blackboard_entry(attr);
                 Entry info(c->make_tree_entry(set_attr, value, bb_entry.empty() ? &event_root_node : bb_entry.node()));
-                c->push_snapshot_replace(chn, SnapshotView(info), bb_entry);
+                c->push_snapshot_replace(chB, SnapshotView(info), bb_entry);
             }
         } else {
-            c->push_snapshot(chn, SnapshotView());
+            c->push_snapshot(chB, SnapshotView());
         }
     }
 
-    void pre_end_cb(Caliper* c, Channel* chn, const Attribute& attr, const Variant& value)
+    void pre_end_cb(Caliper* c, ChannelBody* chB, const Attribute& attr, const Variant& value)
     {
         const Node* marker_node = find_marker(attr);
 
@@ -256,15 +256,15 @@ class EventTrigger
             // Construct the trigger info entry
             if (attr.store_as_value()) {
                 Entry info[2] = { Entry(end_attr, value), region_count_entry };
-                c->push_snapshot(chn, SnapshotView(2, info));
+                c->push_snapshot(chB, SnapshotView(2, info));
             } else {
                 Entry bb_entry = c->get_blackboard_entry(attr);
                 Node* node = c->make_tree_entry(end_attr, value, bb_entry.node());
                 Entry info[2] = { Entry(node), region_count_entry };
-                c->push_snapshot_replace(chn, SnapshotView(2, info), bb_entry);
+                c->push_snapshot_replace(chB, SnapshotView(2, info), bb_entry);
             }
         } else {
-            c->push_snapshot(chn, SnapshotView(region_count_entry));
+            c->push_snapshot(chB, SnapshotView(region_count_entry));
         }
     }
 
@@ -355,18 +355,18 @@ public:
             instance->check_attribute(c, attr);
         });
         chn->events().pre_begin_evt.connect(
-            [instance](Caliper* c, Channel* chn, const Attribute& attr, const Variant& value) {
-                instance->pre_begin_cb(c, chn, attr, value);
+            [instance](Caliper* c, ChannelBody* chB, const Attribute& attr, const Variant& value) {
+                instance->pre_begin_cb(c, chB, attr, value);
             }
         );
         chn->events().pre_set_evt.connect(
-            [instance](Caliper* c, Channel* chn, const Attribute& attr, const Variant& value) {
-                instance->pre_set_cb(c, chn, attr, value);
+            [instance](Caliper* c, ChannelBody* chB, const Attribute& attr, const Variant& value) {
+                instance->pre_set_cb(c, chB, attr, value);
             }
         );
         chn->events().pre_end_evt.connect(
-            [instance](Caliper* c, Channel* chn, const Attribute& attr, const Variant& value) {
-                instance->pre_end_cb(c, chn, attr, value);
+            [instance](Caliper* c, ChannelBody* chB, const Attribute& attr, const Variant& value) {
+                instance->pre_end_cb(c, chB, attr, value);
             }
         );
         chn->events().finish_evt.connect([instance](Caliper*, Channel*) { delete instance; });

--- a/src/services/event/EventTrigger.cpp
+++ b/src/services/event/EventTrigger.cpp
@@ -180,10 +180,14 @@ class EventTrigger
                 c->make_record(2, attrs, vals, trigger_info.builder(), &event_root_node);
                 c->push_snapshot(chn, trigger_info.view());
             } else {
-                //   As an optimization we attach the trigger info entries directly to its
-                // current context node. This drastically reduces the search space for the
-                // trigger info nodes and needs one less slot in the snapshot record.
-                // We use the special-purpose push_snapshot_replace() function for this.
+                //   As an optimization we attach the trigger info entries directly to their
+                // current context node. This drastically reduces the search space in the
+                // metadata tree as otherwise all trigger info nodes anywhere would be in a
+                // very wide branch under a single root node which has to be sequentially
+                // searched. We also now occupy one less slot in the snapshot record.
+                //   To do this we use the special-purpose push_snapshot_replace() function
+                // to replace the original blackboard entry in the snapshot record with the
+                // augmented entry in trigger_info.
                 Entry bb_entry = c->get_blackboard_entry(attr);
                 c->make_record(2, attrs, vals, trigger_info.builder(), bb_entry.empty() ? &event_root_node : bb_entry.node());
                 c->push_snapshot_replace(chn, trigger_info.view(), bb_entry);

--- a/src/services/io/IOService.cpp
+++ b/src/services/io/IOService.cpp
@@ -56,7 +56,7 @@ void handle_unique_record_data(Caliper& c, Channel& channel, curious_read_record
     if (record->bytes_read > 0) {
         // ...we care about how much data was read
         Entry data(io_bytes_read_attr, cali_make_variant_from_uint(record->bytes_read));
-        c.push_snapshot(&channel, SnapshotView(1, &data));
+        c.push_snapshot(channel.body(), SnapshotView(1, &data));
     }
 }
 
@@ -66,7 +66,7 @@ void handle_unique_record_data(Caliper& c, Channel& channel, curious_write_recor
     if (record->bytes_written > 0) {
         // ...we care about how much data was written
         Entry data(io_bytes_written_attr, cali_make_variant_from_uint(record->bytes_written));
-        c.push_snapshot(&channel, SnapshotView(1, &data));
+        c.push_snapshot(channel.body(), SnapshotView(1, &data));
     }
 }
 

--- a/src/services/io/IOService.cpp
+++ b/src/services/io/IOService.cpp
@@ -126,7 +126,7 @@ void handle_io(curious_callback_type_t type, void* usr_data, Record* record)
 
 void init_curious_in_channel(Caliper* c, Channel* channel)
 {
-    channel->events().subscribe_attribute(c, channel, io_region_attr);
+    channel->events().subscribe_attribute(c, io_region_attr);
 
     curious_t curious_inst = curious_init(CURIOUS_ALL_APIS);
     auto      data         = std::unique_ptr<user_data_t>(new user_data_t { curious_inst, *channel });

--- a/src/services/kokkos/KokkosLookup.cpp
+++ b/src/services/kokkos/KokkosLookup.cpp
@@ -260,14 +260,14 @@ class KokkosLookup
         Caliper c;
         Variant v_space(handle.name);
 
-        c.memory_region_begin(&m_channel, ptr, name, 1, 1, &size, 1, &m_space_attr, &v_space);
+        c.memory_region_begin(m_channel.body(), ptr, name, 1, 1, &size, 1, &m_space_attr, &v_space);
         ++m_num_spaces;
     }
 
     void kokkos_deallocate(const void* const ptr)
     {
         Caliper c;
-        c.memory_region_end(&m_channel, ptr);
+        c.memory_region_end(m_channel.body(), ptr);
     }
 
     void kokkos_deepcopy(const void* dst, const void* src, uint64_t size)
@@ -278,7 +278,7 @@ class KokkosLookup
                          { m_src_attr, Variant(CALI_TYPE_ADDR, &src, sizeof(void*)) },
                          { m_size_attr, Variant(cali_make_variant_from_uint(size)) } };
 
-        c.push_snapshot(&m_channel, SnapshotView(3, data));
+        c.push_snapshot(m_channel.body(), SnapshotView(3, data));
 
         ++m_num_copies;
     }

--- a/src/services/ldms/LdmsForwarder.cpp
+++ b/src/services/ldms/LdmsForwarder.cpp
@@ -231,7 +231,7 @@ class LdmsForwarder
 {
     RegionProfile profile;
 
-    void snapshot(Caliper* c, Channel*)
+    void snapshot(Caliper* c)
     {
         Entry e    = c->get(c->get_attribute("mpi.rank"));
         int   rank = e.empty() ? -1 : e.value().to_int();
@@ -258,8 +258,8 @@ public:
         channel->events().post_init_evt.connect([instance](Caliper* c, Channel* channel) {
             instance->post_init(c, channel);
         });
-        channel->events().snapshot.connect([instance](Caliper* c, Channel* channel, SnapshotView, SnapshotBuilder&) {
-            instance->snapshot(c, channel);
+        channel->events().snapshot.connect([instance](Caliper* c, SnapshotView, SnapshotBuilder&) {
+            instance->snapshot(c);
         });
         channel->events().finish_evt.connect([instance](Caliper* c, Channel* chn) { delete instance; });
 

--- a/src/services/libpfm/Libpfm.cpp
+++ b/src/services/libpfm/Libpfm.cpp
@@ -628,7 +628,7 @@ class LibpfmService
 
     struct DataSrcAttrs data_src_attrs;
 
-    void postprocess_snapshot_cb(Caliper* c, Channel* chn, std::vector<Entry>& rec)
+    void postprocess_snapshot_cb(Caliper* c, std::vector<Entry>& rec)
     {
         // Decode data_src encoding
         if (sample_attributes & PERF_SAMPLE_DATA_SRC) {
@@ -738,11 +738,11 @@ public:
         });
 
         if (sI->enable_sampling)
-            chn->events().postprocess_snapshot.connect([](Caliper* c, Channel* chn, std::vector<Entry>& rec) {
-                sI->postprocess_snapshot_cb(c, chn, rec);
+            chn->events().postprocess_snapshot.connect([](Caliper* c, std::vector<Entry>& rec) {
+                sI->postprocess_snapshot_cb(c, rec);
             });
         if (sI->record_counters)
-            chn->events().snapshot.connect([](Caliper*, Channel*, SnapshotView, SnapshotBuilder& rec) {
+            chn->events().snapshot.connect([](Caliper*, SnapshotView, SnapshotBuilder& rec) {
                 sI->snapshot_cb(rec);
             });
 

--- a/src/services/memusage/MemStatService.cpp
+++ b/src/services/memusage/MemStatService.cpp
@@ -102,7 +102,7 @@ public:
 
         MemstatService* instance = new MemstatService(c, fd);
 
-        channel->events().snapshot.connect([instance](Caliper* c, Channel*, SnapshotView, SnapshotBuilder& rec) {
+        channel->events().snapshot.connect([instance](Caliper* c, SnapshotView, SnapshotBuilder& rec) {
             instance->snapshot_cb(c, rec);
         });
         channel->events().finish_evt.connect([instance](Caliper* c, Channel* channel) {

--- a/src/services/monitor/RegionMonitor.cpp
+++ b/src/services/monitor/RegionMonitor.cpp
@@ -34,7 +34,7 @@ class RegionMonitor
 
     unsigned m_num_measured;
 
-    void post_begin_cb(Caliper* c, Channel* channel, const Attribute& attr, const Variant&)
+    void post_begin_cb(Caliper* c, ChannelBody* chB, const Attribute& attr, const Variant&)
     {
         if (!attr.is_nested())
             return;
@@ -54,14 +54,14 @@ class RegionMonitor
         if (it != m_tracking_regions.end()) {
             if (it->second.inclusive_time > 2.0 * it->second.child_time) {
                 SnapshotBuilder tmp;
-                c->pull_snapshot(channel, SnapshotView(), tmp);
+                c->pull_snapshot(chB, SnapshotView(), tmp);
                 m_measuring = true;
                 m_skip      = 1;
             }
         }
     }
 
-    void pre_end_cb(Caliper* c, Channel* channel, const Attribute& attr, const Variant&)
+    void pre_end_cb(Caliper* c, ChannelBody* chB, const Attribute& attr, const Variant&)
     {
         if (!attr.is_nested())
             return;
@@ -72,7 +72,7 @@ class RegionMonitor
 
             m_measuring = false;
             ++m_num_measured;
-            c->push_snapshot(channel, SnapshotView());
+            c->push_snapshot(chB, SnapshotView());
         }
 
         const Node* node = c->get(attr).node();
@@ -132,13 +132,13 @@ public:
         RegionMonitor* instance = new RegionMonitor(c, channel);
 
         channel->events().post_begin_evt.connect(
-            [instance](Caliper* c, Channel* channel, const Attribute& attr, const Variant& val) {
-                instance->post_begin_cb(c, channel, attr, val);
+            [instance](Caliper* c, ChannelBody* chB, const Attribute& attr, const Variant& val) {
+                instance->post_begin_cb(c, chB, attr, val);
             }
         );
         channel->events().pre_end_evt.connect(
-            [instance](Caliper* c, Channel* channel, const Attribute& attr, const Variant& val) {
-                instance->pre_end_cb(c, channel, attr, val);
+            [instance](Caliper* c, ChannelBody* chB, const Attribute& attr, const Variant& val) {
+                instance->pre_end_cb(c, chB, attr, val);
             }
         );
         channel->events().finish_evt.connect([instance](Caliper* c, Channel* channel) {

--- a/src/services/monitor/ThreadMonitor.cpp
+++ b/src/services/monitor/ThreadMonitor.cpp
@@ -37,7 +37,7 @@ class ThreadMonitor
     {
         Caliper c;
         Entry   data(monitor_attr, cali_make_variant_from_int(num_events++));
-        c.push_snapshot(&channel, SnapshotView(1, &data));
+        c.push_snapshot(channel.body(), SnapshotView(1, &data));
     }
 
     // the main monitor loop

--- a/src/services/monitor/Timeseries.cpp
+++ b/src/services/monitor/Timeseries.cpp
@@ -31,6 +31,8 @@ inline double get_timestamp()
 
 class TimeseriesService
 {
+    Channel   m_channel;
+
     Attribute m_timestamp_attr;
     Attribute m_snapshot_attr;
     Attribute m_duration_attr;
@@ -41,7 +43,7 @@ class TimeseriesService
 
     static const char* s_profile_spec;
 
-    void snapshot_cb(Caliper* c, Channel* channel, SnapshotView info, SnapshotBuilder& srec)
+    void snapshot_cb(Caliper* c, SnapshotView info, SnapshotBuilder& srec)
     {
         double  ts_now = get_timestamp();
         Variant v_prev = c->exchange(m_timestamp_attr, Variant(ts_now));
@@ -54,14 +56,14 @@ class TimeseriesService
         c->flush(
             &prof_chn,
             info,
-            [c, channel, info, ts_entries](CaliperMetadataAccessInterface&, const std::vector<Entry>& frec) {
+            [this, c, info, ts_entries](CaliperMetadataAccessInterface&, const std::vector<Entry>& frec) {
                 std::vector<Entry> rec;
                 rec.reserve(frec.size() + info.size() + ts_entries.size());
                 rec.insert(rec.end(), frec.begin(), frec.end());
                 rec.insert(rec.end(), info.begin(), info.end());
                 rec.insert(rec.end(), ts_entries.begin(), ts_entries.end());
 
-                channel->events().process_snapshot(c, channel, SnapshotView(), SnapshotView(rec.size(), rec.data()));
+                m_channel.events().process_snapshot(c, SnapshotView(), SnapshotView(rec.size(), rec.data()));
             }
         );
 
@@ -85,7 +87,7 @@ class TimeseriesService
     }
 
     TimeseriesService(Caliper* c, Channel* channel, ConfigManager::ChannelPtr prof)
-        : m_timeprofile { prof }, m_snapshots { 0 }
+        : m_channel { *channel }, m_timeprofile { prof }, m_snapshots { 0 }
     {
         m_timestamp_attr =
             c->create_attribute("timeseries.starttime", CALI_TYPE_DOUBLE, CALI_ATTR_ASVALUE | CALI_ATTR_SKIP_EVENTS);
@@ -129,8 +131,8 @@ public:
         TimeseriesService* instance = new TimeseriesService(c, channel, profile);
 
         channel->events().snapshot.connect(
-            [instance](Caliper* c, Channel* channel, SnapshotView info, SnapshotBuilder& rec) {
-                instance->snapshot_cb(c, channel, info, rec);
+            [instance](Caliper* c, SnapshotView info, SnapshotBuilder& rec) {
+                instance->snapshot_cb(c, info, rec);
             }
         );
         channel->events().post_init_evt.connect([instance](Caliper* c, Channel* channel) {

--- a/src/services/monitor/Timeseries.cpp
+++ b/src/services/monitor/Timeseries.cpp
@@ -54,7 +54,7 @@ class TimeseriesService
         Channel prof_chn = m_timeprofile->channel();
 
         c->flush(
-            &prof_chn,
+            prof_chn.body(),
             info,
             [this, c, info, ts_entries](CaliperMetadataAccessInterface&, const std::vector<Entry>& frec) {
                 std::vector<Entry> rec;

--- a/src/services/mpireport/MpiReport.cpp
+++ b/src/services/mpireport/MpiReport.cpp
@@ -35,6 +35,7 @@ class MpiReport
     QuerySpec   m_local_spec;
     std::string m_filename;
     bool        m_append_to_file;
+    std::string m_channel_name;
 
     void write_output_cb(Caliper* c, ChannelBody* chB, SnapshotView flush_info)
     {
@@ -47,7 +48,7 @@ class MpiReport
         PMPI_Finalized(&finalized);
 
         if (finalized) {
-            Log(0).stream() << channel->name() << ": mpireport: MPI is already finalized. Cannot aggregate output."
+            Log(0).stream() << m_channel_name << ": mpireport: MPI is already finalized. Cannot aggregate output."
                             << std::endl;
             return;
         }
@@ -91,8 +92,13 @@ class MpiReport
         });
     }
 
-    MpiReport(const QuerySpec& cross_spec, const QuerySpec& local_spec, const std::string& filename, bool append)
-        : m_cross_spec(cross_spec), m_local_spec(local_spec), m_filename(filename), m_append_to_file(append)
+    MpiReport(
+        const QuerySpec& cross_spec,
+        const QuerySpec& local_spec,
+        const std::string& filename,
+        bool append,
+        const std::string& chname)
+        : m_cross_spec(cross_spec), m_local_spec(local_spec), m_filename(filename), m_append_to_file(append), m_channel_name(chname)
     {}
 
 public:
@@ -120,7 +126,8 @@ public:
             cross_parser.spec(),
             local_parser.spec(),
             config.get("filename").to_string(),
-            config.get("append").to_bool()
+            config.get("append").to_bool(),
+            chn->name()
         );
 
         chn->events().write_output_evt.connect([instance](Caliper* c, ChannelBody* chB, SnapshotView info) {

--- a/src/services/mpireport/MpiReport.cpp
+++ b/src/services/mpireport/MpiReport.cpp
@@ -36,7 +36,7 @@ class MpiReport
     std::string m_filename;
     bool        m_append_to_file;
 
-    void write_output_cb(Caliper* c, Channel* channel, SnapshotView flush_info)
+    void write_output_cb(Caliper* c, ChannelBody* chB, SnapshotView flush_info)
     {
         // check if we can use MPI
 
@@ -71,7 +71,7 @@ class MpiReport
                 stream.set_filename(m_filename.c_str(), *c, std::vector<Entry>(flush_info.begin(), flush_info.end()));
         }
 
-        collective_flush(stream, *c, *channel, flush_info, m_local_spec, m_cross_spec, comm);
+        collective_flush(stream, *c, chB, flush_info, m_local_spec, m_cross_spec, comm);
 
         if (comm != MPI_COMM_NULL)
             MPI_Comm_free(&comm);
@@ -87,7 +87,7 @@ class MpiReport
         }
 
         events->mpi_finalize_evt.connect([](Caliper* c, Channel* channel) {
-            c->flush_and_write(channel, SnapshotView());
+            c->flush_and_write(channel->body(), SnapshotView());
         });
     }
 
@@ -123,8 +123,8 @@ public:
             config.get("append").to_bool()
         );
 
-        chn->events().write_output_evt.connect([instance](Caliper* c, Channel* chn, SnapshotView info) {
-            instance->write_output_cb(c, chn, info);
+        chn->events().write_output_evt.connect([instance](Caliper* c, ChannelBody* chB, SnapshotView info) {
+            instance->write_output_cb(c, chB, info);
         });
         chn->events().finish_evt.connect([instance](Caliper*, Channel*) { delete instance; });
 

--- a/src/services/mpiwrap/MpiPattern.h
+++ b/src/services/mpiwrap/MpiPattern.h
@@ -16,6 +16,8 @@ namespace cali
 class Caliper;
 class Channel;
 
+struct ChannelBody;
+
 class MpiPattern
 {
     struct MpiPatternImpl;
@@ -34,10 +36,10 @@ public:
 
     // --- point-to-point
 
-    void handle_send(Caliper* c, Channel* chn, int count, MPI_Datatype type, int dest, int tag, MPI_Comm comm);
+    void handle_send(Caliper* c, ChannelBody* chB, int count, MPI_Datatype type, int dest, int tag, MPI_Comm comm);
     void handle_send_init(
         Caliper*     c,
-        Channel*     chn,
+        ChannelBody* chB,
         int          count,
         MPI_Datatype type,
         int          dest,
@@ -48,7 +50,7 @@ public:
 
     void handle_recv(
         Caliper*     c,
-        Channel*     chn,
+        ChannelBody* chB,
         int          count,
         MPI_Datatype type,
         int          src,
@@ -58,7 +60,7 @@ public:
     );
     void handle_irecv(
         Caliper*     c,
-        Channel*     chn,
+        ChannelBody* chB,
         int          count,
         MPI_Datatype type,
         int          src,
@@ -68,7 +70,7 @@ public:
     );
     void handle_recv_init(
         Caliper*     c,
-        Channel*     chn,
+        ChannelBody* chB,
         int          count,
         MPI_Datatype type,
         int          src,
@@ -77,23 +79,23 @@ public:
         MPI_Request* req
     );
 
-    void handle_start(Caliper* c, Channel* chn, int nreq, MPI_Request* reqs);
-    void handle_pre_completion(Caliper *c, Channel* chn, int nreq, MPI_Request* reqs);
-    void handle_completion(Caliper* c, Channel* chn, int nreq, MPI_Request* reqs, MPI_Status* statuses);
+    void handle_start(Caliper* c, ChannelBody* chB, int nreq, MPI_Request* reqs);
+    void handle_pre_completion(Caliper *c, ChannelBody* chB, int nreq, MPI_Request* reqs);
+    void handle_completion(Caliper* c, ChannelBody* chB, int nreq, MPI_Request* reqs, MPI_Status* statuses);
 
-    void handle_comm_begin(Caliper* c, Channel* chn); //region_begin
-    void handle_comm_end(Caliper* c, Channel* chn);   //region_end
+    void handle_comm_begin(Caliper* c, ChannelBody* chB); //region_begin
+    void handle_comm_end(Caliper* c, ChannelBody* chB);   //region_end
 
-    void request_free(Caliper* c, Channel* chn, MPI_Request* req);
+    void request_free(Caliper* c, ChannelBody* chB, MPI_Request* req);
 
     // --- collectives
 
-    void handle_12n(Caliper* c, Channel* chn, int count, MPI_Datatype type, int root, MPI_Comm comm);
-    void handle_n21(Caliper* c, Channel* chn, int count, MPI_Datatype type, int root, MPI_Comm comm);
-    void handle_n2n(Caliper* c, Channel* chn, int count, MPI_Datatype type, MPI_Comm comm);
-    void handle_barrier(Caliper* c, Channel* chn, MPI_Comm comm);
-    void handle_init(Caliper* c, Channel* chn);
-    void handle_finalize(Caliper* c, Channel* chn);
+    void handle_12n(Caliper* c, ChannelBody* chB, int count, MPI_Datatype type, int root, MPI_Comm comm);
+    void handle_n21(Caliper* c, ChannelBody* chB, int count, MPI_Datatype type, int root, MPI_Comm comm);
+    void handle_n2n(Caliper* c, ChannelBody* chB, int count, MPI_Datatype type, MPI_Comm comm);
+    void handle_barrier(Caliper* c, ChannelBody* chB, MPI_Comm comm);
+    void handle_init(Caliper* c, ChannelBody* chB);
+    void handle_finalize(Caliper* c, ChannelBody* chB);
 };
 
 } // namespace cali

--- a/src/services/mpiwrap/MpiTracing.h
+++ b/src/services/mpiwrap/MpiTracing.h
@@ -15,6 +15,7 @@ namespace cali
 
 class Caliper;
 class Channel;
+struct ChannelBody;
 
 class MpiTracing
 {
@@ -34,10 +35,10 @@ public:
 
     // --- point-to-point
 
-    void handle_send(Caliper* c, Channel* chn, int count, MPI_Datatype type, int dest, int tag, MPI_Comm comm);
+    void handle_send(Caliper* c, ChannelBody* chB, int count, MPI_Datatype type, int dest, int tag, MPI_Comm comm);
     void handle_send_init(
         Caliper*     c,
-        Channel*     chn,
+        ChannelBody* chB,
         int          count,
         MPI_Datatype type,
         int          dest,
@@ -48,7 +49,7 @@ public:
 
     void handle_recv(
         Caliper*     c,
-        Channel*     chn,
+        ChannelBody* chB,
         int          count,
         MPI_Datatype type,
         int          src,
@@ -58,7 +59,7 @@ public:
     );
     void handle_irecv(
         Caliper*     c,
-        Channel*     chn,
+        ChannelBody* chB,
         int          count,
         MPI_Datatype type,
         int          src,
@@ -68,7 +69,7 @@ public:
     );
     void handle_recv_init(
         Caliper*     c,
-        Channel*     chn,
+        ChannelBody* chB,
         int          count,
         MPI_Datatype type,
         int          src,
@@ -77,19 +78,19 @@ public:
         MPI_Request* req
     );
 
-    void handle_start(Caliper* c, Channel* chn, int nreq, MPI_Request* reqs);
-    void handle_completion(Caliper* c, Channel* chn, int nreq, MPI_Request* reqs, MPI_Status* statuses);
+    void handle_start(Caliper* c, ChannelBody* chB, int nreq, MPI_Request* reqs);
+    void handle_completion(Caliper* c, ChannelBody* chB, int nreq, MPI_Request* reqs, MPI_Status* statuses);
 
-    void request_free(Caliper* c, Channel* chn, MPI_Request* req);
+    void request_free(Caliper* c, ChannelBody* chB, MPI_Request* req);
 
     // --- collectives
 
-    void handle_12n(Caliper* c, Channel* chn, int count, MPI_Datatype type, int root, MPI_Comm comm);
-    void handle_n21(Caliper* c, Channel* chn, int count, MPI_Datatype type, int root, MPI_Comm comm);
-    void handle_n2n(Caliper* c, Channel* chn, int count, MPI_Datatype type, MPI_Comm comm);
-    void handle_barrier(Caliper* c, Channel* chn, MPI_Comm comm);
-    void handle_init(Caliper* c, Channel* chn);
-    void handle_finalize(Caliper* c, Channel* chn);
+    void handle_12n(Caliper* c, ChannelBody* chB, int count, MPI_Datatype type, int root, MPI_Comm comm);
+    void handle_n21(Caliper* c, ChannelBody* chB, int count, MPI_Datatype type, int root, MPI_Comm comm);
+    void handle_n2n(Caliper* c, ChannelBody* chB, int count, MPI_Datatype type, MPI_Comm comm);
+    void handle_barrier(Caliper* c, ChannelBody* chB, MPI_Comm comm);
+    void handle_init(Caliper* c, ChannelBody* chB);
+    void handle_finalize(Caliper* c, ChannelBody* chB);
 };
 
 } // namespace cali

--- a/src/services/mpiwrap/Wrapper.w
+++ b/src/services/mpiwrap/Wrapper.w
@@ -272,7 +272,7 @@ mpi_init_cb(Caliper* c, Channel* chn)
 void
 post_init_cb(Caliper* c, Channel* channel)
 {
-    channel->events().subscribe_attribute(c, channel, mpifn_attr);
+    channel->events().subscribe_attribute(c, mpifn_attr);
 
     int initialized = 0;
     int finalized   = 0;

--- a/src/services/mpiwrap/Wrapper.w
+++ b/src/services/mpiwrap/Wrapper.w
@@ -303,9 +303,9 @@ post_init_cb(Caliper* c, Channel* channel)
         for (MpiWrapperConfig* mwc = MpiWrapperConfig::get_wrapper_config(); mwc; mwc = mwc->next){
             if (mwc->enable_{{func}} && mwc->channel.is_active()) {
                 if (mwc->enable_msg_tracing)
-                    mwc->tracing.handle_send(&c, &mwc->channel, {{1}}, {{2}}, {{3}}, {{4}}, {{5}});
+                    mwc->tracing.handle_send(&c, mwc->channel.body(), {{1}}, {{2}}, {{3}}, {{4}}, {{5}});
                 if (mwc->enable_msg_pattern)
-                    mwc->pattern.handle_send(&c, &mwc->channel, {{1}}, {{2}}, {{3}}, {{4}}, {{5}});
+                    mwc->pattern.handle_send(&c, mwc->channel.body(), {{1}}, {{2}}, {{3}}, {{4}}, {{5}});
             }
         }
 
@@ -329,9 +329,9 @@ post_init_cb(Caliper* c, Channel* channel)
         for (MpiWrapperConfig* mwc = MpiWrapperConfig::get_wrapper_config(); mwc; mwc = mwc->next){
             if (mwc->enable_{{func}} && mwc->channel.is_active()) {
                 if (mwc->enable_msg_tracing)
-                    mwc->tracing.handle_send_init(&c, &mwc->channel, {{1}}, {{2}}, {{3}}, {{4}}, {{5}}, {{6}});
+                    mwc->tracing.handle_send_init(&c, mwc->channel.body(), {{1}}, {{2}}, {{3}}, {{4}}, {{5}}, {{6}});
                 if (mwc->enable_msg_pattern)
-                    mwc->pattern.handle_send_init(&c, &mwc->channel, {{1}}, {{2}}, {{3}}, {{4}}, {{5}}, {{6}});
+                    mwc->pattern.handle_send_init(&c, mwc->channel.body(), {{1}}, {{2}}, {{3}}, {{4}}, {{5}}, {{6}});
             }
         }
 
@@ -360,9 +360,9 @@ post_init_cb(Caliper* c, Channel* channel)
         for (MpiWrapperConfig* mwc = MpiWrapperConfig::get_wrapper_config(); mwc; mwc = mwc->next){
             if (mwc->enable_{{func}} && mwc->channel.is_active()) {
                 if (mwc->enable_msg_tracing)
-                    mwc->tracing.handle_recv(&c, &mwc->channel, {{1}}, {{2}}, {{3}}, {{4}}, {{5}}, {{6}});
+                    mwc->tracing.handle_recv(&c, mwc->channel.body(), {{1}}, {{2}}, {{3}}, {{4}}, {{5}}, {{6}});
                 if (mwc->enable_msg_pattern)
-                    mwc->pattern.handle_recv(&c, &mwc->channel, {{1}}, {{2}}, {{3}}, {{4}}, {{5}}, {{6}});
+                    mwc->pattern.handle_recv(&c, mwc->channel.body(), {{1}}, {{2}}, {{3}}, {{4}}, {{5}}, {{6}});
             }
        }
 
@@ -391,12 +391,12 @@ post_init_cb(Caliper* c, Channel* channel)
         for (MpiWrapperConfig* mwc = MpiWrapperConfig::get_wrapper_config(); mwc; mwc = mwc->next) {
             if (mwc->enable_{{func}} && mwc->channel.is_active()) {
                 if (mwc->enable_msg_tracing) {
-                    mwc->tracing.handle_send(&c, &mwc->channel, {{1}}, {{2}}, {{3}}, {{4}}, {{10}});
-                    mwc->tracing.handle_recv(&c, &mwc->channel, {{6}}, {{7}}, {{8}}, {{9}}, {{10}}, {{11}});
+                    mwc->tracing.handle_send(&c, mwc->channel.body(), {{1}}, {{2}}, {{3}}, {{4}}, {{10}});
+                    mwc->tracing.handle_recv(&c, mwc->channel.body(), {{6}}, {{7}}, {{8}}, {{9}}, {{10}}, {{11}});
                 }
                 if (mwc->enable_msg_pattern) {
-                    mwc->pattern.handle_send(&c, &mwc->channel, {{1}}, {{2}}, {{3}}, {{4}}, {{10}});
-                    mwc->pattern.handle_recv(&c, &mwc->channel, {{6}}, {{7}}, {{8}}, {{9}}, {{10}}, {{11}});
+                    mwc->pattern.handle_send(&c, mwc->channel.body(), {{1}}, {{2}}, {{3}}, {{4}}, {{10}});
+                    mwc->pattern.handle_recv(&c, mwc->channel.body(), {{6}}, {{7}}, {{8}}, {{9}}, {{10}}, {{11}});
                 }
             }
         }
@@ -426,12 +426,12 @@ post_init_cb(Caliper* c, Channel* channel)
         for (MpiWrapperConfig* mwc = MpiWrapperConfig::get_wrapper_config(); mwc; mwc = mwc->next) {
             if (mwc->enable_{{func}} && mwc->channel.is_active()) {
                 if (mwc->enable_msg_tracing) {
-                    mwc->tracing.handle_send(&c, &mwc->channel, {{1}}, {{2}}, {{3}}, {{4}}, {{7}});
-                    mwc->tracing.handle_recv(&c, &mwc->channel, {{1}}, {{2}}, {{5}}, {{6}}, {{7}}, {{8}});
+                    mwc->tracing.handle_send(&c, mwc->channel.body(), {{1}}, {{2}}, {{3}}, {{4}}, {{7}});
+                    mwc->tracing.handle_recv(&c, mwc->channel.body(), {{1}}, {{2}}, {{5}}, {{6}}, {{7}}, {{8}});
                 }
                 if (mwc->enable_msg_pattern) {
-                    mwc->pattern.handle_send(&c, &mwc->channel, {{1}}, {{2}}, {{3}}, {{4}}, {{7}});
-                    mwc->pattern.handle_recv(&c, &mwc->channel, {{1}}, {{2}}, {{5}}, {{6}}, {{7}}, {{8}});
+                    mwc->pattern.handle_send(&c, mwc->channel.body(), {{1}}, {{2}}, {{3}}, {{4}}, {{7}});
+                    mwc->pattern.handle_recv(&c, mwc->channel.body(), {{1}}, {{2}}, {{5}}, {{6}}, {{7}}, {{8}});
                 }
             }
         }
@@ -456,9 +456,9 @@ post_init_cb(Caliper* c, Channel* channel)
         for (MpiWrapperConfig* mwc = MpiWrapperConfig::get_wrapper_config(); mwc; mwc = mwc->next) {
             if (mwc->enable_{{func}} && mwc->channel.is_active()) {
                 if (mwc->enable_msg_tracing)
-                    mwc->tracing.handle_irecv(&c, &mwc->channel, {{1}}, {{2}}, {{3}}, {{4}}, {{5}}, {{6}});
+                    mwc->tracing.handle_irecv(&c, mwc->channel.body(), {{1}}, {{2}}, {{3}}, {{4}}, {{5}}, {{6}});
                 if (mwc->enable_msg_pattern)
-                    mwc->pattern.handle_irecv(&c, &mwc->channel, {{1}}, {{2}}, {{3}}, {{4}}, {{5}}, {{6}});
+                    mwc->pattern.handle_irecv(&c, mwc->channel.body(), {{1}}, {{2}}, {{3}}, {{4}}, {{5}}, {{6}});
             }
         }
 
@@ -482,9 +482,9 @@ post_init_cb(Caliper* c, Channel* channel)
         for (MpiWrapperConfig* mwc = MpiWrapperConfig::get_wrapper_config(); mwc; mwc = mwc->next) {
             if (mwc->enable_{{func}} && mwc->channel.is_active()) {
                 if (mwc->enable_msg_tracing)
-                    mwc->tracing.handle_recv_init(&c, &mwc->channel, {{1}}, {{2}}, {{3}}, {{4}}, {{5}}, {{6}});
+                    mwc->tracing.handle_recv_init(&c, mwc->channel.body(), {{1}}, {{2}}, {{3}}, {{4}}, {{5}}, {{6}});
                 if (mwc->enable_msg_pattern)
-                    mwc->pattern.handle_recv_init(&c, &mwc->channel, {{1}}, {{2}}, {{3}}, {{4}}, {{5}}, {{6}});
+                    mwc->pattern.handle_recv_init(&c, mwc->channel.body(), {{1}}, {{2}}, {{3}}, {{4}}, {{5}}, {{6}});
             }
         }
 
@@ -508,9 +508,9 @@ post_init_cb(Caliper* c, Channel* channel)
         for (MpiWrapperConfig* mwc = MpiWrapperConfig::get_wrapper_config(); mwc; mwc = mwc->next) {
             if (mwc->enable_{{func}} && mwc->channel.is_active()) {
                 if (mwc->enable_msg_tracing)
-                    mwc->tracing.handle_start(&c, &mwc->channel, 1, {{0}});
+                    mwc->tracing.handle_start(&c, mwc->channel.body(), 1, {{0}});
                 if (mwc->enable_msg_pattern)
-                    mwc->pattern.handle_start(&c, &mwc->channel, 1, {{0}});
+                    mwc->pattern.handle_start(&c, mwc->channel.body(), 1, {{0}});
             }
         }
 
@@ -534,9 +534,9 @@ post_init_cb(Caliper* c, Channel* channel)
         for (MpiWrapperConfig* mwc = MpiWrapperConfig::get_wrapper_config(); mwc; mwc = mwc->next) {
             if (mwc->enable_{{func}} && mwc->channel.is_active()) {
                 if (mwc->enable_msg_tracing)
-                    mwc->tracing.handle_start(&c, &mwc->channel, {{0}}, {{1}});
+                    mwc->tracing.handle_start(&c, mwc->channel.body(), {{0}}, {{1}});
                 if (mwc->enable_msg_pattern)
-                    mwc->pattern.handle_start(&c, &mwc->channel, {{0}}, {{1}});
+                    mwc->pattern.handle_start(&c, mwc->channel.body(), {{0}}, {{1}});
             }
         }
 
@@ -563,7 +563,7 @@ post_init_cb(Caliper* c, Channel* channel)
 
         for (MpiWrapperConfig* mwc = MpiWrapperConfig::get_wrapper_config(); mwc; mwc = mwc->next) {
             if (mwc->enable_msg_pattern && mwc->enable_{{func}} && mwc->channel.is_active())
-                mwc->pattern.handle_pre_completion(&c, &mwc->channel, 1, &tmp_req);
+                mwc->pattern.handle_pre_completion(&c, mwc->channel.body(), 1, &tmp_req);
         }
 
         {{callfn}}
@@ -571,9 +571,9 @@ post_init_cb(Caliper* c, Channel* channel)
         for (MpiWrapperConfig* mwc = MpiWrapperConfig::get_wrapper_config(); mwc; mwc = mwc->next) {
             if (mwc->enable_{{func}} && mwc->channel.is_active()) {
                 if (mwc->enable_msg_tracing)
-                    mwc->tracing.handle_completion(&c, &mwc->channel, 1, &tmp_req, {{1}});
+                    mwc->tracing.handle_completion(&c, mwc->channel.body(), 1, &tmp_req, {{1}});
                 if (mwc->enable_msg_pattern)
-                    mwc->pattern.handle_completion(&c, &mwc->channel, 1, &tmp_req, {{1}});
+                    mwc->pattern.handle_completion(&c, mwc->channel.body(), 1, &tmp_req, {{1}});
             }
         }
 
@@ -601,7 +601,7 @@ post_init_cb(Caliper* c, Channel* channel)
             if (mwc->enable_{{func}} && mwc->channel.is_active() && (mwc->enable_msg_tracing || mwc->enable_msg_pattern)) {
                 copy_reqs = true;
                 if (mwc->enable_msg_pattern)
-                    mwc->pattern.handle_pre_completion(&c, &mwc->channel, nreq, {{1}});
+                    mwc->pattern.handle_pre_completion(&c, mwc->channel.body(), nreq, {{1}});
                 else
                     break;
             }
@@ -623,9 +623,9 @@ post_init_cb(Caliper* c, Channel* channel)
 
         for (MpiWrapperConfig* mwc = MpiWrapperConfig::get_wrapper_config(); mwc; mwc = mwc->next) {
             if (mwc->enable_msg_tracing && nreq > 0 && mwc->enable_{{func}} && mwc->channel.is_active())
-                mwc->tracing.handle_completion(&c, &mwc->channel, nreq, tmp_req, {{2}});
+                mwc->tracing.handle_completion(&c, mwc->channel.body(), nreq, tmp_req, {{2}});
             if (mwc->enable_msg_pattern && nreq > 0 && mwc->enable_{{func}} && mwc->channel.is_active())
-                mwc->pattern.handle_completion(&c, &mwc->channel, nreq, tmp_req, {{2}});
+                mwc->pattern.handle_completion(&c, mwc->channel.body(), nreq, tmp_req, {{2}});
         }
 
         ::pop_mpifn(&c, ::{{func}}_wrap_count > 0);
@@ -675,10 +675,10 @@ post_init_cb(Caliper* c, Channel* channel)
 
         for (MpiWrapperConfig* mwc = MpiWrapperConfig::get_wrapper_config(); mwc; mwc = mwc->next) {
             if (mwc->enable_msg_tracing && nreq > 0 && mwc->enable_{{func}} && mwc->channel.is_active())
-                mwc->tracing.handle_completion(&c, &mwc->channel, 1, tmp_req+(*{{2}}), {{3}});
+                mwc->tracing.handle_completion(&c, mwc->channel.body(), 1, tmp_req+(*{{2}}), {{3}});
             if (mwc->enable_msg_pattern && nreq > 0 && mwc->enable_{{func}} && mwc->channel.is_active()) {
-                mwc->pattern.handle_pre_completion(&c, &mwc->channel, 1, tmp_req+(*{{2}}));
-                mwc->pattern.handle_completion(&c, &mwc->channel, 1, tmp_req+(*{{2}}), {{3}});
+                mwc->pattern.handle_pre_completion(&c, mwc->channel.body(), 1, tmp_req+(*{{2}}));
+                mwc->pattern.handle_completion(&c, mwc->channel.body(), 1, tmp_req+(*{{2}}), {{3}});
             }
         }
 
@@ -730,11 +730,11 @@ post_init_cb(Caliper* c, Channel* channel)
         for (MpiWrapperConfig* mwc = MpiWrapperConfig::get_wrapper_config(); mwc; mwc = mwc->next) {
             if (mwc->enable_msg_tracing && mwc->enable_{{func}} && mwc->channel.is_active())
                 for (int i = 0; i < *{{2}}; ++i)
-                   mwc->tracing.handle_completion(&c, &mwc->channel, 1, tmp_req+{{3}}[i], {{4}}+{{3}}[i]);
+                   mwc->tracing.handle_completion(&c, mwc->channel.body(), 1, tmp_req+{{3}}[i], {{4}}+{{3}}[i]);
             if (mwc->enable_msg_pattern && mwc->enable_{{func}} && mwc->channel.is_active())
                for (int i = 0; i < *{{2}}; ++i) {
-                   mwc->pattern.handle_pre_completion(&c, &mwc->channel, 1, tmp_req+{{3}}[i]);
-                   mwc->pattern.handle_completion(&c, &mwc->channel, 1, tmp_req+{{3}}[i], {{4}}+{{3}}[i]);
+                   mwc->pattern.handle_pre_completion(&c, mwc->channel.body(), 1, tmp_req+{{3}}[i]);
+                   mwc->pattern.handle_completion(&c, mwc->channel.body(), 1, tmp_req+{{3}}[i], {{4}}+{{3}}[i]);
                }
         }
 
@@ -770,10 +770,10 @@ post_init_cb(Caliper* c, Channel* channel)
         for (MpiWrapperConfig* mwc = MpiWrapperConfig::get_wrapper_config(); mwc; mwc = mwc->next) {
             if (*{{1}} && mwc->enable_{{func}} && mwc->channel.is_active()) {
                 if (mwc->enable_msg_tracing)
-                    mwc->tracing.handle_completion(&c, &mwc->channel, 1, &tmp_req, {{2}});
+                    mwc->tracing.handle_completion(&c, mwc->channel.body(), 1, &tmp_req, {{2}});
                 if (mwc->enable_msg_pattern) {
-                    mwc->pattern.handle_pre_completion(&c, &mwc->channel, 1, &tmp_req);
-                    mwc->pattern.handle_completion(&c, &mwc->channel, 1, &tmp_req, {{2}});
+                    mwc->pattern.handle_pre_completion(&c, mwc->channel.body(), 1, &tmp_req);
+                    mwc->pattern.handle_completion(&c, mwc->channel.body(), 1, &tmp_req, {{2}});
                 }
             }
         }
@@ -823,10 +823,10 @@ post_init_cb(Caliper* c, Channel* channel)
         for (MpiWrapperConfig* mwc = MpiWrapperConfig::get_wrapper_config(); mwc; mwc = mwc->next) {
             if (*{{2}} && mwc->enable_{{func}} && mwc->channel.is_active()) {
                 if (mwc->enable_msg_tracing)
-                    mwc->tracing.handle_completion(&c, &mwc->channel, nreq, tmp_req, {{3}});
+                    mwc->tracing.handle_completion(&c, mwc->channel.body(), nreq, tmp_req, {{3}});
                 if (mwc->enable_msg_pattern) {
-                    mwc->pattern.handle_pre_completion(&c, &mwc->channel, nreq, tmp_req);
-                    mwc->pattern.handle_completion(&c, &mwc->channel, nreq, tmp_req, {{3}});
+                    mwc->pattern.handle_pre_completion(&c, mwc->channel.body(), nreq, tmp_req);
+                    mwc->pattern.handle_completion(&c, mwc->channel.body(), nreq, tmp_req, {{3}});
                 }
             }
         }
@@ -880,10 +880,10 @@ post_init_cb(Caliper* c, Channel* channel)
         for (MpiWrapperConfig* mwc = MpiWrapperConfig::get_wrapper_config(); mwc; mwc = mwc->next) {
             if (*{{3}} && mwc->enable_{{func}} && mwc->channel.is_active()) {
                 if (mwc->enable_msg_tracing)
-                    mwc->tracing.handle_completion(&c, &mwc->channel, 1, tmp_req+(*{{2}}), {{4}});
+                    mwc->tracing.handle_completion(&c, mwc->channel.body(), 1, tmp_req+(*{{2}}), {{4}});
                 if (mwc->enable_msg_pattern) {
-                    mwc->pattern.handle_pre_completion(&c, &mwc->channel, 1, tmp_req+(*{{2}}));
-                    mwc->pattern.handle_completion(&c, &mwc->channel, 1, tmp_req+(*{{2}}), {{4}});
+                    mwc->pattern.handle_pre_completion(&c, mwc->channel.body(), 1, tmp_req+(*{{2}}));
+                    mwc->pattern.handle_completion(&c, mwc->channel.body(), 1, tmp_req+(*{{2}}), {{4}});
                 }
             }
         }
@@ -908,9 +908,9 @@ post_init_cb(Caliper* c, Channel* channel)
 
         for (MpiWrapperConfig* mwc = MpiWrapperConfig::get_wrapper_config(); mwc; mwc = mwc->next) {
             if (mwc->enable_msg_tracing && mwc->enable_{{func}} && mwc->channel.is_active())
-                mwc->tracing.request_free(&c, &mwc->channel, {{0}});
+                mwc->tracing.request_free(&c, mwc->channel.body(), {{0}});
             if (mwc->enable_msg_pattern && mwc->enable_{{func}} && mwc->channel.is_active())
-                mwc->pattern.request_free(&c, &mwc->channel, {{0}});
+                mwc->pattern.request_free(&c, mwc->channel.body(), {{0}});
         }
 
         {{callfn}}
@@ -939,9 +939,9 @@ post_init_cb(Caliper* c, Channel* channel)
         for (MpiWrapperConfig* mwc = MpiWrapperConfig::get_wrapper_config(); mwc; mwc = mwc->next) {
             if (mwc->enable_{{func}} && mwc->channel.is_active()) {
                 if (mwc->enable_msg_tracing)
-                    mwc->tracing.handle_barrier(&c, &mwc->channel, {{0}});
+                    mwc->tracing.handle_barrier(&c, mwc->channel.body(), {{0}});
                 if (mwc->enable_msg_pattern)
-                    mwc->pattern.handle_barrier(&c, &mwc->channel, {{0}});
+                    mwc->pattern.handle_barrier(&c, mwc->channel.body(), {{0}});
             }
         }
 
@@ -965,9 +965,9 @@ post_init_cb(Caliper* c, Channel* channel)
         for (MpiWrapperConfig* mwc = MpiWrapperConfig::get_wrapper_config(); mwc; mwc = mwc->next) {
             if (mwc->enable_{{func}} && mwc->channel.is_active()) {
                 if (mwc->enable_msg_tracing)
-                    mwc->tracing.handle_12n(&c, &mwc->channel, {{1}}, {{2}}, {{3}}, {{4}});
+                    mwc->tracing.handle_12n(&c, mwc->channel.body(), {{1}}, {{2}}, {{3}}, {{4}});
                 if (mwc->enable_msg_pattern)
-                    mwc->pattern.handle_12n(&c, &mwc->channel, {{1}}, {{2}}, {{3}}, {{4}});
+                    mwc->pattern.handle_12n(&c, mwc->channel.body(), {{1}}, {{2}}, {{3}}, {{4}});
             }
         }
 
@@ -991,9 +991,9 @@ post_init_cb(Caliper* c, Channel* channel)
         for (MpiWrapperConfig* mwc = MpiWrapperConfig::get_wrapper_config(); mwc; mwc = mwc->next) {
             if (mwc->enable_{{func}} && mwc->channel.is_active()) {
                 if (mwc->enable_msg_tracing)
-                    mwc->tracing.handle_12n(&c, &mwc->channel, {{1}}, {{2}}, {{6}}, {{7}});
+                    mwc->tracing.handle_12n(&c, mwc->channel.body(), {{1}}, {{2}}, {{6}}, {{7}});
                 if (mwc->enable_msg_pattern)
-                    mwc->pattern.handle_12n(&c, &mwc->channel, {{1}}, {{2}}, {{6}}, {{7}});
+                    mwc->pattern.handle_12n(&c, mwc->channel.body(), {{1}}, {{2}}, {{6}}, {{7}});
             }
         }
 
@@ -1019,13 +1019,13 @@ post_init_cb(Caliper* c, Channel* channel)
                 int tmp_commsize = 0;
                 PMPI_Comm_size({{8}}, &tmp_commsize);
                 int total_count  = std::accumulate({{2}}, {{2}}+tmp_commsize, 0);
-                mwc->tracing.handle_12n(&c, &mwc->channel, total_count, {{3}}, {{7}}, {{8}});
+                mwc->tracing.handle_12n(&c, mwc->channel.body(), total_count, {{3}}, {{7}}, {{8}});
             }
             if (mwc->enable_msg_pattern && mwc->enable_{{func}} && mwc->channel.is_active()) {
                 int tmp_commsize = 0;
                 PMPI_Comm_size({{8}}, &tmp_commsize);
                 int total_count  = std::accumulate({{2}}, {{2}}+tmp_commsize, 0);
-                mwc->pattern.handle_12n(&c, &mwc->channel, total_count, {{3}}, {{7}}, {{8}});
+                mwc->pattern.handle_12n(&c, mwc->channel.body(), total_count, {{3}}, {{7}}, {{8}});
             }
         }
 
@@ -1048,9 +1048,9 @@ post_init_cb(Caliper* c, Channel* channel)
 
         for (MpiWrapperConfig* mwc = MpiWrapperConfig::get_wrapper_config(); mwc; mwc = mwc->next) {
             if (mwc->enable_msg_tracing && mwc->enable_{{func}} && mwc->channel.is_active())
-                mwc->tracing.handle_n21(&c, &mwc->channel, {{1}}, {{2}}, {{6}}, {{7}});
+                mwc->tracing.handle_n21(&c, mwc->channel.body(), {{1}}, {{2}}, {{6}}, {{7}});
             if (mwc->enable_msg_pattern && mwc->enable_{{func}} && mwc->channel.is_active())
-                mwc->pattern.handle_n21(&c, &mwc->channel, {{1}}, {{2}}, {{6}}, {{7}});
+                mwc->pattern.handle_n21(&c, mwc->channel.body(), {{1}}, {{2}}, {{6}}, {{7}});
         }
 
         ::pop_mpifn(&c, ::{{func}}_wrap_count > 0);
@@ -1072,9 +1072,9 @@ post_init_cb(Caliper* c, Channel* channel)
 
         for (MpiWrapperConfig* mwc = MpiWrapperConfig::get_wrapper_config(); mwc; mwc = mwc->next) {
             if (mwc->enable_msg_tracing && mwc->enable_{{func}} && mwc->channel.is_active())
-                mwc->tracing.handle_n21(&c, &mwc->channel, {{1}}, {{2}}, {{7}}, {{8}});
+                mwc->tracing.handle_n21(&c, mwc->channel.body(), {{1}}, {{2}}, {{7}}, {{8}});
             if (mwc->enable_msg_pattern && mwc->enable_{{func}} && mwc->channel.is_active())
-                mwc->pattern.handle_n21(&c, &mwc->channel, {{1}}, {{2}}, {{7}}, {{8}});
+                mwc->pattern.handle_n21(&c, mwc->channel.body(), {{1}}, {{2}}, {{7}}, {{8}});
         }
 
         ::pop_mpifn(&c, ::{{func}}_wrap_count > 0);
@@ -1097,9 +1097,9 @@ post_init_cb(Caliper* c, Channel* channel)
 
         for (MpiWrapperConfig* mwc = MpiWrapperConfig::get_wrapper_config(); mwc; mwc = mwc->next) {
             if (mwc->enable_msg_tracing && mwc->enable_{{func}} && mwc->channel.is_active())
-                mwc->tracing.handle_n21(&c, &mwc->channel, {{2}}, {{3}}, {{5}}, {{6}});
+                mwc->tracing.handle_n21(&c, mwc->channel.body(), {{2}}, {{3}}, {{5}}, {{6}});
             if (mwc->enable_msg_pattern && mwc->enable_{{func}} && mwc->channel.is_active())
-                mwc->pattern.handle_n21(&c, &mwc->channel, {{2}}, {{3}}, {{5}}, {{6}});
+                mwc->pattern.handle_n21(&c, mwc->channel.body(), {{2}}, {{3}}, {{5}}, {{6}});
         }
 
         ::pop_mpifn(&c, ::{{func}}_wrap_count > 0);
@@ -1121,9 +1121,9 @@ post_init_cb(Caliper* c, Channel* channel)
 
         for (MpiWrapperConfig* mwc = MpiWrapperConfig::get_wrapper_config(); mwc; mwc = mwc->next) {
             if (mwc->enable_msg_tracing && mwc->enable_{{func}} && mwc->channel.is_active())
-                mwc->tracing.handle_n2n(&c, &mwc->channel, {{2}}, {{3}}, {{5}});
+                mwc->tracing.handle_n2n(&c, mwc->channel.body(), {{2}}, {{3}}, {{5}});
             if (mwc->enable_msg_pattern && mwc->enable_{{func}} && mwc->channel.is_active())
-                mwc->pattern.handle_n2n(&c, &mwc->channel, {{2}}, {{3}}, {{5}});
+                mwc->pattern.handle_n2n(&c, mwc->channel.body(), {{2}}, {{3}}, {{5}});
         }
 
         ::pop_mpifn(&c, ::{{func}}_wrap_count > 0);
@@ -1147,12 +1147,12 @@ post_init_cb(Caliper* c, Channel* channel)
             if (mwc->enable_msg_tracing && mwc->enable_{{func}} && mwc->channel.is_active()) {
                 int tmp_rank = 0;
                 PMPI_Comm_rank({{5}}, &tmp_rank);
-                mwc->tracing.handle_n2n(&c, &mwc->channel, {{2}}[tmp_rank], {{3}}, {{5}});
+                mwc->tracing.handle_n2n(&c, mwc->channel.body(), {{2}}[tmp_rank], {{3}}, {{5}});
             }
             if (mwc->enable_msg_pattern && mwc->enable_{{func}} && mwc->channel.is_active()) {
                 int tmp_rank = 0;
                 PMPI_Comm_rank({{5}}, &tmp_rank);
-                mwc->pattern.handle_n2n(&c, &mwc->channel, {{2}}[tmp_rank], {{3}}, {{5}});
+                mwc->pattern.handle_n2n(&c, mwc->channel.body(), {{2}}[tmp_rank], {{3}}, {{5}});
             }
         }
 
@@ -1175,9 +1175,9 @@ post_init_cb(Caliper* c, Channel* channel)
 
         for (MpiWrapperConfig* mwc = MpiWrapperConfig::get_wrapper_config(); mwc; mwc = mwc->next) {
             if (mwc->enable_msg_tracing && mwc->enable_{{func}} && mwc->channel.is_active())
-                mwc->tracing.handle_n2n(&c, &mwc->channel, {{2}}, {{3}}, {{5}});
+                mwc->tracing.handle_n2n(&c, mwc->channel.body(), {{2}}, {{3}}, {{5}});
             if (mwc->enable_msg_pattern && mwc->enable_{{func}} && mwc->channel.is_active())
-                mwc->pattern.handle_n2n(&c, &mwc->channel, {{2}}, {{3}}, {{5}});
+                mwc->pattern.handle_n2n(&c, mwc->channel.body(), {{2}}, {{3}}, {{5}});
         }
 
         ::pop_mpifn(&c, ::{{func}}_wrap_count > 0);
@@ -1199,9 +1199,9 @@ post_init_cb(Caliper* c, Channel* channel)
 
         for (MpiWrapperConfig* mwc = MpiWrapperConfig::get_wrapper_config(); mwc; mwc = mwc->next) {
             if (mwc->enable_msg_tracing && mwc->enable_{{func}} && mwc->channel.is_active())
-                mwc->tracing.handle_n2n(&c, &mwc->channel, {{1}}, {{2}}, {{6}});
+                mwc->tracing.handle_n2n(&c, mwc->channel.body(), {{1}}, {{2}}, {{6}});
             if (mwc->enable_msg_pattern && mwc->enable_{{func}} && mwc->channel.is_active())
-                mwc->pattern.handle_n2n(&c, &mwc->channel, {{1}}, {{2}}, {{6}});
+                mwc->pattern.handle_n2n(&c, mwc->channel.body(), {{1}}, {{2}}, {{6}});
         }
         ::pop_mpifn(&c, ::{{func}}_wrap_count > 0);
 #ifndef CALIPER_MPIWRAP_USE_GOTCHA
@@ -1222,9 +1222,9 @@ post_init_cb(Caliper* c, Channel* channel)
 
         for (MpiWrapperConfig* mwc = MpiWrapperConfig::get_wrapper_config(); mwc; mwc = mwc->next) {
             if (mwc->enable_msg_tracing && mwc->enable_{{func}} && mwc->channel.is_active())
-                mwc->tracing.handle_n2n(&c, &mwc->channel, {{1}}, {{2}}, {{7}});
+                mwc->tracing.handle_n2n(&c, mwc->channel.body(), {{1}}, {{2}}, {{7}});
             if (mwc->enable_msg_pattern && mwc->enable_{{func}} && mwc->channel.is_active())
-                mwc->pattern.handle_n2n(&c, &mwc->channel, {{1}}, {{2}}, {{7}});
+                mwc->pattern.handle_n2n(&c, mwc->channel.body(), {{1}}, {{2}}, {{7}});
         }
 
         ::pop_mpifn(&c, ::{{func}}_wrap_count > 0);
@@ -1248,12 +1248,12 @@ post_init_cb(Caliper* c, Channel* channel)
             if (mwc->enable_msg_tracing && mwc->enable_{{func}} && mwc->channel.is_active()) {
                 int tmp_commsize = 0;
                 PMPI_Comm_size({{6}}, &tmp_commsize);
-                mwc->tracing.handle_n2n(&c, &mwc->channel, tmp_commsize * {{1}}, {{2}}, {{6}});
+                mwc->tracing.handle_n2n(&c, mwc->channel.body(), tmp_commsize * {{1}}, {{2}}, {{6}});
             }
             if (mwc->enable_msg_pattern && mwc->enable_{{func}} && mwc->channel.is_active()) {
                 int tmp_commsize = 0;
                 PMPI_Comm_size({{6}}, &tmp_commsize);
-                mwc->pattern.handle_n2n(&c, &mwc->channel, tmp_commsize * {{1}}, {{2}}, {{6}});
+                mwc->pattern.handle_n2n(&c, mwc->channel.body(), tmp_commsize * {{1}}, {{2}}, {{6}});
             }
         }
 
@@ -1280,13 +1280,13 @@ post_init_cb(Caliper* c, Channel* channel)
                 int tmp_commsize = 0;
                 PMPI_Comm_size({{8}}, &tmp_commsize);
                 int total_count  = std::accumulate({{1}}, {{1}}+tmp_commsize, 0);
-                mwc->tracing.handle_n2n(&c, &mwc->channel, total_count, {{3}}, {{8}});
+                mwc->tracing.handle_n2n(&c, mwc->channel.body(), total_count, {{3}}, {{8}});
             }
             if (mwc->enable_msg_pattern && mwc->enable_{{func}} && mwc->channel.is_active()) {
                 int tmp_commsize = 0;
                 PMPI_Comm_size({{8}}, &tmp_commsize);
                 int total_count  = std::accumulate({{1}}, {{1}}+tmp_commsize, 0);
-                mwc->pattern.handle_n2n(&c, &mwc->channel, total_count, {{3}}, {{8}});
+                mwc->pattern.handle_n2n(&c, mwc->channel.body(), total_count, {{3}}, {{8}});
             }
         }
 
@@ -1437,14 +1437,14 @@ void mpiwrap_init(Caliper* c, Channel* chn, ConfigSet& cfg)
         mwc->pattern.init(c, chn);
 
         chn->events().pre_begin_evt.connect(
-            [mwc](Caliper* c, Channel* channel, const Attribute& attr, const Variant& value){
+            [mwc](Caliper* c, ChannelBody* chB, const Attribute& attr, const Variant& value){
                     if (attr == comm_region_attr)
-                        mwc->pattern.handle_comm_begin(c, channel);
+                        mwc->pattern.handle_comm_begin(c, chB);
                 });
         chn->events().pre_end_evt.connect(
-            [mwc](Caliper* c, Channel* channel, const Attribute& attr, const Variant& value){
+            [mwc](Caliper* c, ChannelBody* chB, const Attribute& attr, const Variant& value){
                     if (attr == comm_region_attr)
-                        mwc->pattern.handle_comm_end(c, channel);
+                        mwc->pattern.handle_comm_end(c, chB);
                 });
 
         Log(1).stream() << chn->name() << ": mpi: Enabling message pattern analysis" << std::endl;

--- a/src/services/nvtx/Nvtx.cpp
+++ b/src/services/nvtx/Nvtx.cpp
@@ -106,7 +106,7 @@ public:
         c->make_tree_entry(m_color_attr, v_color, attr.node());
     }
 
-    void on_begin(Caliper*, Channel*, const Attribute& attr, const Variant& value)
+    void on_begin(Caliper*, const Attribute& attr, const Variant& value)
     {
         nvtxEventAttributes_t eventAttrib = { 0 };
 
@@ -143,7 +143,7 @@ public:
         }
     }
 
-    void on_end(Caliper*, Channel*, const Attribute& attr, const Variant& value)
+    void on_end(Caliper*, const Attribute& attr, const Variant& value)
     {
         if (attr.is_nested()) {
             nvtxRangePop();

--- a/src/services/nvtx/Nvtx.cpp
+++ b/src/services/nvtx/Nvtx.cpp
@@ -92,7 +92,7 @@ public:
 
     const char* service_tag() const { return "nvtx"; }
 
-    void on_mark_attribute(Caliper* c, Channel*, const Attribute& attr)
+    void on_mark_attribute(Caliper* c, const Attribute& attr)
     {
         if (m_cycle_colors)
             return;

--- a/src/services/ompt/OmptService.cpp
+++ b/src/services/ompt/OmptService.cpp
@@ -269,7 +269,7 @@ void post_init_cb(Caliper* c, Channel* channel)
     const Attribute sub_attrs[] = { region_attr, thread_type_attr, sync_attr, work_attr, thread_id_attr };
 
     for (const Attribute& attr : sub_attrs)
-        channel->events().subscribe_attribute(c, channel, attr);
+        channel->events().subscribe_attribute(c, attr);
 }
 
 void create_attributes(Caliper* c)

--- a/src/services/papi/Papi.cpp
+++ b/src/services/papi/Papi.cpp
@@ -473,7 +473,7 @@ public:
         channel->events().release_thread_evt.connect([instance](Caliper* c, Channel*) {
             instance->finish_thread_eventsets(c);
         });
-        channel->events().snapshot.connect([instance](Caliper* c, Channel*, SnapshotView, SnapshotBuilder& rec) {
+        channel->events().snapshot.connect([instance](Caliper* c, SnapshotView, SnapshotBuilder& rec) {
             instance->snapshot(c, rec);
         });
         channel->events().finish_evt.connect([instance](Caliper* c, Channel* channel) {

--- a/src/services/pthread/PthreadService.cpp
+++ b/src/services/pthread/PthreadService.cpp
@@ -65,7 +65,7 @@ int cali_pthread_create_wrapper(pthread_t* thread, const pthread_attr_t* attr, v
 
 void post_init_cb(Caliper* c, Channel* channel)
 {
-    channel->events().subscribe_attribute(c, channel, id_attr);
+    channel->events().subscribe_attribute(c, id_attr);
 
     static bool is_wrapped = false;
 

--- a/src/services/recorder/Recorder.cpp
+++ b/src/services/recorder/Recorder.cpp
@@ -29,7 +29,56 @@ using namespace std;
 namespace
 {
 
-const char* spec = R"json(
+class Recorder
+{
+    std::string m_channel_name;
+    ConfigSet   m_config;
+
+    void write_output_cb(Caliper* c, ChannelBody* chB, SnapshotView flush_info)
+    {
+        std::string filename  = m_config.get("filename").to_string();
+        std::string directory = m_config.get("directory").to_string();
+
+        if (filename.empty())
+            filename = cali::util::create_filename();
+        if (!directory.empty())
+            filename = directory + "/" + filename;
+
+        OutputStream stream;
+        stream.set_filename(filename.c_str(), *c, std::vector<Entry>(flush_info.begin(), flush_info.end()));
+
+        CaliWriter writer(stream);
+
+        c->flush(chB, flush_info, [&writer](CaliperMetadataAccessInterface& db, const std::vector<Entry>& rec) {
+            writer.write_snapshot(db, rec);
+        });
+
+        writer.write_globals(*c, c->get_globals(chB));
+
+        Log(1).stream() << m_channel_name << ": Recorder: Wrote " << writer.num_written() << " records." << std::endl;
+    }
+
+    Recorder(const std::string& chname, const ConfigSet& cfg)
+        : m_channel_name { chname}, m_config { cfg }
+    { }
+
+public:
+
+    static const char* s_spec;
+
+    static void recorder_register(Caliper* c, Channel* channel)
+    {
+        auto cfg = services::init_config_from_spec(channel->config(), s_spec);
+        Recorder* instance = new Recorder(channel->name(), cfg);
+
+        channel->events().write_output_evt.connect([instance](Caliper* c, ChannelBody* chB, SnapshotView info){
+                instance->write_output_cb(c, chB, info);
+            });
+        channel->events().finish_evt.connect([instance](Caliper*, Channel*){ delete instance; });
+    }
+};
+
+const char* Recorder::s_spec = R"json(
 {
 "name"        : "recorder",
 "description" : "Write records into .cali file",
@@ -47,42 +96,11 @@ const char* spec = R"json(
 ]}
 )json";
 
-void write_output_cb(Caliper* c, Channel* chn, SnapshotView flush_info)
-{
-    ConfigSet cfg = services::init_config_from_spec(chn->config(), spec);
-
-    std::string filename  = cfg.get("filename").to_string();
-    std::string directory = cfg.get("directory").to_string();
-
-    if (filename.empty())
-        filename = cali::util::create_filename();
-    if (!directory.empty())
-        filename = directory + "/" + filename;
-
-    OutputStream stream;
-    stream.set_filename(filename.c_str(), *c, std::vector<Entry>(flush_info.begin(), flush_info.end()));
-
-    CaliWriter writer(stream);
-
-    c->flush(chn, flush_info, [&writer](CaliperMetadataAccessInterface& db, const std::vector<Entry>& rec) {
-        writer.write_snapshot(db, rec);
-    });
-
-    writer.write_globals(*c, c->get_globals(*chn));
-
-    Log(1).stream() << chn->name() << ": Recorder: Wrote " << writer.num_written() << " records." << std::endl;
-}
-
-void recorder_register(Caliper* c, Channel* chn)
-{
-    chn->events().write_output_evt.connect(::write_output_cb);
-}
-
-} // namespace
+} // namespace [anonymous]
 
 namespace cali
 {
 
-CaliperService recorder_service { ::spec, ::recorder_register };
+CaliperService recorder_service { ::Recorder::s_spec, ::Recorder::recorder_register };
 
 }

--- a/src/services/rocprofiler/RocProfiler.cpp
+++ b/src/services/rocprofiler/RocProfiler.cpp
@@ -334,7 +334,7 @@ class RocProfilerService
             ROCPROFILER_CALL(rocprofiler_start_context(rocprofiler_ctx));
             ROCPROFILER_CALL(rocprofiler_start_context(activity_ctx));
 
-            channel->events().pre_flush_evt.connect([this](Caliper*, Channel*, SnapshotView) { this->pre_flush_cb(); });
+            channel->events().pre_flush_evt.connect([this](Caliper*, ChannelBody*, SnapshotView) { this->pre_flush_cb(); });
         }
 
         if (m_enable_snapshot_timestamps) {

--- a/src/services/rocprofiler/RocProfiler.cpp
+++ b/src/services/rocprofiler/RocProfiler.cpp
@@ -229,8 +229,7 @@ class RocProfilerService
                 if (!mpi_rank_entry.empty())
                     snapshot.builder().append(mpi_rank_entry);
 
-                s_instance->m_channel.events()
-                    .process_snapshot(&c, &s_instance->m_channel, SnapshotView(), snapshot.view());
+                s_instance->m_channel.events().process_snapshot(&c, SnapshotView(), snapshot.view());
 
                 ++s_instance->m_num_activity_records;
             } else if (header->category == ROCPROFILER_BUFFER_CATEGORY_TRACING && header->kind == ROCPROFILER_BUFFER_TRACING_MEMORY_COPY) {
@@ -313,7 +312,7 @@ class RocProfilerService
         }
     }
 
-    void snapshot_cb(Caliper* c, Channel* channel, SnapshotView trigger_info, SnapshotBuilder& snapshot)
+    void snapshot_cb(Caliper* c, SnapshotView trigger_info, SnapshotBuilder& snapshot)
     {
         auto ts = rocprofiler_timestamp_t {};
         rocprofiler_get_timestamp(&ts);
@@ -345,8 +344,8 @@ class RocProfilerService
             c->set(m_host_timestamp_attr, Variant(cali_make_variant_from_uint(static_cast<uint64_t>(ts))));
 
             channel->events().snapshot.connect(
-                [this](Caliper* c, Channel* channel, SnapshotView trigger_info, SnapshotBuilder& snapshot) {
-                    this->snapshot_cb(c, channel, trigger_info, snapshot);
+                [this](Caliper* c, SnapshotView trigger_info, SnapshotBuilder& snapshot) {
+                    this->snapshot_cb(c, trigger_info, snapshot);
                 }
             );
         }

--- a/src/services/rocprofiler/RocProfiler.cpp
+++ b/src/services/rocprofiler/RocProfiler.cpp
@@ -268,8 +268,7 @@ class RocProfilerService
                 if (!mpi_rank_entry.empty())
                     snapshot.builder().append(mpi_rank_entry);
 
-                s_instance->m_channel.events()
-                    .process_snapshot(&c, &s_instance->m_channel, SnapshotView(), snapshot.view());
+                s_instance->m_channel.events().process_snapshot(&c, SnapshotView(), snapshot.view());
 
                 ++s_instance->m_num_activity_records;
             }

--- a/src/services/rocprofiler/RocProfiler.cpp
+++ b/src/services/rocprofiler/RocProfiler.cpp
@@ -326,7 +326,7 @@ class RocProfilerService
     void post_init_cb(Caliper* c, Channel* channel)
     {
         if (m_enable_api_callbacks) {
-            channel->events().subscribe_attribute(c, channel, m_api_attr);
+            channel->events().subscribe_attribute(c, m_api_attr);
             ROCPROFILER_CALL(rocprofiler_start_context(hip_api_ctx));
         }
 

--- a/src/services/rocprofiler/RocTX.cpp
+++ b/src/services/rocprofiler/RocTX.cpp
@@ -29,7 +29,7 @@ class RocTXBinding : public AnnotationBinding
 
 public:
 
-    void on_begin(Caliper*, Channel*, const Attribute& attr, const Variant& value)
+    void on_begin(Caliper*, const Attribute& attr, const Variant& value)
     {
         const char* msg = nullptr;
         std::string str; // string obj must not be deleted until end of function
@@ -53,7 +53,7 @@ public:
         }
     }
 
-    void on_end(Caliper*, Channel*, const Attribute& attr, const Variant&)
+    void on_end(Caliper*, const Attribute& attr, const Variant&)
     {
         if (attr.is_nested()) {
             if (roctxRangePop() < 0)

--- a/src/services/roctracer/RocTracer.cpp
+++ b/src/services/roctracer/RocTracer.cpp
@@ -125,7 +125,7 @@ class RocTracerService
 
     void subscribe_attributes(Caliper* c)
     {
-        channel->events().subscribe_attribute(c, m_api_attr);
+        m_channel.events().subscribe_attribute(c, m_api_attr);
     }
 
     void push_correlation(uint64_t id, cali::Node* node)
@@ -415,7 +415,7 @@ class RocTracerService
             return;
         }
 
-        channel->events().pre_flush_evt.connect([this](Caliper*, Channel*, SnapshotView) { this->pre_flush_cb(); });
+        channel->events().pre_flush_evt.connect([this](Caliper*, ChannelBody*, SnapshotView) { this->pre_flush_cb(); });
 
         Log(1).stream() << channel->name() << ": roctracer: Tracing initialized" << std::endl;
     }

--- a/src/services/roctracer/RocTracer.cpp
+++ b/src/services/roctracer/RocTracer.cpp
@@ -123,9 +123,9 @@ class RocTracerService
         }
     }
 
-    void subscribe_attributes(Caliper* c, Channel* channel)
+    void subscribe_attributes(Caliper* c)
     {
-        channel->events().subscribe_attribute(c, channel, m_api_attr);
+        channel->events().subscribe_attribute(c, m_api_attr);
     }
 
     void push_correlation(uint64_t id, cali::Node* node)
@@ -452,7 +452,7 @@ class RocTracerService
 
     void post_init_cb(Caliper* c, Channel* channel)
     {
-        subscribe_attributes(c, channel);
+        subscribe_attributes(c);
 
         uint64_t starttime = 0;
         roctracer_get_timestamp(&starttime);

--- a/src/services/roctracer/RocTracer.cpp
+++ b/src/services/roctracer/RocTracer.cpp
@@ -293,7 +293,7 @@ class RocTracerService
 
             FixedSizeSnapshotRecord<8> snapshot;
             c->make_record(num, attr, data, snapshot.builder(), parent);
-            m_channel.events().process_snapshot(c, &m_channel, SnapshotView(), snapshot.view());
+            m_channel.events().process_snapshot(c, SnapshotView(), snapshot.view());
 
             ++num_records;
         }
@@ -333,7 +333,7 @@ class RocTracerService
 
     void pre_flush_cb() { roctracer_flush_activity_expl(m_roctracer_pool); }
 
-    void snapshot_cb(Caliper* c, Channel* channel, const SnapshotView, SnapshotBuilder& snapshot)
+    void snapshot_cb(Caliper* c, const SnapshotView, SnapshotBuilder& snapshot)
     {
         uint64_t timestamp = 0;
         roctracer_get_timestamp(&timestamp);
@@ -462,8 +462,8 @@ class RocTracerService
         if (m_record_host_timestamp || m_record_host_duration) {
             c->set(m_host_timestamp_attr, cali_make_variant_from_uint(starttime));
 
-            channel->events().snapshot.connect([](Caliper* c, Channel* chn, SnapshotView info, SnapshotBuilder& rec) {
-                s_instance->snapshot_cb(c, chn, info, rec);
+            channel->events().snapshot.connect([](Caliper* c, SnapshotView info, SnapshotBuilder& rec) {
+                s_instance->snapshot_cb(c, info, rec);
             });
         }
 

--- a/src/services/roctx/RocTX.cpp
+++ b/src/services/roctx/RocTX.cpp
@@ -29,7 +29,7 @@ class RocTXBinding : public AnnotationBinding
 
 public:
 
-    void on_begin(Caliper*, Channel*, const Attribute& attr, const Variant& value)
+    void on_begin(Caliper*, const Attribute& attr, const Variant& value)
     {
         const char* msg = nullptr;
         std::string str; // string obj must not be deleted until end of function
@@ -53,7 +53,7 @@ public:
         }
     }
 
-    void on_end(Caliper*, Channel*, const Attribute& attr, const Variant&)
+    void on_end(Caliper*, const Attribute& attr, const Variant&)
     {
         if (attr.is_nested()) {
             if (roctxRangePop() < 0)

--- a/src/services/sampler/Sampler.cpp
+++ b/src/services/sampler/Sampler.cpp
@@ -97,7 +97,7 @@ void on_prof(int sig, siginfo_t* info, void* context)
     }
 #endif
 
-    c.push_snapshot(&channel, SnapshotView(count, data));
+    c.push_snapshot(channel.body(), SnapshotView(count, data));
     ++n_processed_samples;
 }
 
@@ -248,7 +248,7 @@ void sampler_register(Caliper* c, Channel* chn)
     frequency     = std::min(std::max(frequency, 1), 10000);
     nsec_interval = 1000000000 / frequency;
 
-    c->set(chn, c->create_attribute("sample.frequency", CALI_TYPE_INT, CALI_ATTR_GLOBAL), Variant(frequency));
+    c->set(chn->body(), c->create_attribute("sample.frequency", CALI_TYPE_INT, CALI_ATTR_GLOBAL), Variant(frequency));
 
     chn->events().create_thread_evt.connect(create_thread_cb);
     chn->events().release_thread_evt.connect(release_thread_cb);

--- a/src/services/statistics/Statistics.cpp
+++ b/src/services/statistics/Statistics.cpp
@@ -94,13 +94,13 @@ public:
     {
         Statistics* instance = new Statistics;
 
-        chn->events().pre_begin_evt.connect([instance](Caliper* c, Channel* chn, const Attribute&, const Variant&) {
+        chn->events().pre_begin_evt.connect([instance](Caliper*, ChannelBody*, const Attribute&, const Variant&) {
             ++instance->num_begin;
         });
-        chn->events().pre_end_evt.connect([instance](Caliper* c, Channel* chn, const Attribute&, const Variant&) {
+        chn->events().pre_end_evt.connect([instance](Caliper*, ChannelBody*, const Attribute&, const Variant&) {
             ++instance->num_end;
         });
-        chn->events().pre_set_evt.connect([instance](Caliper* c, Channel* chn, const Attribute&, const Variant&) {
+        chn->events().pre_set_evt.connect([instance](Caliper*, ChannelBody*, const Attribute&, const Variant&) {
             ++instance->num_set;
         });
         chn->events().snapshot.connect([instance](Caliper*, SnapshotView, SnapshotBuilder& rec) {
@@ -108,7 +108,6 @@ public:
         });
         chn->events().process_snapshot.connect([instance](Caliper*, SnapshotView, SnapshotView rec) {
             std::lock_guard<std::mutex> g(instance->lock);
-
             instance->max_snapshot_len = std::max<unsigned int>(rec.size(), instance->max_snapshot_len);
         });
 

--- a/src/services/statistics/Statistics.cpp
+++ b/src/services/statistics/Statistics.cpp
@@ -103,10 +103,10 @@ public:
         chn->events().pre_set_evt.connect([instance](Caliper* c, Channel* chn, const Attribute&, const Variant&) {
             ++instance->num_set;
         });
-        chn->events().snapshot.connect([instance](Caliper*, Channel*, SnapshotView, SnapshotBuilder& rec) {
+        chn->events().snapshot.connect([instance](Caliper*, SnapshotView, SnapshotBuilder& rec) {
             ++instance->num_snapshots;
         });
-        chn->events().process_snapshot.connect([instance](Caliper*, Channel*, SnapshotView, SnapshotView rec) {
+        chn->events().process_snapshot.connect([instance](Caliper*, SnapshotView, SnapshotView rec) {
             std::lock_guard<std::mutex> g(instance->lock);
 
             instance->max_snapshot_len = std::max<unsigned int>(rec.size(), instance->max_snapshot_len);

--- a/src/services/symbollookup/SymbolLookup.cpp
+++ b/src/services/symbollookup/SymbolLookup.cpp
@@ -285,7 +285,7 @@ public:
             instance->check_attributes(c);
             instance->init_lookup();
         });
-        chn->events().postprocess_snapshot.connect([instance](Caliper* c, Channel* chn, std::vector<Entry>& rec) {
+        chn->events().postprocess_snapshot.connect([instance](Caliper* c, std::vector<Entry>& rec) {
             instance->process_snapshot(c, rec);
         });
         chn->events().finish_evt.connect([instance](Caliper* c, Channel* chn) {

--- a/src/services/symbollookup/SymbolLookup.cpp
+++ b/src/services/symbollookup/SymbolLookup.cpp
@@ -281,7 +281,7 @@ public:
     {
         SymbolLookup* instance = new SymbolLookup(c, chn);
 
-        chn->events().pre_flush_evt.connect([instance](Caliper* c, Channel* chn, SnapshotView) {
+        chn->events().pre_flush_evt.connect([instance](Caliper* c, ChannelBody*, SnapshotView) {
             instance->check_attributes(c);
             instance->init_lookup();
         });

--- a/src/services/sysalloc/SysAllocService.cpp
+++ b/src/services/sysalloc/SysAllocService.cpp
@@ -60,7 +60,7 @@ void* cali_malloc_wrapper(size_t size)
         Caliper c = Caliper::sigsafe_instance(); // prevent reentry
 
         if (c && p->channel.is_active())
-            c.memory_region_begin(&p->channel, ret, "malloc", 1, 1, &size);
+            c.memory_region_begin(p->channel.body(), ret, "malloc", 1, 1, &size);
     }
 
     errno = saved_errno;
@@ -81,7 +81,7 @@ void* cali_calloc_wrapper(size_t num, size_t size)
         Caliper c = Caliper::sigsafe_instance(); // prevent reentry
 
         if (c && p->channel.is_active())
-            c.memory_region_begin(&p->channel, ret, "calloc", size, 1, &num);
+            c.memory_region_begin(p->channel.body(), ret, "calloc", size, 1, &num);
     }
 
     errno = saved_errno;
@@ -98,7 +98,7 @@ void* cali_realloc_wrapper(void* ptr, size_t size)
         Caliper c = Caliper::sigsafe_instance();
 
         if (c && p->channel.is_active())
-            c.memory_region_end(&p->channel, ptr);
+            c.memory_region_end(p->channel.body(), ptr);
     }
 
     void* ret = (*orig_realloc)(ptr, size);
@@ -109,7 +109,7 @@ void* cali_realloc_wrapper(void* ptr, size_t size)
         Caliper c = Caliper::sigsafe_instance();
 
         if (c && p->channel.is_active())
-            c.memory_region_begin(&p->channel, ret, "realloc", 1, 1, &size);
+            c.memory_region_begin(p->channel.body(), ret, "realloc", 1, 1, &size);
     }
 
     errno = saved_errno;
@@ -125,7 +125,7 @@ void cali_free_wrapper(void* ptr)
         Caliper c = Caliper::sigsafe_instance();
 
         if (c && p->channel.is_active())
-            c.memory_region_end(&p->channel, ptr);
+            c.memory_region_end(p->channel.body(), ptr);
     }
 
     (*orig_free)(ptr);

--- a/src/services/tau/tau.cpp
+++ b/src/services/tau/tau.cpp
@@ -58,7 +58,7 @@ public:
     const char* service_tag() const { return "tau"; };
 
     // handle a begin event by starting a TAU timer
-    void on_begin(Caliper* c, Channel*, const Attribute& attr, const Variant& value)
+    void on_begin(Caliper* c, const Attribute& attr, const Variant& value)
     {
         if (attr.type() == CALI_TYPE_STRING) {
             Tau_start((const char*) value.data());
@@ -68,7 +68,7 @@ public:
     }
 
     // handle an end event by stopping a TAU timer
-    void on_end(Caliper* c, Channel*, const Attribute& attr, const Variant& value)
+    void on_end(Caliper* c, const Attribute& attr, const Variant& value)
     {
         if (attr.type() == CALI_TYPE_STRING) {
             Tau_stop((const char*) value.data());

--- a/src/services/templates/MeasurementService.cpp
+++ b/src/services/templates/MeasurementService.cpp
@@ -58,7 +58,7 @@ class MeasurementTemplateService
     unsigned  m_num_errors; // Number of measurement errors encountered at runtime
     TimePoint m_starttime;  // Initial value for our measurement function
 
-    void snapshot_cb(Caliper* c, Channel* /*channel*/, SnapshotView /*trigger_info*/, SnapshotBuilder& rec)
+    void snapshot_cb(Caliper* c, SnapshotView /*trigger_info*/, SnapshotBuilder& rec)
     {
         //   The snapshot callback triggers performance measurements.
         // Measurement services should make measurements and add them to the
@@ -222,8 +222,8 @@ public:
             instance->post_init_cb(c, channel);
         });
         channel->events().snapshot.connect(
-            [instance](Caliper* c, Channel* channel, SnapshotView trigger_info, SnapshotBuilder& rec) {
-                instance->snapshot_cb(c, channel, trigger_info, rec);
+            [instance](Caliper* c, SnapshotView trigger_info, SnapshotBuilder& rec) {
+                instance->snapshot_cb(c, trigger_info, rec);
             }
         );
         channel->events().finish_evt.connect([instance](Caliper* c, Channel* channel) {

--- a/src/services/textlog/TextLog.cpp
+++ b/src/services/textlog/TextLog.cpp
@@ -152,7 +152,7 @@ class TextLogService
         for (const Attribute& a : c->get_all_attributes())
             check_attribute(a);
 
-        chn->events().process_snapshot.connect([this](Caliper* c, Channel* chn, SnapshotView info, SnapshotView rec) {
+        chn->events().process_snapshot.connect([this](Caliper* c, SnapshotView info, SnapshotView rec) {
             process_snapshot(c, info, rec);
         });
     }

--- a/src/services/textlog/TextLog.cpp
+++ b/src/services/textlog/TextLog.cpp
@@ -173,7 +173,7 @@ public:
     {
         TextLogService* instance = new TextLogService(c, chn);
 
-        chn->events().create_attr_evt.connect([instance](Caliper* c, Channel* chn, const Attribute& attr) {
+        chn->events().create_attr_evt.connect([instance](Caliper*, const Attribute& attr) {
             instance->check_attribute(attr);
         });
         chn->events().post_init_evt.connect([instance](Caliper* c, Channel* chn) { instance->post_init(c, chn); });

--- a/src/services/timer/Timer.cpp
+++ b/src/services/timer/Timer.cpp
@@ -98,29 +98,26 @@ class TimerService
         ti->prev_snapshot_timestamp = nsec;
 
         if (record_inclusive_duration && !info.empty() && !c->is_signal()) {
-            Entry event = info.get(begin_evt_attr);
+            Attribute info_attr = c->get_attribute(info[0].attribute());
+            Variant v_id = info_attr.get(begin_evt_attr);
 
-            if (event.empty())
-                event = info.get(end_evt_attr);
-            if (event.empty())
-                return;
-
-            cali_id_t evt_attr_id = event.value().to_id();
-
-            if (event.attribute() == begin_evt_attr.id()) {
+            if (v_id) {
                 // begin event: push current timestamp onto the inclusive timer stack
-                ti->inclusive_timer_stack[evt_attr_id].push_back(nsec);
-            } else if (event.attribute() == end_evt_attr.id()) {
-                // end event: fetch begin timestamp from inclusive timer stack
-                auto stack_it = ti->inclusive_timer_stack.find(evt_attr_id);
+                ti->inclusive_timer_stack[v_id.to_id()].push_back(nsec);
+            } else {
+                v_id = info_attr.get(end_evt_attr);
+                if (v_id) {
+                    // end event: fetch begin timestamp from inclusive timer stack
+                    auto stack_it = ti->inclusive_timer_stack.find(v_id.to_id());
 
-                if (stack_it == ti->inclusive_timer_stack.end() || stack_it->second.empty()) {
-                    ++n_stack_errors;
-                    return;
+                    if (stack_it == ti->inclusive_timer_stack.end() || stack_it->second.empty()) {
+                        ++n_stack_errors;
+                        return;
+                    }
+
+                    rec.append(inclusive_duration_attr, cali_make_variant_from_uint(nsec - stack_it->second.back()));
+                    stack_it->second.pop_back();
                 }
-
-                rec.append(inclusive_duration_attr, cali_make_variant_from_uint(nsec - stack_it->second.back()));
-                stack_it->second.pop_back();
             }
         }
     }
@@ -134,10 +131,7 @@ class TimerService
 
         if (!begin_evt_attr || !end_evt_attr) {
             if (record_inclusive_duration)
-                Log(1).stream() << chn->name()
-                                << ": Timestamp: Note: event trigger attributes not registered,\n"
-                                   "    disabling phase timers."
-                                << std::endl;
+                Log(1).stream() << chn->name() << ": timer: Event attributes not found, disabling inclusive timers.\n";
 
             record_inclusive_duration = false;
         }

--- a/src/services/timer/Timer.cpp
+++ b/src/services/timer/Timer.cpp
@@ -82,7 +82,7 @@ class TimerService
         return ti;
     }
 
-    void snapshot_cb(Caliper* c, Channel* chn, SnapshotView info, SnapshotBuilder& rec)
+    void snapshot_cb(Caliper* c, SnapshotView info, SnapshotBuilder& rec)
     {
         auto     now  = clock::now();
         uint64_t nsec = chrono::duration_cast<chrono::nanoseconds>(now - tstart).count();
@@ -210,8 +210,8 @@ public:
 
         chn->events().post_init_evt.connect([instance](Caliper* c, Channel* chn) { instance->post_init_cb(c, chn); });
         chn->events().create_thread_evt.connect([instance](Caliper* c, Channel*) { instance->acquire_timerinfo(c); });
-        chn->events().snapshot.connect([instance](Caliper* c, Channel* chn, SnapshotView info, SnapshotBuilder& rec) {
-            instance->snapshot_cb(c, chn, info, rec);
+        chn->events().snapshot.connect([instance](Caliper* c, SnapshotView info, SnapshotBuilder& rec) {
+            instance->snapshot_cb(c, info, rec);
         });
         chn->events().finish_evt.connect([instance](Caliper* c, Channel* chn) {
             instance->finish_cb(c, chn);

--- a/src/services/topdown/IntelTopdown.cpp
+++ b/src/services/topdown/IntelTopdown.cpp
@@ -186,7 +186,7 @@ public:
             else
                 Log(0).stream() << channel->name() << ": topdown: Could not find counter attributes!" << std::endl;
         });
-        channel->events().postprocess_snapshot.connect([instance](Caliper*, Channel*, std::vector<Entry>& rec) {
+        channel->events().postprocess_snapshot.connect([instance](Caliper*, std::vector<Entry>& rec) {
             instance->postprocess_snapshot_cb(rec);
         });
         channel->events().finish_evt.connect([instance](Caliper* c, Channel* channel) {

--- a/src/services/trace/Trace.cpp
+++ b/src/services/trace/Trace.cpp
@@ -125,7 +125,7 @@ class Trace
         case BufferPolicy::Flush:
             {
                 Log(1).stream() << m_channel.name() << ": trace: Trace buffer full, flushing.\n";
-                c->flush_and_write(&m_channel, SnapshotView());
+                c->flush_and_write(m_channel.body(), SnapshotView());
                 return tbuf;
             }
 

--- a/src/services/trace/Trace.cpp
+++ b/src/services/trace/Trace.cpp
@@ -70,7 +70,9 @@ class Trace
 
     std::mutex flush_lock;
 
-    TraceBuffer* acquire_tbuf(Caliper* c, Channel* chn, bool can_alloc)
+    Channel    m_channel;
+
+    TraceBuffer* acquire_tbuf(Caliper* c, bool can_alloc)
     {
         //   we store a pointer to the thread-local trace buffer for this channel
         // on the thread's blackboard
@@ -96,12 +98,12 @@ class Trace
         return tbuf;
     }
 
-    TraceBuffer* handle_overflow(Caliper* c, Channel* chn, TraceBuffer* tbuf)
+    TraceBuffer* handle_overflow(Caliper* c, TraceBuffer* tbuf)
     {
         switch (policy) {
         case BufferPolicy::Stop:
             tbuf->stopped.store(true);
-            Log(1).stream() << chn->name() << ": Trace buffer full: recording stopped." << std::endl;
+            Log(1).stream() << m_channel.name() << ": trace: Trace buffer full, recording stopped!\n";
             return 0;
 
         case BufferPolicy::Grow:
@@ -109,8 +111,7 @@ class Trace
                 TraceBufferChunk* newchunk = new TraceBufferChunk(buffersize);
 
                 if (!newchunk) {
-                    Log(0).stream() << "Trace: error: unable to allocate new trace buffer. Recording stopped."
-                                    << std::endl;
+                    Log(0).stream() << m_channel.name() << ": trace: Unable to allocate new trace buffer, recording stopped!\n";
                     tbuf->stopped.store(true);
                     return 0;
                 }
@@ -123,10 +124,8 @@ class Trace
 
         case BufferPolicy::Flush:
             {
-                Log(1).stream() << chn->name() << ": Trace buffer full: flushing." << std::endl;
-
-                c->flush_and_write(chn, SnapshotView());
-
+                Log(1).stream() << m_channel.name() << ": trace: Trace buffer full, flushing.\n";
+                c->flush_and_write(&m_channel, SnapshotView());
                 return tbuf;
             }
 
@@ -135,9 +134,9 @@ class Trace
         return 0;
     }
 
-    void process_snapshot_cb(Caliper* c, Channel* chn, SnapshotView rec)
+    void process_snapshot_cb(Caliper* c, SnapshotView rec)
     {
-        TraceBuffer* tbuf = acquire_tbuf(c, chn, !c->is_signal());
+        TraceBuffer* tbuf = acquire_tbuf(c, !c->is_signal());
 
         if (!tbuf || tbuf->stopped.load()) {
             ++dropped_snapshots;
@@ -145,22 +144,20 @@ class Trace
         }
 
         if (!tbuf->chunks->fits(rec))
-            tbuf = handle_overflow(c, chn, tbuf);
+            tbuf = handle_overflow(c, tbuf);
         if (!tbuf)
             return;
 
         tbuf->chunks->save_snapshot(rec);
     }
 
-    void flush_cb(Caliper* c, Channel* chn, SnapshotFlushFn proc_fn)
+    void flush_cb(Caliper* c, SnapshotFlushFn proc_fn)
     {
         std::lock_guard<std::mutex> g(flush_lock);
-
         TraceBuffer* tbuf = nullptr;
 
         {
             std::lock_guard<util::spinlock> g(tbuf_lock);
-
             tbuf = tbuf_list;
         }
 
@@ -171,23 +168,20 @@ class Trace
             // but just drop the snapshot
 
             tbuf->stopped.store(true);
-
             num_written += tbuf->chunks->flush(c, proc_fn);
             tbuf->stopped.store(false);
         }
 
-        Log(1).stream() << chn->name() << ": Trace: Flushed " << num_written << " snapshots." << std::endl;
+        Log(1).stream() << m_channel.name() << ": trace: Flushed " << num_written << " snapshots.\n";
     }
 
     void clear_cb(Caliper* c, Channel* chn)
     {
         std::lock_guard<std::mutex> g(flush_lock);
-
         TraceBuffer* tbuf = nullptr;
 
         {
             std::lock_guard<util::spinlock> g(tbuf_lock);
-
             tbuf = tbuf_list;
         }
 
@@ -233,7 +227,7 @@ class Trace
             unitfmt_result bytes_reserved = unitfmt(aggregate_info.reserved, unitfmt_bytes);
             unitfmt_result bytes_used     = unitfmt(aggregate_info.used, unitfmt_bytes);
 
-            Log(2).stream() << chn->name() << ": Trace: " << bytes_reserved.val << " " << bytes_reserved.symbol
+            Log(2).stream() << chn->name() << ": trace: " << bytes_reserved.val << " " << bytes_reserved.symbol
                             << " reserved, " << bytes_used.val << " " << bytes_used.symbol << " used, "
                             << aggregate_info.nchunks << " chunks." << std::endl;
         }
@@ -250,24 +244,22 @@ class Trace
         if (it != polmap.end())
             policy = it->second;
         else
-            Log(0).stream() << "Trace: error: unknown buffer policy \"" << polname << "\"" << std::endl;
+            Log(0).stream() << "trace: error: unknown buffer policy \"" << polname << "\"" << std::endl;
     }
 
     void create_thread_cb(Caliper* c, Channel* chn)
     {
         // init trace buffer on new threads
-        acquire_tbuf(c, chn, true);
+        acquire_tbuf(c, true);
     }
 
     void release_thread_cb(Caliper* c, Channel* chn)
     {
-        TraceBuffer* tbuf = acquire_tbuf(c, chn, false);
+        TraceBuffer* tbuf = acquire_tbuf(c, false);
 
         if (tbuf) {
             tbuf->retired.store(true);
-
             std::lock_guard<util::spinlock> g(tbuf_lock);
-
             ++num_retired;
         }
     }
@@ -281,18 +273,18 @@ class Trace
                             << num_retired << " retired, " << num_released << " released." << std::endl;
     }
 
-    Trace(Caliper* c, Channel* chn) : dropped_snapshots(0)
+    Trace(Caliper* c, Channel* channel) : dropped_snapshots(0), m_channel { *channel }
     {
         tbuf_lock.unlock();
         flush_lock.unlock();
 
-        ConfigSet cfg = services::init_config_from_spec(chn->config(), s_spec);
+        ConfigSet cfg = services::init_config_from_spec(channel->config(), s_spec);
 
         init_overflow_policy(cfg.get("buffer_policy").to_string());
         buffersize = cfg.get("buffer_size").to_uint() * 1024 * 1024;
 
         tbuf_attr = c->create_attribute(
-            std::string("trace.tbuf.") + std::to_string(chn->id()),
+            std::string("trace.tbuf.") + std::to_string(channel->id()),
             CALI_TYPE_PTR,
             CALI_ATTR_SCOPE_THREAD | CALI_ATTR_ASVALUE | CALI_ATTR_SKIP_EVENTS | CALI_ATTR_HIDDEN
         );
@@ -323,11 +315,11 @@ public:
         chn->events().release_thread_evt.connect([instance](Caliper* c, Channel* chn) {
             instance->release_thread_cb(c, chn);
         });
-        chn->events().process_snapshot.connect([instance](Caliper* c, Channel* chn, SnapshotView, SnapshotView rec) {
-            instance->process_snapshot_cb(c, chn, rec);
+        chn->events().process_snapshot.connect([instance](Caliper* c, SnapshotView, SnapshotView rec) {
+            instance->process_snapshot_cb(c, rec);
         });
-        chn->events().flush_evt.connect([instance](Caliper* c, Channel* chn, SnapshotView, SnapshotFlushFn fn) {
-            instance->flush_cb(c, chn, fn);
+        chn->events().flush_evt.connect([instance](Caliper* c, SnapshotView, SnapshotFlushFn fn) {
+            instance->flush_cb(c, fn);
         });
         chn->events().clear_evt.connect([instance](Caliper* c, Channel* chn) { instance->clear_cb(c, chn); });
         chn->events().finish_evt.connect([instance](Caliper* c, Channel* chn) {
@@ -338,7 +330,7 @@ public:
         });
 
         // Initialize trace buffer on master thread
-        instance->acquire_tbuf(c, chn, true);
+        instance->acquire_tbuf(c, true);
 
         Log(1).stream() << chn->name() << ": Registered trace service" << std::endl;
     }

--- a/src/services/umpire/UmpireStatistics.cpp
+++ b/src/services/umpire/UmpireStatistics.cpp
@@ -48,7 +48,6 @@ class UmpireService
 
     void process_allocator(
         Caliper*           c,
-        Channel*           channel,
         const std::string& name,
         umpire::Allocator& alloc,
         SnapshotView       context
@@ -126,7 +125,7 @@ class UmpireService
         rec.append(m_total_hwm_attr, Variant(total_hwm));
     }
 
-    void record_global_highwatermarks(Caliper* c, Channel* channel)
+    void record_global_highwatermarks(Caliper* c, ChannelBody* chB)
     {
         auto& rm = umpire::ResourceManager::getInstance();
 
@@ -139,7 +138,7 @@ class UmpireService
 
             uint64_t hwm = rm.getAllocator(s).getHighWatermark();
 
-            c->set(channel, attr, Variant(hwm));
+            c->set(chB, attr, Variant(hwm));
         }
     }
 
@@ -221,8 +220,8 @@ public:
         });
 
         if (instance->m_record_global_hwm)
-            channel->events().pre_flush_evt.connect([instance](Caliper* c, Channel* channel, SnapshotView) {
-                instance->record_global_highwatermarks(c, channel);
+            channel->events().pre_flush_evt.connect([instance](Caliper* c, ChannelBody* chB, SnapshotView) {
+                instance->record_global_highwatermarks(c, chB);
             });
 
         Log(1).stream() << channel->name() << ": Registered umpire service" << std::endl;

--- a/src/services/umpire/UmpireStatistics.cpp
+++ b/src/services/umpire/UmpireStatistics.cpp
@@ -21,6 +21,8 @@ namespace
 
 class UmpireService
 {
+    Channel m_channel;
+
     Attribute m_alloc_name_attr;
     Attribute m_alloc_current_size_attr;
     Attribute m_alloc_actual_size_attr;
@@ -72,10 +74,10 @@ class UmpireService
         rec.builder().append(context);
 
         c->make_record(5, attr, data, rec.builder(), &m_root_node);
-        channel->events().process_snapshot(c, channel, SnapshotView(), rec.view());
+        m_channel.events().process_snapshot(c, SnapshotView(), rec.view());
     }
 
-    void snapshot(Caliper* c, Channel* channel, SnapshotView info, SnapshotBuilder& rec)
+    void snapshot(Caliper* c, SnapshotView info, SnapshotBuilder& rec)
     {
         //   Bit of a hack: We create one record for each allocator for
         // allocator-specific info. This way we can use generic allocator.name
@@ -116,7 +118,7 @@ class UmpireService
             total_hwm += alloc.getHighWatermark();
 
             if (m_per_allocator_stats)
-                process_allocator(c, channel, s, alloc, context.view());
+                process_allocator(c, s, alloc, context.view());
         }
 
         rec.append(m_total_size_attr, Variant(total_size));
@@ -186,7 +188,7 @@ class UmpireService
         );
     }
 
-    UmpireService(Caliper* c, Channel* channel) : m_root_node(CALI_INV_ID, CALI_INV_ID, Variant())
+    UmpireService(Caliper* c, Channel* channel) : m_channel { *channel }, m_root_node(CALI_INV_ID, CALI_INV_ID, Variant())
     {
         auto config = services::init_config_from_spec(channel->config(), s_spec);
 

--- a/src/services/variorum/Variorum.cpp
+++ b/src/services/variorum/Variorum.cpp
@@ -90,7 +90,7 @@ class VariorumService
     // Number of measurement errors encountered at runtime
     unsigned m_num_errors;
 
-    void snapshot_cb(Caliper* c, Channel* /*channel*/, SnapshotView /*trigger_info*/, SnapshotBuilder& rec)
+    void snapshot_cb(Caliper* c, SnapshotView /*trigger_info*/, SnapshotBuilder& rec)
     {
         // The snapshot callback triggers performance measurements.
         // Measurement services should make measurements and add them to the
@@ -270,8 +270,8 @@ public:
             instance->post_init_cb(c, channel);
         });
         channel->events().snapshot.connect(
-            [instance](Caliper* c, Channel* channel, SnapshotView trigger_info, SnapshotBuilder& rec) {
-                instance->snapshot_cb(c, channel, trigger_info, rec);
+            [instance](Caliper* c, SnapshotView trigger_info, SnapshotBuilder& rec) {
+                instance->snapshot_cb(c, trigger_info, rec);
             }
         );
         channel->events().finish_evt.connect([instance](Caliper* c, Channel* channel) {

--- a/src/services/vtune/VTuneBindings.cpp
+++ b/src/services/vtune/VTuneBindings.cpp
@@ -68,13 +68,13 @@ public:
 
     const char* service_tag() const { return "vtune"; };
 
-    void on_begin(Caliper* c, Channel*, const Attribute& attr, const Variant& value)
+    void on_begin(Caliper* c, const Attribute& attr, const Variant& value)
     {
         if (attr.type() == CALI_TYPE_STRING)
             __itt_task_begin(get_itt_domain(attr), __itt_null, __itt_null, get_itt_string(value));
     }
 
-    void on_end(Caliper* c, Channel*, const Attribute& attr, const Variant& value)
+    void on_end(Caliper* c, const Attribute& attr, const Variant& value)
     {
         if (attr.type() == CALI_TYPE_STRING)
             __itt_task_end(get_itt_domain(attr));

--- a/test/cali-flush-perftest.cpp
+++ b/test/cali-flush-perftest.cpp
@@ -165,10 +165,10 @@ int main(int argc, char* argv[])
 
     for (auto& chn : channels)
         if (cfg.write)
-            c.flush_and_write(&chn, cali::SnapshotView());
+            c.flush_and_write(chn.body(), cali::SnapshotView());
         else
             c.flush(
-                &chn,
+                chn.body(),
                 cali::SnapshotView(),
                 [](cali::CaliperMetadataAccessInterface&, const std::vector<cali::Entry>&) {}
             );

--- a/test/ci_app_tests/ci_test_binding.cpp
+++ b/test/ci_app_tests/ci_test_binding.cpp
@@ -34,7 +34,7 @@ public:
         c->make_tree_entry(m_prop_attr, Variant(4242), c->node(attr.id()));
     }
 
-    void on_begin(Caliper* c, Channel* chn, const Attribute& attr, const Variant& value)
+    void on_begin(Caliper* c, const Attribute& attr, const Variant& value)
     {
         if (attr == m_my_attr)
             return;
@@ -50,7 +50,7 @@ public:
             std::cout << "begin " << s << std::endl;
     }
 
-    void on_end(Caliper* c, Channel* chn, const Attribute& attr, const Variant& value)
+    void on_end(Caliper* c, const Attribute& attr, const Variant& value)
     {
         if (attr == m_my_attr)
             return;

--- a/test/ci_app_tests/test_basictrace.py
+++ b/test/ci_app_tests/test_basictrace.py
@@ -181,7 +181,7 @@ class CaliperBasicTraceTest(unittest.TestCase):
 
     def test_esc(self):
         target_cmd = [ './ci_test_basic', 'newline' ]
-        query_cmd  = [ '../../src/tools/cali-query/cali-query', '-j', '-s', 'cali.event.set' ]
+        query_cmd  = [ '../../src/tools/cali-query/cali-query', '-j' ]
 
         caliper_config = {
             'CALI_CONFIG_PROFILE'    : 'serial-trace',
@@ -191,10 +191,16 @@ class CaliperBasicTraceTest(unittest.TestCase):
 
         obj = json.loads( cat.run_test_with_query(target_cmd, query_cmd, caliper_config) )
 
-        self.assertEqual(len(obj), 2)
+        targets = {}
+        for rec in obj:
+            for key in rec.keys():
+                if key.startswith('event.set#'):
+                    targets[key] = rec[key]
 
-        self.assertEqual(obj[0]['event.set# =\\weird ""attribute"=  '], '  \\\\ weird," name",' )
-        self.assertEqual(obj[1]['event.set#newline'], 'A newline:\n!')
+        self.assertGreaterEqual(len(targets), 2)
+
+        self.assertEqual(targets['event.set# =\\weird ""attribute"=  '], '  \\\\ weird," name",' )
+        self.assertEqual(targets['event.set#newline'], 'A newline:\n!')
 
     def test_macros(self):
         # Use ConfigManager API here

--- a/test/ci_app_tests/test_report.py
+++ b/test/ci_app_tests/test_report.py
@@ -122,7 +122,7 @@ class CaliperReportTest(unittest.TestCase):
 
         caliper_config = {
             'CALI_SERVICES_ENABLE'   : 'event,trace,report',
-            'CALI_REPORT_CONFIG'     : 'select *,count() as Count group by path where cali.event.end format tree',
+            'CALI_REPORT_CONFIG'     : 'select *,sum(region.count) as Count group by path where region.count format tree',
             'CALI_LOG_VERBOSITY'     : '0'
         }
 
@@ -139,13 +139,9 @@ class CaliperReportTest(unittest.TestCase):
         ]
 
         report_output,_ = cat.run_test(target_cmd, caliper_config)
-        lines = report_output.decode().splitlines()
-
+        lines = [ l.rstrip() for l in report_output.decode().splitlines() ]
         for target in report_targets:
-            for line in lines:
-                if target in line:
-                    break
-            else:
+            if not target in lines:
                 self.fail('%s not found in report' % target)
 
     def test_report_table_formatter(self):


### PR DESCRIPTION
Simplify channel arguments in the Caliper callback functions. Also adds a major performance improvement for generating snapshot info nodes for begin/end/set events, e.g. when tracing.