### PR TITLE
Fix clang warnings

### DIFF
--- a/src/services/mpiwrap/Wrapper.w
+++ b/src/services/mpiwrap/Wrapper.w
@@ -24,6 +24,7 @@
 
 #if defined(__GNUC__)
 #    pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#    pragma GCC diagnostic ignored "-Wunused-variable"
 #endif
 
 namespace cali


### PR DESCRIPTION
Fix compilation warnings with clang-22

```
caliper-build/src/services/mpiwrap/Wrapper.cpp:225:6: warning: ‘{anonymous}::MPI_Barrier_is_wrapped’ defined but not used [-Wunused-variable]
  225 | bool MPI_Barrier_is_wrapped = false;
      |      ^~~~~~~~~~~~~~~~~~~~~~
caliper-build/src/services/mpiwrap/Wrapper.cpp:222:6: warning: ‘{anonymous}::MPI_Attr_put_is_wrapped’ defined but not used [-Wunused-variable]
  222 | bool MPI_Attr_put_is_wrapped = false;
      |      ^~~~~~~~~~~~~~~~~~~~~~~
caliper-build/src/services/mpiwrap/Wrapper.cpp:219:6: warning: ‘{anonymous}::MPI_Attr_get_is_wrapped’ defined but not used [-Wunused-variable]
  219 | bool MPI_Attr_get_is_wrapped = false;
      |      ^~~~~~~~~~~~~~~~~~~~~~~
```