### PR TITLE
LDMS Connector: update to LDMS 4.5.1

### DIFF
--- a/cmake/FindLDMS.cmake
+++ b/cmake/FindLDMS.cmake
@@ -17,23 +17,38 @@
 #  LDMS_LIBRARIES          The LDMS library
 #  LDMS_INCLUDE_DIRS       The location of LDMS headers
 
+# Set up search paths based on LDMS_PREFIX
+set(LDMS_SEARCH_PATHS /usr/lib64 /usr/lib /opt/ovis/lib)
+set(LDMS_INCLUDE_SEARCH_PATHS /usr/include /usr/local/include /opt/ovis/include)
+
+if(LDMS_PREFIX)
+    list(INSERT LDMS_SEARCH_PATHS 0 "${LDMS_PREFIX}/lib")
+    list(INSERT LDMS_INCLUDE_SEARCH_PATHS 0 "${LDMS_PREFIX}/include")
+endif()
+
 find_library(LDMS_LIBLDMS
     NAMES ldms
-    PATHS /usr/lib64 /usr/lib /opt/ovis/lib
+    PATHS ${LDMS_SEARCH_PATHS}
 )
 
 find_library(LDMS_LIBSTREAM
     NAMES ldmsd_stream
-    PATHS /usr/lib64 /usr/lib /opt/ovis/lib
+    PATHS ${LDMS_SEARCH_PATHS}
 )
 
 find_path(LDMS_INCLUDE_DIRS
-    NAMES "ldms.h" "ldmsd_stream.h"
-    PATH_SUFFIXES "ldms"
+    NAMES "ldms/ldms.h" "ldms/ldmsd_stream.h"
+    PATHS ${LDMS_INCLUDE_SEARCH_PATHS}
 )
-message(STATUS "libldms.so => ${LDMS_LIBRARIES}")
-message(STATUS "ldmsd_stream.h => ${LDMS_INCLUDE_DIRS}")
-message(STATUS "ldms.h => ${LDMS_INCLUDE_DIRS}")
+
+message(STATUS "libldms.so => ${LDMS_LIBLDMS}")
+message(STATUS "libldmsd_stream.so => ${LDMS_LIBSTREAM}")
+message(STATUS "LDMS include dir => ${LDMS_INCLUDE_DIRS}")
+
+# Set LDMS_LIBRARIES to include both libraries
+if(LDMS_LIBLDMS AND LDMS_LIBSTREAM)
+    set(LDMS_LIBRARIES ${LDMS_LIBLDMS} ${LDMS_LIBSTREAM})
+endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(LDMS DEFAULT_MSG

--- a/src/services/ldms/CMakeLists.txt
+++ b/src/services/ldms/CMakeLists.txt
@@ -1,11 +1,11 @@
-include_directories(${LDMS_INCLUDE_DIRS})
-
 set(CALIPER_LDMS_SOURCES
   LdmsForwarder.cpp)
 
 add_library(caliper-ldms OBJECT ${CALIPER_LDMS_SOURCES})
+target_include_directories(caliper-ldms PRIVATE ${LDMS_INCLUDE_DIRS})
+
+# Add compiler flags to handle LDMS header compatibility issues
+target_compile_options(caliper-ldms PRIVATE -fpermissive)
 
 add_service_objlib("caliper-ldms")
 add_caliper_service("ldms CALIPER_HAVE_LDMS")
-
-


### PR DESCRIPTION
Work in progress -- do not merge (I'm still testing locally on a sample application, and we should consider adding some unit testing for the connector)


These changes are required to compile Caliper with LDMS 4.5.1. In addition to general updates to the API, I encountered several bugs in the implementation of the pipeline.

### API Updates

-  `ldms_xprt_put()` now requires a name. As a placeholder, I'm using `"tst"`
- `ldms_xprt_new_with_auth` has a new function signature--I removed the second nullptr from the args

### Summary of Bug Fixes

#### 1. CMake

The LDMS_PREFIX cmake variable was not being used anywhere, so Caliper could not link with a custom LDMS installation. I added a few lines in FindLDMS.cmake to use LDMS_PREFIX.

#### 2. Env Variables

In `LdmsForwarder.cpp`, if one of the env variables is not set, all are set to the defaults. I broke up that if-block so I could set just one var and the rest fall back to defaults.

#### 3. JSON

In `LdmsForwarder.cpp` (`write_ldms_record()`), the JSON string is missing a key for the `"caliper-perf-data"` value. I added the "stream" key so the JSON went from:

```
{
    ...,
    nodelist: XX,
    caliper-perf-data,
    duration: YY,
    ...
}
```
to 
```
{
    ...,
    nodelist: XX,
    stream: caliper-perf-data,
    duration: YY,
    ...
}
```

#### 4. Connection

I was getting errors running on more than 6 ranks. I think that the issue was that `write_ldms_record()` was calling `caliper_ldms_connector_initialize()` on every write, so as the number of ranks increased I was creating too many connections.

As a possible fix, I made the LDMS connection into a member variable in the `LdmsForwarder` class, initializing this once per rank and reusing it for every write on that rank. I'm not sure if this has consequences beyond my narrow use-case, but it did seem to resolve the problem for me.


FYI @ppebay