### PR TITLE
Add find_dependency(CUDAToolkit) to caliper-config.cmake.in

### DIFF
--- a/caliper-config.cmake.in
+++ b/caliper-config.cmake.in
@@ -2,10 +2,6 @@
 
 include(CMakeFindDependencyMacro)
 
-if (@CALIPER_HAVE_CUPTI@)
-  find_dependency(CUDAToolkit)
-endif()
-
 include("${CMAKE_CURRENT_LIST_DIR}/caliper-targets.cmake")
 
 set_and_check(caliper_INCLUDE_DIR "@PACKAGE_caliper_INSTALL_INCLUDE_DIR@")
@@ -38,6 +34,11 @@ endif()
 if (@CALIPER_HAVE_ROCPROFILER@)
   find_dependency(rocprofiler-sdk)
   find_dependency(rocprofiler-sdk-roctx)
+endif()
+
+# Add CUDAToolkit target for cupti support
+if (@CALIPER_HAVE_CUPTI@)
+  find_dependency(CUDAToolkit)
 endif()
 
 check_required_components(caliper)


### PR DESCRIPTION
Without this change, applications that do not find the cupti target will incur the following cmake configuration error.

```
1 error found in build log:
     98     -- Kripke: Using external CAMP
     99     -- Kripke: Setting CAMP_HAVE_CUDA
     100    -- Caliper support is TRUE
     101    -- Kripke selected default architecture: 'CUDA'
     102    -- Kripke selected default layout:       'DGZ'
     103    -- Configuring done (5.9s)
  >> 104    CMake Error at /usr/WS1/mckinsey/bp_cuptihackathon/wkp-fail/spack/o
            pt/spack/linux-sapphirerapids/caliper-master-ngq5qtesxcpkhloxgp5ack
            czyt323vle/share/cmake/caliper/caliper-targets.cmake:61 (set_target
            _properties):
     105      The link interface of target "caliper" contains:
     106    
     107        CUDA::cupti
     108    
     109      but the target was not found.  Possible reasons include:
     110    
```