### PR TITLE
Add DeepWiki documentation badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Caliper: A Performance Analysis Toolbox in a Library
 ==========================================
 
-[![Github Actions](https://github.com/LLNL/Caliper/actions/workflows/cmake.yml/badge.svg)](https://github.com/LLNL/Caliper/actions)
+[![Github Actions](https://github.com/LLNL/Caliper/actions/workflows/cmake.yml/badge.svg)](https://github.com/LLNL/Caliper/actions) [![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/llnl/Caliper)
 [![Build Status](https://travis-ci.org/LLNL/Caliper.svg)](https://travis-ci.org/LLNL/Caliper)
 [![Coverage](https://img.shields.io/codecov/c/github/LLNL/Caliper/master.svg)](https://codecov.io/gh/LLNL/Caliper)
 


### PR DESCRIPTION
Adds a [DeepWiki](https://deepwiki.com/llnl/Caliper) badge to the README for auto-generated interactive documentation.

This is a minimal, single-line addition.