### PR TITLE
Improved CI jobs logs and error handling

### DIFF
--- a/scripts/gitlab/build-and-test.sh
+++ b/scripts/gitlab/build-and-test.sh
@@ -13,8 +13,23 @@ fi
 # SPDX-License-Identifier: (BSD-3-Clause)
 ###############################################################################
 
+# Navigation:
+# - VARIABLES
+# - HELPER FUNCTIONS
+# - SETUP
+# - BUILD DEPENDENCIES
+# - HOST CONFIG / CMAKE CACHE FILES
+# - BUILD PROJECT
+# - TEST PROJECT
+
+###############################################################################
+# VARIABLES
+###############################################################################
+
 set -o errexit
 set -o nounset
+
+exec 2>&1
 
 option=${1:-""}
 hostname="$(hostname)"
@@ -37,21 +52,164 @@ ci_registry_image=${CI_REGISTRY_IMAGE:-"czregistry.llnl.gov:5050/radiuss/caliper
 export ci_registry_user=${CI_REGISTRY_USER:-"${USER}"}
 export ci_registry_token=${CI_JOB_TOKEN:-"${registry_token}"}
 
-timed_message ()
+###############################################################################
+# HELPER FUNCTIONS
+###############################################################################
+
+# Helper function to print errors in red
+print_error ()
 {
-    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-    echo "~ $(date --rfc-3339=seconds) ~ ${1}"
-    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    local error_msg="${1}"
+    echo -e "\e[31m[Error]: ${error_msg}\e[0m"
 }
+
+# Helper function to print warnings in gray
+print_warning ()
+{
+    local warning_msg="${1}"
+    echo -e "\e[1;30m[Warning]: ${warning_msg}\e[0m"
+}
+
+# Helper function to print information
+print_info ()
+{
+    local info_msg="${1}"
+    echo -e "[Information]: ${info_msg}"
+}
+
+# Portable UTC timestamp formatter for epoch seconds.
+format_utc_timestamp ()
+{
+    local timestamp="${1}"
+    # BSD/macOS date supports epoch conversion via: date -r <seconds>
+    if date -u -r "${timestamp}" "+%Y-%m-%d %H:%M:%S UTC" >/dev/null 2>&1
+    then
+        date -u -r "${timestamp}" "+%Y-%m-%d %H:%M:%S UTC"
+    else
+        # GNU date supports epoch conversion via: date -d "@<seconds>"
+        date -u -d "@${timestamp}" "+%Y-%m-%d %H:%M:%S UTC"
+    fi
+}
+
+# Portable elapsed time formatter (HH:MM:SS).
+format_elapsed_hms ()
+{
+    local elapsed="${1}"
+    printf '%02d:%02d:%02d' $((elapsed / 3600)) $(((elapsed % 3600) / 60)) $((elapsed % 60))
+}
+
+# Track script start time for elapsed time calculations
+script_start_time=$(date +%s)
+
+# Storage for section start times (supports nesting)
+declare -A section_start_times
+
+# Section stack for tracking nested sections
+section_id_stack=()
+section_counter=0
+section_indent=""
+
+# GitLab CI collapsible section helpers with nesting support
+section_start ()
+{
+    local section_name="${1}"
+    local section_title="${2}"
+    local section_state="${3:-""}"
+
+    local collapsed="false"
+    if [[ "${section_state}" == "collapsed" ]]
+    then
+        collapsed="true"
+    fi
+
+    # Generate unique section ID
+    section_counter=$((section_counter + 1))
+    local section_id="${section_name}_${section_counter}"
+
+    local timestamp=$(date +%s)
+    local current_time=$(format_utc_timestamp "${timestamp}")
+    local total_elapsed=$((timestamp - script_start_time))
+    local total_elapsed_formatted=$(format_elapsed_hms "${total_elapsed}")
+
+    # Store section start time for later calculation
+    section_start_times[${section_id}]=${timestamp}
+
+    # Push section ID onto stack
+    section_id_stack+=("${section_id}")
+
+    echo -e "\e[1;30m${section_indent}~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\e[0m"
+    echo -e "\e[1;30m${section_indent}~ TIME                    | TOTAL    | SECTION  \e[0m"
+    echo -e "\e[1;30m${section_indent}~ ${current_time} | ${total_elapsed_formatted} | ${section_title}\e[0m"
+    echo -e "\e[0Ksection_start:${timestamp}:${section_id}[collapsed=${collapsed}]\r\e[0K${section_indent}~ ${section_title}"
+
+    # Increase indentation for nested sections
+    section_indent="${section_indent}  "
+}
+
+section_end ()
+{
+    # Pop section ID from stack
+    if [[ ${#section_id_stack[@]} -eq 0 ]]; then
+        print_warning "section_end called with empty stack"
+        return 1
+    fi
+
+    # Decrease indentation before displaying
+    section_indent="${section_indent%  }"
+
+    local stack_index=$((${#section_id_stack[@]} - 1))
+    local section_id="${section_id_stack[$stack_index]}"
+    unset section_id_stack[$stack_index]
+
+    local timestamp=$(date +%s)
+    local current_time=$(format_utc_timestamp "${timestamp}")
+    local total_elapsed=$((timestamp - script_start_time))
+    local total_elapsed_formatted=$(format_elapsed_hms "${total_elapsed}")
+
+    # Calculate section elapsed time
+    local section_start=${section_start_times[${section_id}]:-${timestamp}}
+    local section_elapsed=$((timestamp - section_start))
+    local section_elapsed_formatted=$(format_elapsed_hms "${section_elapsed}")
+
+    echo -e "\e[0Ksection_end:${timestamp}:${section_id}\r\e[0K\e[0m"
+    echo -e "\e[1;30m${section_indent}~ ${current_time} | ${total_elapsed_formatted} | ${section_elapsed_formatted}\e[0m"
+    echo -e "\e[1;30m${section_indent}~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\e[0m"
+
+    # Clean up stored time
+    unset section_start_times[${section_id}]
+}
+
+# For convenience, a helper function to run a command within a section and handle errors
+run_section ()
+{
+    local id="$1"
+    local title="$2"
+    local collapsed="$3"
+    local err_msg="$4"
+    local status=0
+    shift 4
+
+    section_start "$id" "$title" "$collapsed"
+    if "$@"; then
+        section_end
+    else
+        status=$?
+        section_end
+        print_error "$err_msg"
+        exit $status
+    fi
+}
+
+###############################################################################
+# SETUP
+###############################################################################
 
 if [[ ${debug_mode} == true ]]
 then
-    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-    echo "~~~~~ Debug mode:"
-    echo "~~~~~ - Spack debug mode."
-    echo "~~~~~ - Deactivated shared memory."
-    echo "~~~~~ - Do not push to buildcache."
-    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    print_info "Debug mode:"
+    print_info "- Spack debug mode."
+    print_info "- Deactivated shared memory."
+    print_info "- Do not push to buildcache."
     use_dev_shm=false
     spack_debug=true
     push_to_registry=false
@@ -59,7 +217,7 @@ fi
 
 if [[ -n ${module_list} ]]
 then
-    timed_message "Modules to load: ${module_list}"
+    print_info "Loading modules: ${module_list}"
     module load ${module_list}
 fi
 
@@ -86,28 +244,30 @@ else
     prefix="${project_dir}/../spack-and-build-root"
 fi
 
-echo "Creating directory ${prefix}"
-echo "project_dir: ${project_dir}"
+print_info "Creating directory ${prefix}"
+print_info "project_dir: ${project_dir}"
 
 mkdir -p ${prefix}
 
 spack_cmd="${prefix}/spack/bin/spack"
 spack_env_path="${prefix}/spack_env"
-uberenv_cmd="./scripts/uberenv/uberenv.py"
+uberenv_cmd="${project_dir}/scripts/uberenv/uberenv.py"
 if [[ ${spack_debug} == true ]]
 then
     spack_cmd="${spack_cmd} --debug --stacktrace"
     uberenv_cmd="${uberenv_cmd} --spack-debug"
 fi
 
-# Dependencies
+###############################################################################
+# BUILD DEPENDENCIES
+###############################################################################
 if [[ "${option}" != "--build-only" && "${option}" != "--test-only" ]]
 then
-    timed_message "Building dependencies"
+    section_start "dependencies" "Building Dependencies"
 
     if [[ -z ${spec} ]]
     then
-        echo "[Error]: SPEC is undefined, aborting..."
+        section_end ; print_error "SPEC is undefined, aborting..."
         exit 1
     fi
 
@@ -122,45 +282,51 @@ then
     mkdir -p ${spack_user_cache}
 
     # generate cmake cache file with uberenv and radiuss spack package
-    timed_message "Spack setup and environment"
-    ${uberenv_cmd} --setup-and-env-only --spec="${spec}" ${prefix_opt}
+    run_section "spack_setup" "Spack setup and environment" "collapsed" \
+      "Spack environment setup failed (Uberenv)" \
+      ${uberenv_cmd} --setup-and-env-only --spec="${spec}" ${prefix_opt}
 
     if [[ -n ${ci_registry_token} ]]
     then
-        timed_message "GitLab registry as Spack Buildcache"
-        ${spack_cmd} -D ${spack_env_path} mirror add --unsigned --oci-username-variable ci_registry_user --oci-password-variable ci_registry_token gitlab_ci oci://${ci_registry_image}
+        run_section "registry_setup" "GitLab registry as Spack Buildcache" "collapsed" \
+          "Adding gitlab registry to spack environment failed" \
+          ${spack_cmd} -D ${spack_env_path} mirror add --unsigned --oci-username-variable ci_registry_user --oci-password-variable ci_registry_token gitlab_ci oci://${ci_registry_image}
     fi
 
-    timed_message "Spack build of dependencies"
-    ${uberenv_cmd} --skip-setup-and-env --spec="${spec}" ${prefix_opt}
+    run_section "spack_build" "Spack build of dependencies" "collapsed" \
+      "Spack build of dependencies failed (Uberenv)" \
+      ${uberenv_cmd} --skip-setup-and-env --spec="${spec}" ${prefix_opt}
 
     if [[ -n ${ci_registry_token} && ${push_to_registry} == true ]]
     then
-        timed_message "Push dependencies to buildcache"
-        ${spack_cmd} -D ${spack_env_path} buildcache push --only dependencies gitlab_ci
+        run_section "buildcache_push" "Push dependencies to buildcache" "collapsed" \
+          "Pushing dependencies to gitlab registry failed" \
+          ${spack_cmd} -D ${spack_env_path} buildcache push --only dependencies gitlab_ci
     fi
 
-    timed_message "Dependencies built"
+    section_end
 fi
 
-# Find cmake cache file (hostconfig)
+###############################################################################
+# HOST CONFIG / CMAKE CACHE FILE
+###############################################################################
 if [[ -z ${hostconfig} ]]
 then
     # If no host config file was provided, we assume it was generated.
     # This means we are looking of a unique one in project dir.
-    hostconfigs=( $( ls "${project_dir}/"*.cmake ) )
+    shopt -s nullglob; hostconfigs=( "${project_dir}"/*.cmake ); shopt -u nullglob
     if [[ ${#hostconfigs[@]} == 1 ]]
     then
         hostconfig_path=${hostconfigs[0]}
     elif [[ ${#hostconfigs[@]} == 0 ]]
     then
-        echo "[Error]: No result for: ${project_dir}/*.cmake"
-        echo "[Error]: Spack generated host-config not found."
+        print_error "No result for: ${project_dir}/*.cmake"
+        print_error "Spack generated host-config not found."
         exit 1
     else
-        echo "[Error]: More than one result for: ${project_dir}/*.cmake"
-        echo "[Error]: ${hostconfigs[@]}"
-        echo "[Error]: Please specify one with HOST_CONFIG variable"
+        print_error "More than one result for: ${project_dir}/*.cmake"
+        print_error "${hostconfigs[@]}"
+        print_error "Please specify one with HOST_CONFIG variable"
         exit 1
     fi
 else
@@ -169,8 +335,11 @@ else
 fi
 
 hostconfig=$(basename ${hostconfig_path})
-echo "[Information]: Found hostconfig ${hostconfig_path}"
+print_info "Found hostconfig ${hostconfig_path}"
 
+###############################################################################
+# BUILD PROJECT
+###############################################################################
 # Build Directory
 # When using /dev/shm, we use prefix for both spack builds and source build, unless BUILD_ROOT was defined
 build_root=${BUILD_ROOT:-"${prefix}"}
@@ -178,20 +347,17 @@ build_root=${BUILD_ROOT:-"${prefix}"}
 build_dir="${build_root}/build_${hostconfig//.cmake/}"
 install_dir="${build_root}/install_${hostconfig//.cmake/}"
 
-cmake_exe=`grep 'CMake executable' ${hostconfig_path} | cut -d ':' -f 2 | xargs`
+cmake_exe=$(grep 'CMake executable' ${hostconfig_path} | cut -d ':' -f 2 | xargs 2>/dev/null)
 
-# Build
 if [[ "${option}" != "--deps-only" && "${option}" != "--test-only" ]]
 then
-    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-    echo "~~~~~ Prefix: ${prefix}"
-    echo "~~~~~ Host-config: ${hostconfig_path}"
-    echo "~~~~~ Build Dir:   ${build_dir}"
-    echo "~~~~~ Project Dir: ${project_dir}"
-    echo "~~~~~ Install Dir: ${install_dir}"
-    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-    echo ""
-    timed_message "Cleaning working directory"
+    print_info "Prefix       ${prefix}"
+    print_info "Host-config  ${hostconfig_path}"
+    print_info "Build Dir    ${build_dir}"
+    print_info "Project Dir  ${project_dir}"
+    print_info "Install Dir  ${install_dir}"
+
+    section_start "clean" "Cleaning working directory" "collapsed"
 
     # Map CPU core allocations
     declare -A core_counts=(["lassen"]=40 ["dane"]=28 ["matrix"]=28 ["corona"]=32 ["rzansel"]=48 ["tioga"]=32 ["tuolumne"]=48)
@@ -202,8 +368,8 @@ then
     #       use max cores.
     rm -rf ${build_dir} 2>/dev/null
     mkdir -p ${build_dir} && cd ${build_dir}
+    section_end
 
-    timed_message "Building Caliper"
     # We set the MPI tests command to allow overlapping.
     # Shared allocation: Allows build_and_test.sh to run within a sub-allocation (see CI config).
     # Use /dev/shm: Prevent MPI tests from running on a node where the build dir doesn't exist.
@@ -216,55 +382,78 @@ then
         cmake_options="-DRUN_MPI_TESTS=Off"
     fi
 
-    $cmake_exe \
+    section_start "cmake_config" "CMake Configuration" "collapsed"
+    if $cmake_exe \
       -C ${hostconfig_path} \
       ${cmake_options} \
       -DCMAKE_INSTALL_PREFIX=${install_dir} \
       ${project_dir}
-    if ! $cmake_exe --build . -j ${core_counts[$truehostname]}
     then
-        echo "[Error]: Compilation failed, building with verbose output..."
-        timed_message "Re-building with --verbose"
-        $cmake_exe --build . --verbose -j 1
+        section_end
     else
-        timed_message "Installing"
-        $cmake_exe --install .
+        status=$?
+        section_end ; print_error "CMake configuration failed"
+        exit ${status}
     fi
 
-    timed_message "Caliper built and installed"
+    section_start "build" "Building Caliper" "collapsed"
+    if $cmake_exe --build . -j ${core_counts[$truehostname]}
+    then
+        section_end
+    else
+        status=$?
+        section_end ; print_error "Compilation failed, building with verbose output..."
+
+        section_start "build_verbose" "Verbose Rebuild"
+        $cmake_exe --build . --verbose -j 1
+        section_end
+
+        exit ${status}
+    fi
+
+    run_section "install" "Installing Caliper" "collapsed" \
+      "Installation failed" \
+      $cmake_exe --install .
 fi
 
-# Test
+###############################################################################
+# TEST PROJECT
+###############################################################################
 if [[ "${option}" != "--build-only" ]]
 then
 
     if [[ ! -d ${build_dir} ]]
     then
-        echo "[Error]: Build directory not found : ${build_dir}" && exit 1
+        print_error "Build directory not found : ${build_dir}"
+        exit 1
     fi
 
     cd ${build_dir}
 
-    timed_message "Testing Caliper"
+    section_start "tests" "Running Tests" "collapsed"
     ctest --output-on-failure -T test 2>&1 | tee tests_output.txt
+    ctest_status=${PIPESTATUS[0]}
 
     no_test_str="No tests were found!!!"
     if [[ "$(tail -n 1 tests_output.txt)" == "${no_test_str}" ]]
     then
-        echo "[Error]: No tests were found" && exit 1
+        section_end ; print_error "No tests were found (ctest status: ${ctest_status})"
+        exit 1
     fi
 
-    timed_message "Preparing tests xml reports for export"
     tree Testing
     xsltproc -o junit.xml ${project_dir}/scripts/radiuss-spack-configs/utilities/ctest-to-junit.xsl Testing/*/Test.xml
     mv junit.xml ${project_dir}/junit.xml
 
     if grep -q "Errors while running CTest" ./tests_output.txt
     then
-        echo "[Error]: Failure(s) while running CTest" && exit 1
+        section_end ; print_error "Failure(s) while running CTest (ctest status: ${ctest_status})"
+        exit 1
     fi
 
-    timed_message "Caliper tests completed"
+    section_end
 fi
 
-timed_message "Build and test completed"
+echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+echo "~ Build and test completed"
+echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"

--- a/scripts/gitlab/build-and-test.sh
+++ b/scripts/gitlab/build-and-test.sh
@@ -392,7 +392,14 @@ then
         section_end
     else
         status=$?
-        section_end ; print_error "CMake configuration failed"
+        section_end ; print_error "CMake configuration failed, dumping output..."
+
+        $cmake_exe \
+          -C ${hostconfig_path} \
+          ${cmake_options} \
+          -DCMAKE_INSTALL_PREFIX=${install_dir} \
+          ${project_dir} --debug-output --trace-expand
+
         exit ${status}
     fi
 


### PR DESCRIPTION
 ## Summary
 
 This ports the GitLab CI log-folding improvements from llnl/Umpire#1049 to Caliper's GitLab build script.
 
 The goal is to make CI logs easier to navigate without changing the underlying build/test workflow.
 
 ## What changed
 
 - add reusable helpers for GitLab collapsible sections
 - add portable UTC timestamps and elapsed-time reporting
 - add nested section support for clearer CI log structure
 - redirect stderr to stdout so section output stays grouped in CI logs
 - replace ad hoc timing messages with structured foldable sections
 - improve error/info/warning output for failed CI steps
 - preserve command exit status when piping `ctest` output through `tee`
 - use safer host-config discovery with `nullglob`
 
 ## Project-specific notes
 
 This keeps the existing Caliper behavior intact, including its project-specific build, test, and cleanup logic. Only the CI log structure and related error/reporting flow were updated.
 
 ## Why
 
 Large GitLab logs are difficult to inspect when everything is printed as a flat stream. Foldable sections make it much easier to:
 - jump to the relevant phase
 - spot failures quickly
 - understand where time is spent in CI
 
 ## Testing
 
 - `bash -n scripts/gitlab/build-and-test.sh`