### PR TITLE
Stop setting spack-packages builtin repo ref in shared environment

### DIFF
--- a/.gitlab/jobs/corona.yml
+++ b/.gitlab/jobs/corona.yml
@@ -21,13 +21,12 @@ variables:
 # project. We keep ${PROJECT_<MACHINE>_VARIANTS} and ${PROJECT_<MACHINE>_DEPS}
 # when possible so that the comparison with the original job is easier.
 
-# rocm@:6.2.3 is not supported by Caliper anymore.
-# Caliper depends on rocprofiler-sdk which requires rocm@6.2.4:
-rocmcc_5_7_1_hip:
-  extends: .job_on_corona
+# Override to allow failure.
+rocmcc_6_4_3_hip:
   variables:
-    ON_CORONA: "OFF"
-
+    SPEC: "${PROJECT_CORONA_VARIANTS} +rocm amdgpu_target=gfx906 %llvm-amdgpu@=6.4.3 ^hip@6.4.3 ${PROJECT_CORONA_DEPS}"
+  extends: .job_on_corona
+  allow_failure: true
 
 ############
 # Extra jobs
@@ -35,12 +34,6 @@ rocmcc_5_7_1_hip:
 # We do not recommend using ${PROJECT_<MACHINE>_VARIANTS} and
 # ${PROJECT_<MACHINE>_DEPS} in the extra jobs. There is no reason not to fully
 # describe the spec here.
-
-rocmcc_6_4_2_hip:
-  variables:
-    SPEC: "${PROJECT_CORONA_VARIANTS} +rocm amdgpu_target=gfx906 %llvm-amdgpu@=6.4.2 ^hip@6.4.2 ${PROJECT_CORONA_DEPS}"
-  extends: .job_on_corona
-  allow_failure: true
 
 master:
   variables:

--- a/.uberenv_config.json
+++ b/.uberenv_config.json
@@ -7,5 +7,7 @@
 "spack_branch": "v1.1.1",
 "spack_configs_path": "scripts/radiuss-spack-configs",
 "spack_packages_path": "scripts/radiuss-spack-configs/spack_repo/llnl_radiuss/packages",
+"spack_packages_url": "https://github.com/spack/spack-packages.git",
+"spack_packages_commit": "e4c0b2d275f9b4714f80156f79f1e29347dedf16",
 "spack_setup_clingo": false
 }


### PR DESCRIPTION
In this PR, the definition of the spack-packages reference to use in CI is transferred from the shared environment configuration in Radiuss-Spack-Configs to the uberenv settings file .uberenv_config.json.

This will allow developers to easily change the spack-packages used in the project CI (and build_and_test.sh use in general).

This required an update of radiuss-spack-configs to remove the reference from the shared environment.