### PR TITLE
Fix some recipe specs

### DIFF
--- a/src/caliper/controllers/CudaActivityProfileController.cpp
+++ b/src/caliper/controllers/CudaActivityProfileController.cpp
@@ -70,7 +70,7 @@ public:
         query.append(format_spec);
 
         if (use_mpi) {
-            config()["CALI_SERVICES_ENABLE"].append(",mpi,mpireport");
+            config()["CALI_SERVICES_ENABLE"].append(",mpireport");
             config()["CALI_AGGREGATE_KEY"]               = "mpi.rank";
             config()["CALI_MPIREPORT_FILENAME"]          = output;
             config()["CALI_MPIREPORT_WRITE_ON_FINALIZE"] = "false";

--- a/src/caliper/controllers/CudaActivityReportController.cpp
+++ b/src/caliper/controllers/CudaActivityReportController.cpp
@@ -68,7 +68,7 @@ public:
         cross_query.append(" format ").append(format);
 
         if (use_mpi) {
-            config()["CALI_SERVICES_ENABLE"].append(",mpi,mpireport");
+            config()["CALI_SERVICES_ENABLE"].append(",mpireport");
             config()["CALI_MPIREPORT_FILENAME"]          = opts.get("output", "stderr");
             config()["CALI_MPIREPORT_APPEND"]            = opts.get("output.append");
             config()["CALI_MPIREPORT_WRITE_ON_FINALIZE"] = "false";

--- a/src/caliper/controllers/OpenMPReportController.cpp
+++ b/src/caliper/controllers/OpenMPReportController.cpp
@@ -52,7 +52,7 @@ public:
         cross_query.append(" format ").append(format);
 
         if (use_mpi) {
-            config()["CALI_SERVICES_ENABLE"].append(",mpi,mpireport");
+            config()["CALI_SERVICES_ENABLE"].append(",mpireport");
             config()["CALI_MPIREPORT_FILENAME"]          = opts.get("output", "stderr");
             config()["CALI_MPIREPORT_WRITE_ON_FINALIZE"] = "false";
             config()["CALI_MPIREPORT_LOCAL_CONFIG"]      = opts.build_query("local", local_query);

--- a/src/caliper/controllers/ROCmActivityReportController.cpp
+++ b/src/caliper/controllers/ROCmActivityReportController.cpp
@@ -81,7 +81,7 @@ public:
         cross_query.append(" format ").append(format);
 
         if (use_mpi) {
-            config()["CALI_SERVICES_ENABLE"].append(",mpi,mpireport");
+            config()["CALI_SERVICES_ENABLE"].append(",mpireport");
             config()["CALI_MPIREPORT_FILENAME"]          = opts.get("output", "stderr");
             config()["CALI_MPIREPORT_APPEND"]            = opts.get("output.append");
             config()["CALI_MPIREPORT_WRITE_ON_FINALIZE"] = "false";

--- a/src/caliper/controllers/RuntimeReportController.cpp
+++ b/src/caliper/controllers/RuntimeReportController.cpp
@@ -64,7 +64,7 @@ public:
         q_cross.append(" format ").append(format);
 
         if (use_mpi) {
-            config()["CALI_SERVICES_ENABLE"].append(",mpi,mpireport");
+            config()["CALI_SERVICES_ENABLE"].append(",mpireport");
             config()["CALI_MPIREPORT_FILENAME"]          = opts.get("output", "stderr");
             config()["CALI_MPIREPORT_APPEND"]            = opts.get("output.append");
             config()["CALI_MPIREPORT_WRITE_ON_FINALIZE"] = "false";

--- a/src/caliper/controllers/SampleProfileController.cpp
+++ b/src/caliper/controllers/SampleProfileController.cpp
@@ -76,7 +76,7 @@ public:
             config()["CALI_SERVICES_ENABLE"].append(",pthread");
 
         if (use_mpi) {
-            config()["CALI_SERVICES_ENABLE"].append(",mpi,mpireport");
+            config()["CALI_SERVICES_ENABLE"].append(",mpireport");
             config()["CALI_MPIREPORT_FILENAME"]          = output;
             config()["CALI_MPIREPORT_WRITE_ON_FINALIZE"] = "false";
             config()["CALI_MPIREPORT_CONFIG"]            = opts.build_query("local", query);

--- a/src/caliper/controllers/SampleReportController.cpp
+++ b/src/caliper/controllers/SampleReportController.cpp
@@ -73,7 +73,7 @@ public:
             config()["CALI_SERVICES_ENABLE"].append(",pthread");
 
         if (use_mpi) {
-            config()["CALI_SERVICES_ENABLE"].append(",mpi,mpireport");
+            config()["CALI_SERVICES_ENABLE"].append(",mpireport");
             config()["CALI_MPIREPORT_FILENAME"]          = opts.get("output", "stderr");
             config()["CALI_MPIREPORT_APPEND"]            = opts.get("output.append");
             config()["CALI_MPIREPORT_WRITE_ON_FINALIZE"] = "false";

--- a/src/caliper/controllers/controllers.cpp
+++ b/src/caliper/controllers/controllers.cpp
@@ -428,7 +428,7 @@ const char* builtin_mpi_option_specs = R"json(
   "select
     min(min#mms.min) as \"Msg size (min)\" unit Byte,
     avg(avg#mms.avg) as \"Msg size (avg)\" unit Byte,
-    max(max#mms.avg) as \"Msg size (avg)\" unit Byte"
+    max(max#mms.max) as \"Msg size (max)\" unit Byte"
  }
 },
 {


### PR DESCRIPTION
Fixes two issues:
* Report recipes should not load mpi service by default (which would cause MPI regions to show up even when MPI profiling is disabled for the report recipe)
* Fix query for `mpi.message.size` option