### PR TITLE
Add smaps and proc_status memory usage services

### DIFF
--- a/doc/sphinx/services.rst
+++ b/doc/sphinx/services.rst
@@ -1083,6 +1083,72 @@ Example:
                 7147              150 main                mainloop
                 8425              115 main                mainloop                  0
 
+.. _proc_status-service:
+
+Proc_Status
+--------------------------------
+
+The proc_status service records process memory usage values from
+``/proc/self/status``. This includes virtual memory size and its
+breakdown (locked, pinned, data, stack, text, shared library, and page
+table memory), resident set size (RSS) and its breakdown (anonymous,
+file-backed, and shared memory), swap usage, and hugetlb memory usage.
+It also records the memory high-water marks (peak virtual memory size
+and peak RSS).
+
+After each snapshot, the service resets the kernel's per-process
+resident set size high-water mark (VmHWM) accounting by writing "5" to
+``/proc/self/clear_refs``. This way, the ``proc_status.vmhwm`` attribute
+reports the peak RSS observed *since the previous snapshot*, rather than
+since process start.
+
+Many of the values in ``/proc/self/status`` are inaccurate, where the
+potential magnitude of the inaccuracy in a given application varies
+across kernel versions. For a more accurate -- but more expensive --
+measurement of resident set size, enable the :ref:`smaps
+<smaps-service>` service.
+
+``/proc/self/status`` and ``/proc/self/clear_refs`` are Linux-specific
+files. If either file cannot be opened, the service will log an error
+and not perform any measurements.
+
+The proc_status service provides the following attributes. Values are
+reported in "kB" by the kernel; actually KiB, i.e., 1024 bytes:
+
++--------------------------+------------------------------------------------------------------------+
+| proc_status.vmpeak       | Peak virtual memory size                                               |
++--------------------------+------------------------------------------------------------------------+
+| proc_status.vmsize       | Current virtual memory size                                            |
++--------------------------+------------------------------------------------------------------------+
+| proc_status.vmlck        | Size of locked memory                                                  |
++--------------------------+------------------------------------------------------------------------+
+| proc_status.vmpin        | Size of pinned memory                                                  |
++--------------------------+------------------------------------------------------------------------+
+| proc_status.vmhwm        | Peak resident set size ("high water mark") since the previous snapshot |
++--------------------------+------------------------------------------------------------------------+
+| proc_status.vmrss        | Resident set size                                                      |
++--------------------------+------------------------------------------------------------------------+
+| proc_status.rssanon      | Resident anonymous memory                                              |
++--------------------------+------------------------------------------------------------------------+
+| proc_status.rssfile      | Resident file mappings                                                 |
++--------------------------+------------------------------------------------------------------------+
+| proc_status.rssshmem     | Resident shared memory (SysV shm, tmpfs, shared anonymous mappings)    |
++--------------------------+------------------------------------------------------------------------+
+| proc_status.vmdata       | Size of the data segment                                               |
++--------------------------+------------------------------------------------------------------------+
+| proc_status.vmstk        | Size of the stack segment                                              |
++--------------------------+------------------------------------------------------------------------+
+| proc_status.vmexe        | Size of the text (code) segment                                        |
++--------------------------+------------------------------------------------------------------------+
+| proc_status.vmlib        | Size of shared library code                                            |
++--------------------------+------------------------------------------------------------------------+
+| proc_status.vmpte        | Size of page table entries                                             |
++--------------------------+------------------------------------------------------------------------+
+| proc_status.vmswap       | Swapped-out anonymous private data, not including shmem swap usage     |
++--------------------------+------------------------------------------------------------------------+
+| proc_status.hugetlbpages | Size of hugetlb memory allocations                                     |
++--------------------------+------------------------------------------------------------------------+
+
 .. _pthread-service:
 
 Pthread
@@ -1278,6 +1344,50 @@ a flat profile of the number of samples per function::
     CALI_SERVICES_ENABLE=report,sampler,symbollookup,trace
     CALI_SAMPLER_FREQUENCY=100
     CALI_REPORT_CONFIG="SELECT source.function#cali.sampler.pc,count() GROUP BY source.function#cali.sampler.pc FORMAT table ORDER BY count DESC"
+
+.. _smaps-service:
+
+Smaps
+--------------------------------
+
+The smaps service records process memory usage values from
+``/proc/self/smaps_rollup``. Notably, this include both resident set
+size (RSS) and proportional set size (PSS); the former charges the
+process for every page regardless of whether it's shared with other
+processes, while the latter charges the process for a given shared page
+in proportion to the total number of processes that share it.  The
+service also records subtotals of shared vs. private memory and clean
+(not modified) vs. dirty (modified) pages.
+
+For the values it reports, the smaps service is more accurate but also
+significantly more expensive than services like :ref:`proc_status
+<proc_status-service>`.  Unlike counters reported in, e.g.,
+``/proc/self/statm`` or ``/proc/self/status`` -- read by the memstat and
+proc_status services, respectively -- the kernel computes values in
+``/proc/self/smaps_rollup`` by walking its virtual memory areas and page
+tables when the file is read.  Consider configuring the :ref:`event
+<event-service>` service to limit which regions trigger snapshots.
+
+``/proc/self/smaps_rollup`` is only available in Linux kernels 4.14 or
+later.  If the file cannot be opened, the service will log an error and
+not perform any measurements.
+
+The smaps service provides the following attributes. Values are
+reported in "kB" by the kernel; actually KiB, i.e., 1024 bytes:
+
++---------------------+---------------------------------------+
+| smaps.rss           | Resident set size                     |
++---------------------+---------------------------------------+
+| smaps.pss           | Proportional set size                 |
++---------------------+---------------------------------------+
+| smaps.shared_clean  | Shared, clean (not modified) memory   |
++---------------------+---------------------------------------+
+| smaps.shared_dirty  | Shared, dirty (modified) memory       |
++---------------------+---------------------------------------+
+| smaps.private_clean | Private, clean (not modified) memory  |
++---------------------+---------------------------------------+
+| smaps.private_dirty | Private, dirty (modified) memory      |
++---------------------+---------------------------------------+
 
 .. _symbollookup-service:
 

--- a/src/caliper/controllers/controllers.cpp
+++ b/src/caliper/controllers/controllers.cpp
@@ -653,7 +653,101 @@ const char* builtin_gotcha_option_specs = R"json(
   "select
     max(max#mem.vmsize) as VmSize unit pages,max(max#mem.vmrss) as VmRSS unit pages,max(max#mem.data) as Data unit pages"
  }
-}
+},{
+  "name": "mem.sizes",
+  "description": "Memory usage via /proc/self/status",
+  "type": "bool",
+  "category": "metric",
+  "services": [ "proc_status" ],
+  "query":
+  {
+   "local":
+   "let
+     mem.vmpeak=first(max#proc_status.vmpeak,proc_status.vmpeak),
+     mem.vmsize=first(max#proc_status.vmsize,proc_status.vmsize),
+     mem.vmlck=first(max#proc_status.vmlck,proc_status.vmlck),
+     mem.vmpin=first(max#proc_status.vmpin,proc_status.vmpin),
+     mem.vmhwm=first(max#proc_status.vmhwm,proc_status.vmhwm),
+     mem.vmrss=first(max#proc_status.vmrss,proc_status.vmrss),
+     mem.rssanon=first(max#proc_status.rssanon,proc_status.rssanon),
+     mem.rssfile=first(max#proc_status.rssfile,proc_status.rssfile),
+     mem.rssshmem=first(max#proc_status.rssshmem,proc_status.rssshmem),
+     mem.vmdata=first(max#proc_status.vmdata,proc_status.vmdata),
+     mem.vmstk=first(max#proc_status.vmstk,proc_status.vmstk),
+     mem.vmexe=first(max#proc_status.vmexe,proc_status.vmexe),
+     mem.vmlib=first(max#proc_status.vmlib,proc_status.vmlib),
+     mem.vmpte=first(max#proc_status.vmpte,proc_status.vmpte),
+     mem.vmswap=first(max#proc_status.vmswap,proc_status.vmswap),
+     mem.hugetlbpages=first(max#proc_status.hugetlbpages,proc_status.hugetlbpages)
+    select
+     max(mem.vmpeak) as VmPeak unit KiB,
+     max(mem.vmsize) as VmSize unit KiB,
+     max(mem.vmlck) as VmLck unit KiB,
+     max(mem.vmpin) as VmPin unit KiB,
+     max(mem.vmhwm) as VmHWM unit KiB,
+     max(mem.vmrss) as VmRSS unit KiB,
+     max(mem.rssanon) as RssAnon unit KiB,
+     max(mem.rssfile) as RssFile unit KiB,
+     max(mem.rssshmem) as RssShmem unit KiB,
+     max(mem.vmdata) as VmData unit KiB,
+     max(mem.vmstk) as VmStk unit KiB,
+     max(mem.vmexe) as VmExe unit KiB,
+     max(mem.vmlib) as VmLib unit KiB,
+     max(mem.vmpte) as VmPTE unit KiB,
+     max(mem.vmswap) as VmSwap unit KiB,
+     max(mem.hugetlbpages) as HugetlbPages unit KiB",
+   "cross":
+   "select
+     max(max#mem.vmpeak) as VmPeak unit KiB,
+     max(max#mem.vmsize) as VmSize unit KiB,
+     max(max#mem.vmlck) as VmLck unit KiB,
+     max(max#mem.vmpin) as VmPin unit KiB,
+     max(max#mem.vmhwm) as VmHWM unit KiB,
+     max(max#mem.vmrss) as VmRSS unit KiB,
+     max(max#mem.rssanon) as RssAnon unit KiB,
+     max(max#mem.rssfile) as RssFile unit KiB,
+     max(max#mem.rssshmem) as RssShmem unit KiB,
+     max(max#mem.vmdata) as VmData unit KiB,
+     max(max#mem.vmstk) as VmStk unit KiB,
+     max(max#mem.vmexe) as VmExe unit KiB,
+     max(max#mem.vmlib) as VmLib unit KiB,
+     max(max#mem.vmpte) as VmPTE unit KiB,
+     max(max#mem.vmswap) as VmSwap unit KiB,
+     max(max#mem.hugetlbpages) as HugetlbPages unit KiB"
+  }
+ },{
+  "name": "mem.smaps",
+  "description": "Memory usage via /proc/self/smaps_rollup",
+  "type": "bool",
+  "category": "metric",
+  "services": [ "smaps" ],
+  "query":
+  {
+   "local":
+   "let
+     mem.rss=first(max#smaps.rss,smaps.rss),
+     mem.pss=first(max#smaps.pss,smaps.pss),
+     mem.shared_clean=first(max#smaps.shared_clean,smaps.shared_clean),
+     mem.shared_dirty=first(max#smaps.shared_dirty,smaps.shared_dirty),
+     mem.private_clean=first(max#smaps.private_clean,smaps.private_clean),
+     mem.private_dirty=first(max#smaps.private_dirty,smaps.private_dirty)
+    select
+     max(mem.rss) as Rss unit KiB,
+     max(mem.pss) as Pss unit KiB,
+     max(mem.shared_clean) as Shared_Clean unit KiB,
+     max(mem.shared_dirty) as Shared_Dirty unit KiB,
+     max(mem.private_clean) as Private_Clean unit KiB,
+     max(mem.private_dirty) as Private_Dirty unit KiB",
+   "cross":
+   "select
+     max(max#mem.rss) as Rss unit KiB,
+     max(max#mem.pss) as Pss unit KiB,
+     max(max#mem.shared_clean) as Shared_Clean unit KiB,
+     max(max#mem.shared_dirty) as Shared_Dirty unit KiB,
+     max(max#mem.private_clean) as Private_Clean unit KiB,
+     max(max#mem.private_dirty) as Private_Dirty unit KiB"
+  }
+ }
 ]
 )json";
 

--- a/src/services/memusage/CMakeLists.txt
+++ b/src/services/memusage/CMakeLists.txt
@@ -1,5 +1,9 @@
 set(CALIPER_MEMUSAGE_SOURCES
-  MemStatService.cpp)
+  MemStatService.cpp
+  ProcStatusService.cpp
+  SmapsService.cpp)
 
 add_service_sources(${CALIPER_MEMUSAGE_SOURCES})
 add_caliper_service("memstat")
+add_caliper_service("proc_status")
+add_caliper_service("smaps")

--- a/src/services/memusage/ProcStatusService.cpp
+++ b/src/services/memusage/ProcStatusService.cpp
@@ -1,0 +1,283 @@
+// Copyright (c) 2026, Triad National Security, LLC.
+// See top-level LICENSE file for details.
+
+#include "../Services.h"
+
+#include "caliper/Caliper.h"
+#include "caliper/SnapshotRecord.h"
+
+#include "caliper/common/Attribute.h"
+#include "caliper/common/Log.h"
+
+#include <fcntl.h>
+#include <inttypes.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <array>
+
+using namespace cali;
+
+namespace
+{
+
+inline std::array<uint64_t, 16> parse_proc_status(const char* buf)
+{
+    std::array<uint64_t, 16> numbers = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+
+    const char* start = strstr(buf, "VmPeak:");
+    sscanf(start, "VmPeak: %" SCNu64, &numbers[0]);
+
+    start = strstr(start, "VmSize:");
+    sscanf(start, "VmSize: %" SCNu64, &numbers[1]);
+
+    start = strstr(start, "VmLck:");
+    sscanf(start, "VmLck: %" SCNu64, &numbers[2]);
+
+    start = strstr(start, "VmPin:");
+    sscanf(start, "VmPin: %" SCNu64, &numbers[3]);
+
+    start = strstr(start, "VmHWM:");
+    sscanf(start, "VmHWM: %" SCNu64, &numbers[4]);
+
+    start = strstr(start, "VmRSS:");
+    sscanf(start, "VmRSS: %" SCNu64, &numbers[5]);
+
+    start = strstr(start, "RssAnon:");
+    sscanf(start, "RssAnon: %" SCNu64, &numbers[6]);
+
+    start = strstr(start, "RssFile:");
+    sscanf(start, "RssFile: %" SCNu64, &numbers[7]);
+
+    start = strstr(start, "RssShmem:");
+    sscanf(start, "RssShmem: %" SCNu64, &numbers[8]);
+
+    start = strstr(start, "VmData:");
+    sscanf(start, "VmData: %" SCNu64, &numbers[9]);
+
+    start = strstr(start, "VmStk:");
+    sscanf(start, "VmStk: %" SCNu64, &numbers[10]);
+
+    start = strstr(start, "VmExe:");
+    sscanf(start, "VmExe: %" SCNu64, &numbers[11]);
+
+    start = strstr(start, "VmLib:");
+    sscanf(start, "VmLib: %" SCNu64, &numbers[12]);
+
+    start = strstr(start, "VmPTE:");
+    sscanf(start, "VmPTE: %" SCNu64, &numbers[13]);
+
+    start = strstr(start, "VmSwap:");
+    sscanf(start, "VmSwap: %" SCNu64, &numbers[14]);
+
+    start = strstr(start, "HugetlbPages:");
+    sscanf(start, "HugetlbPages: %" SCNu64, &numbers[15]);
+
+    return numbers;
+}
+
+class ProcStatusService
+{
+    Attribute m_vmpeak_attr;
+    Attribute m_vmsize_attr;
+    Attribute m_vmlck_attr;
+    Attribute m_vmpin_attr;
+    Attribute m_vmhwm_attr;
+    Attribute m_vmrss_attr;
+    Attribute m_rssanon_attr;
+    Attribute m_rssfile_attr;
+    Attribute m_rssshmem_attr;
+    Attribute m_vmdata_attr;
+    Attribute m_vmstk_attr;
+    Attribute m_vmexe_attr;
+    Attribute m_vmlib_attr;
+    Attribute m_vmpte_attr;
+    Attribute m_vmswap_attr;
+    Attribute m_hugetlbpages_attr;
+
+    int m_status_fd, m_clear_fd;
+
+    unsigned m_status_failed, m_clear_failed;
+
+    void snapshot_cb(Caliper*, SnapshotBuilder& rec)
+    {
+        char    buf[4096];
+        ssize_t ret = pread(m_status_fd, buf, sizeof(buf), 0);
+
+        if (ret < 0) {
+            ++m_status_failed;
+            return;
+        }
+
+        auto val = parse_proc_status(buf);
+
+        rec.append(m_vmpeak_attr, cali_make_variant_from_uint(val[0]));
+        rec.append(m_vmsize_attr, cali_make_variant_from_uint(val[1]));
+        rec.append(m_vmlck_attr, cali_make_variant_from_uint(val[2]));
+        rec.append(m_vmpin_attr, cali_make_variant_from_uint(val[3]));
+        rec.append(m_vmhwm_attr, cali_make_variant_from_uint(val[4]));
+        rec.append(m_vmrss_attr, cali_make_variant_from_uint(val[5]));
+        rec.append(m_rssanon_attr, cali_make_variant_from_uint(val[6]));
+        rec.append(m_rssfile_attr, cali_make_variant_from_uint(val[7]));
+        rec.append(m_rssshmem_attr, cali_make_variant_from_uint(val[8]));
+        rec.append(m_vmdata_attr, cali_make_variant_from_uint(val[9]));
+        rec.append(m_vmstk_attr, cali_make_variant_from_uint(val[10]));
+        rec.append(m_vmexe_attr, cali_make_variant_from_uint(val[11]));
+        rec.append(m_vmlib_attr, cali_make_variant_from_uint(val[12]));
+        rec.append(m_vmpte_attr, cali_make_variant_from_uint(val[13]));
+        rec.append(m_vmswap_attr, cali_make_variant_from_uint(val[14]));
+        rec.append(m_hugetlbpages_attr, cali_make_variant_from_uint(val[15]));
+
+        // Reset accounting: write 5 to /proc/self/clear_refs
+        ret = pwrite(m_clear_fd, "5", sizeof(char), 0);
+
+        if (ret < 0) {
+            ++m_clear_failed;
+            return;
+        }
+    }
+
+    void finish_cb(Caliper*, Channel* channel)
+    {
+        if (m_status_failed > 0)
+            Log(0).stream() << channel->name() << ": proc_status: failed to read /proc/self/status " << m_status_failed
+                            << " times\n";
+        if (m_clear_failed > 0)
+            Log(0).stream() << channel->name() << ": proc_status: failed to write to /proc/self/clear_refs "
+                            << m_clear_failed << " times\n";
+    }
+
+    ProcStatusService(Caliper* c, int status_fd, int clear_fd)
+        : m_status_fd { status_fd }, m_clear_fd { clear_fd }, m_status_failed { 0 }, m_clear_failed { 0 }
+    {
+        m_vmpeak_attr = c->create_attribute(
+            "proc_status.vmpeak",
+            CALI_TYPE_UINT,
+            CALI_ATTR_SCOPE_PROCESS | CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE
+        );
+        m_vmsize_attr = c->create_attribute(
+            "proc_status.vmsize",
+            CALI_TYPE_UINT,
+            CALI_ATTR_SCOPE_PROCESS | CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE
+        );
+        m_vmlck_attr = c->create_attribute(
+            "proc_status.vmlck",
+            CALI_TYPE_UINT,
+            CALI_ATTR_SCOPE_PROCESS | CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE
+        );
+        m_vmpin_attr = c->create_attribute(
+            "proc_status.vmpin",
+            CALI_TYPE_UINT,
+            CALI_ATTR_SCOPE_PROCESS | CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE
+        );
+        m_vmhwm_attr = c->create_attribute(
+            "proc_status.vmhwm",
+            CALI_TYPE_UINT,
+            CALI_ATTR_SCOPE_PROCESS | CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE
+        );
+        m_vmrss_attr = c->create_attribute(
+            "proc_status.vmrss",
+            CALI_TYPE_UINT,
+            CALI_ATTR_SCOPE_PROCESS | CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE
+        );
+        m_rssanon_attr = c->create_attribute(
+            "proc_status.rssanon",
+            CALI_TYPE_UINT,
+            CALI_ATTR_SCOPE_PROCESS | CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE
+        );
+        m_rssfile_attr = c->create_attribute(
+            "proc_status.rssfile",
+            CALI_TYPE_UINT,
+            CALI_ATTR_SCOPE_PROCESS | CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE
+        );
+        m_rssshmem_attr = c->create_attribute(
+            "proc_status.rssshmem",
+            CALI_TYPE_UINT,
+            CALI_ATTR_SCOPE_PROCESS | CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE
+        );
+        m_vmdata_attr = c->create_attribute(
+            "proc_status.vmdata",
+            CALI_TYPE_UINT,
+            CALI_ATTR_SCOPE_PROCESS | CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE
+        );
+        m_vmstk_attr = c->create_attribute(
+            "proc_status.vmstk",
+            CALI_TYPE_UINT,
+            CALI_ATTR_SCOPE_PROCESS | CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE
+        );
+        m_vmexe_attr = c->create_attribute(
+            "proc_status.vmexe",
+            CALI_TYPE_UINT,
+            CALI_ATTR_SCOPE_PROCESS | CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE
+        );
+        m_vmlib_attr = c->create_attribute(
+            "proc_status.vmlib",
+            CALI_TYPE_UINT,
+            CALI_ATTR_SCOPE_PROCESS | CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE
+        );
+        m_vmpte_attr = c->create_attribute(
+            "proc_status.vmpte",
+            CALI_TYPE_UINT,
+            CALI_ATTR_SCOPE_PROCESS | CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE
+        );
+        m_vmswap_attr = c->create_attribute(
+            "proc_status.vmswap",
+            CALI_TYPE_UINT,
+            CALI_ATTR_SCOPE_PROCESS | CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE
+        );
+        m_hugetlbpages_attr = c->create_attribute(
+            "proc_status.hugetlbpages",
+            CALI_TYPE_UINT,
+            CALI_ATTR_SCOPE_PROCESS | CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE
+        );
+    }
+
+public:
+
+    static void proc_status_register(Caliper* c, Channel* channel)
+    {
+        int status_fd = open("/proc/self/status", O_RDONLY | O_NONBLOCK);
+
+        if (status_fd < 0) {
+            Log(0).perror(errno, "open(\"/proc/self/status\")");
+            return;
+        }
+
+        int clear_fd = open("/proc/self/clear_refs", O_WRONLY | O_NONBLOCK);
+
+        if (clear_fd < 0) {
+            Log(0).perror(errno, "open(\"/proc/self/clear_refs\")");
+            return;
+        }
+
+        ProcStatusService* instance = new ProcStatusService(c, status_fd, clear_fd);
+
+        channel->events().snapshot.connect([instance](Caliper* c, SnapshotView, SnapshotBuilder& rec) {
+            instance->snapshot_cb(c, rec);
+        });
+        channel->events().finish_evt.connect([instance](Caliper* c, Channel* channel) {
+            instance->finish_cb(c, channel);
+            close(instance->m_status_fd);
+            close(instance->m_clear_fd);
+            delete instance;
+        });
+
+        Log(1).stream() << channel->name() << ": registered proc_status service\n";
+    }
+};
+
+const char* proc_status_spec = R"json(
+{
+    "name"        : "proc_status",
+    "description" : "Record process memory info from /proc/self/status"
+}
+)json";
+
+} // namespace
+
+namespace cali
+{
+
+CaliperService proc_status_service { ::proc_status_spec, ::ProcStatusService::proc_status_register };
+
+}

--- a/src/services/memusage/SmapsService.cpp
+++ b/src/services/memusage/SmapsService.cpp
@@ -1,0 +1,163 @@
+// Copyright (c) 2026, Triad National Security, LLC.
+// See top-level LICENSE file for details.
+
+#include "../Services.h"
+
+#include "caliper/Caliper.h"
+#include "caliper/SnapshotRecord.h"
+
+#include "caliper/common/Attribute.h"
+#include "caliper/common/Log.h"
+
+#include <fcntl.h>
+#include <inttypes.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <array>
+
+using namespace cali;
+
+namespace
+{
+
+inline std::array<uint64_t, 6> parse_smaps_rollup(const char* buf)
+{
+    std::array<uint64_t, 6> numbers = { 0, 0, 0, 0, 0, 0 };
+
+    const char* start = strstr(buf, "Rss:");
+    sscanf(start, "Rss: %" SCNu64, &numbers[0]);
+
+    start = strstr(start, "Pss:");
+    sscanf(start, "Pss: %" SCNu64, &numbers[1]);
+
+    start = strstr(start, "Shared_Clean:");
+    sscanf(start, "Shared_Clean: %" SCNu64, &numbers[2]);
+
+    start = strstr(start, "Shared_Dirty:");
+    sscanf(start, "Shared_Dirty: %" SCNu64, &numbers[3]);
+
+    start = strstr(start, "Private_Clean:");
+    sscanf(start, "Private_Clean: %" SCNu64, &numbers[4]);
+
+    start = strstr(start, "Private_Dirty:");
+    sscanf(start, "Private_Dirty: %" SCNu64, &numbers[5]);
+
+    return numbers;
+}
+
+class SmapsService
+{
+    Attribute m_rss_attr;
+    Attribute m_pss_attr;
+    Attribute m_shared_clean_attr;
+    Attribute m_shared_dirty_attr;
+    Attribute m_private_clean_attr;
+    Attribute m_private_dirty_attr;
+
+    int m_fd;
+
+    unsigned m_failed;
+
+    void snapshot_cb(Caliper*, SnapshotBuilder& rec)
+    {
+        char    buf[1024];
+        ssize_t ret = pread(m_fd, buf, sizeof(buf), 0);
+
+        if (ret < 0) {
+            ++m_failed;
+            return;
+        }
+
+        auto val = parse_smaps_rollup(buf);
+
+        rec.append(m_rss_attr, cali_make_variant_from_uint(val[0]));
+        rec.append(m_pss_attr, cali_make_variant_from_uint(val[1]));
+        rec.append(m_shared_clean_attr, cali_make_variant_from_uint(val[2]));
+        rec.append(m_shared_dirty_attr, cali_make_variant_from_uint(val[3]));
+        rec.append(m_private_clean_attr, cali_make_variant_from_uint(val[4]));
+        rec.append(m_private_dirty_attr, cali_make_variant_from_uint(val[5]));
+    }
+
+    void finish_cb(Caliper*, Channel* channel)
+    {
+        if (m_failed > 0)
+            Log(0).stream() << channel->name() << ": smaps: failed to read /proc/self/smaps_rollup " << m_failed
+                            << " times\n";
+    }
+
+    SmapsService(Caliper* c, int fd) : m_fd { fd }, m_failed { 0 }
+    {
+        m_rss_attr = c->create_attribute(
+            "smaps.rss",
+            CALI_TYPE_UINT,
+            CALI_ATTR_SCOPE_PROCESS | CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE
+        );
+        m_pss_attr = c->create_attribute(
+            "smaps.pss",
+            CALI_TYPE_UINT,
+            CALI_ATTR_SCOPE_PROCESS | CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE
+        );
+        m_shared_clean_attr = c->create_attribute(
+            "smaps.shared_clean",
+            CALI_TYPE_UINT,
+            CALI_ATTR_SCOPE_PROCESS | CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE
+        );
+        m_shared_dirty_attr = c->create_attribute(
+            "smaps.shared_dirty",
+            CALI_TYPE_UINT,
+            CALI_ATTR_SCOPE_PROCESS | CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE
+        );
+        m_private_clean_attr = c->create_attribute(
+            "smaps.private_clean",
+            CALI_TYPE_UINT,
+            CALI_ATTR_SCOPE_PROCESS | CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE
+        );
+        m_private_dirty_attr = c->create_attribute(
+            "smaps.private_dirty",
+            CALI_TYPE_UINT,
+            CALI_ATTR_SCOPE_PROCESS | CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE
+        );
+    }
+
+public:
+
+    static void smaps_register(Caliper* c, Channel* channel)
+    {
+        int fd = open("/proc/self/smaps_rollup", O_RDONLY | O_NONBLOCK);
+
+        if (fd < 0) {
+            Log(0).perror(errno, "open(\"/proc/self/smaps_rollup\")");
+            return;
+        }
+
+        SmapsService* instance = new SmapsService(c, fd);
+
+        channel->events().snapshot.connect([instance](Caliper* c, SnapshotView, SnapshotBuilder& rec) {
+            instance->snapshot_cb(c, rec);
+        });
+        channel->events().finish_evt.connect([instance](Caliper* c, Channel* channel) {
+            instance->finish_cb(c, channel);
+            close(instance->m_fd);
+            delete instance;
+        });
+
+        Log(1).stream() << channel->name() << ": registered smaps service\n";
+    }
+};
+
+const char* smaps_spec = R"json(
+{
+    "name"        : "smaps",
+    "description" : "Record process memory info from /proc/self/smaps_rollup"
+}
+)json";
+
+} // namespace
+
+namespace cali
+{
+
+CaliperService smaps_service { ::smaps_spec, ::SmapsService::smaps_register };
+
+}

--- a/test/ci_app_tests/test_linux_services.py
+++ b/test/ci_app_tests/test_linux_services.py
@@ -47,5 +47,61 @@ class CaliperLinuxServicesTest(unittest.TestCase):
                          'myphase',
                          'iteration' }))
 
+    def test_proc_status_service(self):
+        target_cmd = [ './ci_test_basic' ]
+
+        caliper_config = {
+            'CALI_SERVICES_ENABLE'   : 'event,proc_status,trace,recorder',
+            'CALI_RECORDER_FILENAME' : 'stdout',
+        }
+
+        out,_ = cat.run_test(target_cmd, caliper_config)
+        snapshots,_ = caliperreader.read_caliper_contents(io.StringIO(out.decode()))
+
+        self.assertTrue(len(snapshots) > 1)
+
+        self.assertTrue(cat.has_snapshot_with_keys(
+            snapshots, { 'proc_status.vmpeak',
+                         'proc_status.vmsize',
+                         'proc_status.vmlck',
+                         'proc_status.vmpin',
+                         'proc_status.vmhwm',
+                         'proc_status.vmrss',
+                         'proc_status.rssanon',
+                         'proc_status.rssfile',
+                         'proc_status.rssshmem',
+                         'proc_status.vmdata',
+                         'proc_status.vmstk',
+                         'proc_status.vmexe',
+                         'proc_status.vmlib',
+                         'proc_status.vmpte',
+                         'proc_status.vmswap',
+                         'proc_status.hugetlbpages',
+                         'myphase',
+                         'iteration' }))
+
+    def test_smaps_service(self):
+        target_cmd = [ './ci_test_basic' ]
+
+        caliper_config = {
+            'CALI_SERVICES_ENABLE'   : 'event,smaps,trace,recorder',
+            'CALI_RECORDER_FILENAME' : 'stdout',
+        }
+
+        out,_ = cat.run_test(target_cmd, caliper_config)
+        snapshots,_ = caliperreader.read_caliper_contents(io.StringIO(out.decode()))
+
+        self.assertTrue(len(snapshots) > 1)
+
+        self.assertTrue(cat.has_snapshot_with_keys(
+            snapshots, { 'smaps.rss',
+                         'smaps.pss',
+                         'smaps.shared_clean',
+                         'smaps.shared_dirty',
+                         'smaps.private_clean',
+                         'smaps.private_dirty',
+                         'myphase',
+                         'iteration' }))
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
For context: I've been looking for ways to help applications reduce memory usage. Sometimes that means helping teams find opportunities to make greater use of shared memory. So I went looking for ways to quantify that benefit, which led me to reading proportional set size (PSS) from `/proc/self/smaps_rollup`.

Add two new services under src/services/memusage/:

* smaps: records RSS, PSS, and shared/private clean/dirty memory from /proc/self/smaps_rollup.
* proc_status: records virtual memory, RSS, swap, and hugetlb usage from /proc/self/status, resetting the kernel's RSS high-water mark via /proc/self/clear_refs after each snapshot (which can help uncover regions with high but short-lived usage).

Both implementations drew heavy inspiration from the existing memstat service (src/services/memusage/MemStatService.cpp), and since these new services also each read memory usage info from a file in `/proc` I put them in that same memusage subdirectory as a starting point. Happy to move, rename, refactor anything you want changed!

Also:

* formatted both new files with clang-format;
* added a section describing each service in doc/sphinx/services.rst;
* and added a test for each service in test/ci_app_tests/test_linux_services.py.