### PR TITLE
Include <iterator> and <cstdlib> for Clang 23.1.0

### DIFF
--- a/src/common/StringConverter.cpp
+++ b/src/common/StringConverter.cpp
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <iterator>
 #include <sstream>
 
 cali_id_t cali::StringConverter::to_id() const

--- a/src/common/util/demangle.cpp
+++ b/src/common/util/demangle.cpp
@@ -7,6 +7,7 @@
 #include <cxxabi.h>
 #endif
 
+#include <cstdlib>
 #include <cstring>
 
 namespace cali


### PR DESCRIPTION
Caliper-2.15.0/src/common/StringConverter.cpp:33:57: error: no member named 'back_inserter' in namespace 'std'
   33 |         std::transform(m_str.begin(), m_str.end(), std::back_inserter(lower), ::tolower);
      |                                                         ^~~~~~~~~~~~~
1 error generated.

Caliper-2.15.0/src/common/util/demangle.cpp:39:5: error: use of undeclared identifier 'free'
   39 |     free(demangled);
      |     ^~~~
1 error generated.

using Clang 23.1.0 on macOS